### PR TITLE
fix: for non-components show text "View element code" on right click

### DIFF
--- a/app/src/routes/project/RightClickMenu/index.tsx
+++ b/app/src/routes/project/RightClickMenu/index.tsx
@@ -48,7 +48,7 @@ export const RightClickMenu = observer(({ children }: RightClickMenuProps) => {
                 action: () => viewSource(instance),
             },
             root && {
-                label: 'View component code',
+                label: `View ${instance ? 'component' : 'element'} code`,
                 action: () => viewSource(root),
             },
         ].filter(Boolean) as MenuItem[];


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When we select a component we have the `instance` information but when we select any non-components it's `undefined`, used that logic to differentiate between elements and components.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

<img width="1144" alt="Screenshot 2024-08-31 at 6 06 37 PM" src="https://github.com/user-attachments/assets/d0ee9fbc-3591-4c56-9fb8-defdc8a770d0">

<img width="855" alt="Screenshot 2024-08-31 at 6 07 17 PM" src="https://github.com/user-attachments/assets/adb7d1d8-24e7-41d2-b7ad-17f9214aa277">

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other

Fixes #251 