### PR TITLE
Refresh layers when the DOM is mutated

### DIFF
--- a/app/common/constants.ts
+++ b/app/common/constants.ts
@@ -22,8 +22,8 @@ export enum WebviewChannels {
     ELEMENT_INSERTED = 'element-inserted',
     ELEMENT_REMOVED = 'element-removed',
     STYLE_UPDATED = 'style-updated',
-    WINDOW_RESIZED = 'window-resize',
-    WINDOW_MUTATED = 'window-mutate',
+    WINDOW_RESIZED = 'window-resized',
+    WINDOW_MUTATED = 'window-mutated',
 }
 
 export enum MainChannels {

--- a/app/electron/preload/webview/elements/helpers.ts
+++ b/app/electron/preload/webview/elements/helpers.ts
@@ -32,9 +32,9 @@ export const getDomElement = (el: HTMLElement, getStyle: boolean): DomElement =>
     const parentDomElement: ParentDomElement | undefined = parent
         ? {
               selector: getUniqueSelector(parent as HTMLElement),
-              rect: parent?.getBoundingClientRect() as DOMRect,
+              rect: parent.getBoundingClientRect() as DOMRect,
               encodedTemplateNode:
-                  parent?.getAttribute(EditorAttributes.DATA_ONLOOK_ID) || undefined,
+                  parent.getAttribute(EditorAttributes.DATA_ONLOOK_ID) || undefined,
           }
         : undefined;
 

--- a/app/electron/preload/webview/elements/helpers.ts
+++ b/app/electron/preload/webview/elements/helpers.ts
@@ -28,7 +28,6 @@ export const getDeepElement = (x: number, y: number): Element | undefined => {
 };
 
 export const getDomElement = (el: HTMLElement, getStyle: boolean): DomElement => {
-    console.log(el, getStyle);
     const parent = el.parentElement;
     const parentDomElement: ParentDomElement | undefined = parent
         ? {

--- a/app/electron/preload/webview/elements/helpers.ts
+++ b/app/electron/preload/webview/elements/helpers.ts
@@ -28,12 +28,16 @@ export const getDeepElement = (x: number, y: number): Element | undefined => {
 };
 
 export const getDomElement = (el: HTMLElement, getStyle: boolean): DomElement => {
+    console.log(el, getStyle);
     const parent = el.parentElement;
-    const parentDomElement: ParentDomElement = {
-        selector: getUniqueSelector(parent as HTMLElement),
-        rect: parent?.getBoundingClientRect() as DOMRect,
-        encodedTemplateNode: parent?.getAttribute(EditorAttributes.DATA_ONLOOK_ID) || undefined,
-    };
+    const parentDomElement: ParentDomElement | undefined = parent
+        ? {
+              selector: getUniqueSelector(parent as HTMLElement),
+              rect: parent?.getBoundingClientRect() as DOMRect,
+              encodedTemplateNode:
+                  parent?.getAttribute(EditorAttributes.DATA_ONLOOK_ID) || undefined,
+          }
+        : undefined;
 
     const rect = el.getBoundingClientRect();
     const styles = getStyle ? getStyles(el) : {};

--- a/app/electron/preload/webview/events.ts
+++ b/app/electron/preload/webview/events.ts
@@ -3,9 +3,11 @@ import { CssStyleChange } from './changes';
 import { insertElement, removeElement } from './elements/insert';
 import { ActionElement, ActionElementLocation } from '/common/actions';
 import { WebviewChannels } from '/common/constants';
+import { getUniqueSelector } from '/common/helpers';
 
 export function listenForEvents() {
     listenForWindowEvents();
+    listenForDomMutation();
     listenForEditEvents();
 }
 
@@ -13,6 +15,38 @@ function listenForWindowEvents() {
     window.addEventListener('resize', () => {
         ipcRenderer.sendToHost(WebviewChannels.WINDOW_RESIZED);
     });
+}
+
+function listenForDomMutation() {
+    const targetNode = document.body;
+    const config = { childList: true, subtree: true };
+
+    const observer = new MutationObserver((mutationsList, observer) => {
+        const added = new Set<string>();
+        const removed = new Set<string>();
+
+        for (const mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                const parent = mutation.target as HTMLElement;
+                const parentSelector = getUniqueSelector(parent, targetNode);
+                for (const node of mutation.addedNodes) {
+                    added.add(parentSelector);
+                }
+
+                for (const node of mutation.removedNodes) {
+                    removed.add(parentSelector);
+                }
+            }
+        }
+
+        if (added.size > 0 || removed.size > 0) {
+            ipcRenderer.sendToHost(WebviewChannels.WINDOW_MUTATED, {
+                added: Array.from(added),
+                removed: Array.from(removed),
+            });
+        }
+    });
+    observer.observe(targetNode, config);
 }
 
 function listenForEditEvents() {

--- a/app/src/lib/editor/engine/ast/index.ts
+++ b/app/src/lib/editor/engine/ast/index.ts
@@ -29,6 +29,9 @@ export class AstManager {
             return;
         }
         const selector = getUniqueSelector(element, element.ownerDocument.body);
+        if (!this.templateNodeMap.isProcessed(selector) && !this.layersMap.has(selector)) {
+            return;
+        }
         this.layersMap.delete(selector);
         this.templateNodeMap.removeSelector(selector);
 

--- a/app/src/lib/editor/engine/ast/index.ts
+++ b/app/src/lib/editor/engine/ast/index.ts
@@ -24,13 +24,24 @@ export class AstManager {
         });
     }
 
-    resetPathToElement(element: HTMLElement | undefined) {
+    removeElement(element: HTMLElement | undefined) {
         if (!element) {
             return;
         }
         const selector = getUniqueSelector(element, element.ownerDocument.body);
         this.layersMap.delete(selector);
         this.templateNodeMap.removeSelector(selector);
+
+        const parent = element.parentElement;
+        if (!parent) {
+            return;
+        }
+        const parentSelector = getUniqueSelector(parent, parent.ownerDocument.body);
+        const parentNode = this.layersMap.get(parentSelector);
+        if (!parentNode) {
+            return;
+        }
+        parentNode.children = parentNode.children?.filter((child) => child.id !== selector);
     }
 
     async getInstance(selector: string): Promise<TemplateNode | undefined> {

--- a/app/src/lib/editor/engine/ast/index.ts
+++ b/app/src/lib/editor/engine/ast/index.ts
@@ -32,6 +32,15 @@ export class AstManager {
         this.layersMap.delete(selector);
         this.templateNodeMap.removeSelector(selector);
 
+        // Remove all children
+        const children = element.querySelectorAll('*');
+        children.forEach((child) => {
+            const childSelector = getUniqueSelector(child as HTMLElement, child.ownerDocument.body);
+            this.layersMap.delete(childSelector);
+            this.templateNodeMap.removeSelector(childSelector);
+        });
+
+        // Remove from parent
         const parent = element.parentElement;
         if (!parent) {
             return;
@@ -65,9 +74,13 @@ export class AstManager {
         }
     }
 
+    setDoc(doc: Document) {
+        this.doc = doc;
+    }
+
     async setMapRoot(rootElement: Element) {
         this.clear();
-        this.doc = rootElement.ownerDocument;
+        this.setDoc(rootElement.ownerDocument);
         const res = await this.processNode(rootElement as HTMLElement);
         if (res && res.layerNode) {
             this.updateLayers([res.layerNode]);

--- a/app/src/lib/editor/engine/ast/index.ts
+++ b/app/src/lib/editor/engine/ast/index.ts
@@ -11,8 +11,6 @@ const IGNORE_TAGS = ['SCRIPT', 'STYLE'];
 export class AstManager {
     private doc: Document | undefined;
     private layersMap: Map<string, LayerNode> = new Map();
-    // TODO: Move this into AstMap
-    private processedForMap = new Set<string>();
     templateNodeMap: AstMap = new AstMap();
     layers: LayerNode[] = [];
 
@@ -32,7 +30,7 @@ export class AstManager {
         }
         const selector = getUniqueSelector(element, element.ownerDocument.body);
         this.layersMap.delete(selector);
-        this.processedForMap.delete(selector);
+        this.templateNodeMap.removeSelector(selector);
     }
 
     async getInstance(selector: string): Promise<TemplateNode | undefined> {
@@ -46,7 +44,7 @@ export class AstManager {
     }
 
     async checkForNode(selector: string) {
-        if (this.isProcessed(selector)) {
+        if (this.templateNodeMap.isProcessed(selector)) {
             return;
         }
         const element = this.doc?.querySelector(selector);
@@ -54,11 +52,6 @@ export class AstManager {
         if (res && res.layerNode && res.refreshed) {
             this.updateLayers([res.layerNode]);
         }
-    }
-
-    // TODO: Move this into AstMap
-    private isProcessed(selector: string): boolean {
-        return this.processedForMap.has(selector);
     }
 
     async setMapRoot(rootElement: Element) {
@@ -82,7 +75,6 @@ export class AstManager {
 
     private async processNodeForMap(node: HTMLElement) {
         const selector = getUniqueSelector(node, this.doc?.body);
-        this.processedForMap.add(selector);
         if (!selector) {
             return;
         }
@@ -157,7 +149,7 @@ export class AstManager {
                 return;
             }
             const selector = getUniqueSelector(element, element.ownerDocument.body);
-            if (!this.isProcessed(selector)) {
+            if (!this.templateNodeMap.isProcessed(selector)) {
                 this.processNodeForMap(element);
             }
 
@@ -219,6 +211,5 @@ export class AstManager {
         this.templateNodeMap = new AstMap();
         this.layers = [];
         this.layersMap = new Map();
-        this.processedForMap = new Set();
     }
 }

--- a/app/src/lib/editor/engine/ast/index.ts
+++ b/app/src/lib/editor/engine/ast/index.ts
@@ -24,11 +24,11 @@ export class AstManager {
         });
     }
 
-    removeElement(element: HTMLElement | undefined) {
+    refreshElement(selector: string) {
+        const element = this.doc?.querySelector(selector);
         if (!element) {
             return;
         }
-        const selector = getUniqueSelector(element, element.ownerDocument.body);
         if (!this.templateNodeMap.isProcessed(selector) && !this.layersMap.has(selector)) {
             return;
         }

--- a/app/src/lib/editor/engine/ast/index.ts
+++ b/app/src/lib/editor/engine/ast/index.ts
@@ -11,8 +11,8 @@ const IGNORE_TAGS = ['SCRIPT', 'STYLE'];
 export class AstManager {
     private doc: Document | undefined;
     private layersMap: Map<string, LayerNode> = new Map();
-    templateNodeMap: AstMap = new AstMap();
     layers: LayerNode[] = [];
+    templateNodeMap: AstMap = new AstMap();
 
     constructor() {
         makeAutoObservable(this);
@@ -33,14 +33,14 @@ export class AstManager {
             return;
         }
         this.layersMap.delete(selector);
-        this.templateNodeMap.removeSelector(selector);
+        this.templateNodeMap.remove(selector);
 
         // Remove all children
         const children = element.querySelectorAll('*');
         children.forEach((child) => {
             const childSelector = getUniqueSelector(child as HTMLElement, child.ownerDocument.body);
             this.layersMap.delete(childSelector);
-            this.templateNodeMap.removeSelector(childSelector);
+            this.templateNodeMap.remove(childSelector);
         });
 
         // Remove from parent

--- a/app/src/lib/editor/engine/ast/map.ts
+++ b/app/src/lib/editor/engine/ast/map.ts
@@ -5,6 +5,15 @@ export class AstMap {
     selectorToInstance: Map<string, TemplateNode> = new Map();
     selectorToRoot: Map<string, TemplateNode> = new Map();
 
+    isProcessed(selector: string): boolean {
+        return this.selectorToInstance.has(selector) || this.selectorToRoot.has(selector);
+    }
+
+    removeSelector(selector: string) {
+        this.selectorToInstance.delete(selector);
+        this.selectorToRoot.delete(selector);
+    }
+
     getSelectors(templateNode: TemplateNode): string[] {
         return this.templateToSelectors.get(templateNode) || [];
     }

--- a/app/src/lib/editor/engine/ast/map.ts
+++ b/app/src/lib/editor/engine/ast/map.ts
@@ -9,7 +9,7 @@ export class AstMap {
         return this.selectorToInstance.has(selector) || this.selectorToRoot.has(selector);
     }
 
-    removeSelector(selector: string) {
+    remove(selector: string) {
         this.selectorToInstance.delete(selector);
         this.selectorToRoot.delete(selector);
     }

--- a/app/src/lib/editor/engine/dom/index.ts
+++ b/app/src/lib/editor/engine/dom/index.ts
@@ -28,6 +28,11 @@ export class DomManager {
         await this.setDom(webview.id, root);
     }
 
+    async refreshAstDoc(webview: WebviewTag) {
+        const root = await this.getBodyFromWebview(webview);
+        this.ast.setDoc(root.ownerDocument);
+    }
+
     getElementBySelector(selector: string, webviewId: string) {
         const root = this.getDomElement(webviewId) as Element;
         const el = root.querySelector(selector);

--- a/app/src/lib/editor/eventHandler.ts
+++ b/app/src/lib/editor/eventHandler.ts
@@ -36,23 +36,14 @@ export class WebviewEventHandler {
                 return;
             }
             const { added, removed } = e.args[0] as { added: string[]; removed: string[] };
-            const body = await this.editorEngine.dom.getBodyFromWebview(webview);
-            this.editorEngine.ast.setDoc(body.ownerDocument);
+            await this.editorEngine.dom.refreshAstDoc(webview);
 
             added.forEach((selector: string) => {
-                const element = body.querySelector(selector);
-                if (!element) {
-                    return;
-                }
-                this.editorEngine.ast.removeElement(element as HTMLElement);
+                this.editorEngine.ast.refreshElement(selector);
             });
 
             removed.forEach((selector: string) => {
-                const element = body.querySelector(selector);
-                if (!element) {
-                    return;
-                }
-                this.editorEngine.ast.removeElement(element as HTMLElement);
+                this.editorEngine.ast.refreshElement(selector);
             });
         }, 1000);
     }
@@ -65,8 +56,7 @@ export class WebviewEventHandler {
             }
             this.editorEngine.mode = EditorMode.DESIGN;
             const webview = e.target as Electron.WebviewTag;
-            const body = await this.editorEngine.dom.getBodyFromWebview(webview);
-            this.editorEngine.ast.setDoc(body.ownerDocument);
+            await this.editorEngine.dom.refreshAstDoc(webview);
             const domElement: DomElement = e.args[0];
             this.editorEngine.elements.click([domElement], webview);
         };
@@ -75,8 +65,7 @@ export class WebviewEventHandler {
     handleElementRemoved() {
         return async (e: Electron.IpcMessageEvent) => {
             const webview = e.target as Electron.WebviewTag;
-            const body = await this.editorEngine.dom.getBodyFromWebview(webview);
-            this.editorEngine.ast.setDoc(body.ownerDocument);
+            await this.editorEngine.dom.refreshAstDoc(webview);
             this.editorEngine.clear();
         };
     }

--- a/app/src/lib/editor/eventHandler.ts
+++ b/app/src/lib/editor/eventHandler.ts
@@ -35,10 +35,25 @@ export class WebviewEventHandler {
                 console.error('No args found for window mutated event');
                 return;
             }
-            const elements = e.args[0] as string[];
-            // const body = await this.editorEngine.dom.getBodyFromWebview(webview);
-            // this.editorEngine.dom.setDom(webview.id, body);
-            await this.editorEngine.dom.refreshDom(webview);
+            const { added, removed } = e.args[0] as { added: string[]; removed: string[] };
+            const body = await this.editorEngine.dom.getBodyFromWebview(webview);
+            this.editorEngine.ast.setDoc(body.ownerDocument);
+
+            added.forEach((selector: string) => {
+                const element = body.querySelector(selector);
+                if (!element) {
+                    return;
+                }
+                this.editorEngine.ast.removeElement(element as HTMLElement);
+            });
+
+            removed.forEach((selector: string) => {
+                const element = body.querySelector(selector);
+                if (!element) {
+                    return;
+                }
+                this.editorEngine.ast.removeElement(element as HTMLElement);
+            });
         }, 1000);
     }
 
@@ -50,7 +65,8 @@ export class WebviewEventHandler {
             }
             this.editorEngine.mode = EditorMode.DESIGN;
             const webview = e.target as Electron.WebviewTag;
-            await this.editorEngine.dom.refreshDom(webview);
+            const body = await this.editorEngine.dom.getBodyFromWebview(webview);
+            this.editorEngine.ast.setDoc(body.ownerDocument);
             const domElement: DomElement = e.args[0];
             this.editorEngine.elements.click([domElement], webview);
         };
@@ -59,7 +75,8 @@ export class WebviewEventHandler {
     handleElementRemoved() {
         return async (e: Electron.IpcMessageEvent) => {
             const webview = e.target as Electron.WebviewTag;
-            await this.editorEngine.dom.refreshDom(webview);
+            const body = await this.editorEngine.dom.getBodyFromWebview(webview);
+            this.editorEngine.ast.setDoc(body.ownerDocument);
             this.editorEngine.clear();
         };
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Refresh layers when the DOM is mutated. This way the layers can keep up with changing DOM.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [x] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
