### PR TITLE
:bug: fixed lag in the long layer name animation tooltip 

### DIFF
--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -18,8 +18,7 @@ const TooltipContent = React.forwardRef<
         sideOffset={sideOffset}
         className={cn(
             'z-50 overflow-hidden rounded-md bg-black px-2 py-1.5 text-xs text-text-foreground',
-            'animate-in fade-in-0 zoom-in-95 duration-100',
-            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 duration-100',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 duration-100',
             className,
         )}
         {...props}

--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -22,10 +22,7 @@ const TooltipContent = React.forwardRef<
             className,
         )}
         {...props}
-    >
-        {props.children}
-        <TooltipPrimitive.Arrow className="fill-black" />
-    </TooltipPrimitive.Content>
+    />
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -17,11 +17,16 @@ const TooltipContent = React.forwardRef<
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-            'z-50 overflow-hidden rounded-md bg-black px-2 py-1.5 text-xs text-text-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'z-50 overflow-hidden rounded-md bg-black px-2 py-1.5 text-xs text-text-foreground',
+            'animate-in fade-in-0 zoom-in-95 duration-100',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 duration-100',
             className,
         )}
         {...props}
-    />
+    >
+        {props.children}
+        <TooltipPrimitive.Arrow className="fill-black" />
+    </TooltipPrimitive.Content>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/app/src/routes/editor/LayersPanel/Tree/TreeNode.tsx
+++ b/app/src/routes/editor/LayersPanel/Tree/TreeNode.tsx
@@ -179,9 +179,12 @@ const TreeNode = observer(
                 {node.data.textContent !== '' && (
                     <TooltipPortal container={document.getElementById('layer-tab-id')}>
                         <TooltipContent side="right" align="center" sideOffset={sideOffset()}>
-                            <TooltipArrow />
-                            <p
-                                className={'max-w-[200px] overflow-hidden relative'}
+                            <motion.p
+                                initial={{ opacity: 0, y: -10 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                exit={{ opacity: 0, y: -10 }}
+                                transition={{ duration: 0.2 }}
+                                className="max-w-[200px] overflow-hidden"
                                 style={{
                                     display: '-webkit-box',
                                     WebkitLineClamp: 4,
@@ -190,7 +193,7 @@ const TreeNode = observer(
                                 }}
                             >
                                 {node.data.textContent}
-                            </p>
+                            </motion.p>
                         </TooltipContent>
                     </TooltipPortal>
                 )}

--- a/app/src/routes/editor/LayersPanel/Tree/TreeNode.tsx
+++ b/app/src/routes/editor/LayersPanel/Tree/TreeNode.tsx
@@ -179,6 +179,7 @@ const TreeNode = observer(
                 {node.data.textContent !== '' && (
                     <TooltipPortal container={document.getElementById('layer-tab-id')}>
                         <TooltipContent side="right" align="center" sideOffset={sideOffset()}>
+                            <TooltipArrow className="fill-black" />
                             <motion.p
                                 initial={{ opacity: 0, y: -10 }}
                                 animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes #360 

I removed the animations from the tooltip component itself and now they appear at the same time. 
I also added a slight animation for the text so that it doesn't jump into focus when the tooltip animates (this is just a small quality of life improvement). 


### What is the purpose of this pull request? 

https://github.com/user-attachments/assets/2a10901e-5cec-4381-a8a5-5d2e6a161b8d

This PR fixes this issue #360 

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [x] Refactor
- [ ] Release
- [ ] Other


This is a demo of
