### PR TITLE
Add refresh layer escape hatch

### DIFF
--- a/app/electron/preload/webview/api.ts
+++ b/app/electron/preload/webview/api.ts
@@ -3,6 +3,7 @@ import { getElementAtLoc, getElementWithSelector } from './elements';
 import { getInsertedElements, getInsertLocation } from './elements/insert';
 import { getMovedElements } from './elements/move';
 import { drag, endDrag, startDrag } from './elements/move/drag';
+import { processDom } from './dom';
 
 export function setApi() {
     contextBridge.exposeInMainWorld('api', {
@@ -14,5 +15,6 @@ export function setApi() {
         drag: drag,
         endDrag: endDrag,
         getMovedElements: getMovedElements,
+        processDom: processDom,
     });
 }

--- a/app/src/lib/editor/engine/index.ts
+++ b/app/src/lib/editor/engine/index.ts
@@ -118,4 +118,14 @@ export class EditorEngine {
         }
         webview.openDevTools();
     }
+
+    async refreshLayers() {
+        this.ast.clear();
+        const webviews = this.webviews.webviews;
+        if (webviews.size === 0) {
+            return;
+        }
+        const webview = Array.from(webviews.values())[0].webview;
+        webview.executeJavaScript('window.api?.processDom()');
+    }
 }

--- a/app/src/routes/project/RightClickMenu/index.tsx
+++ b/app/src/routes/project/RightClickMenu/index.tsx
@@ -33,6 +33,12 @@ export const RightClickMenu = observer(({ children }: RightClickMenuProps) => {
                 editorEngine.inspect();
             },
         },
+        {
+            label: 'Refresh layers',
+            action: () => {
+                editorEngine.refreshLayers();
+            },
+        },
     ];
 
     useEffect(() => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Allow the ability to manually refresh layers. For situations where animation happens that changes the page drastically.
<img width="1728" alt="Screenshot 2024-09-11 at 4 09 50 PM" src="https://github.com/user-attachments/assets/c7e9605d-2caa-4500-95bf-a77b9f9f33d5">

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [X] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
