### PR TITLE
feat: Add unit test coverage tracking

### DIFF
--- a/app/bunfig.toml
+++ b/app/bunfig.toml
@@ -1,2 +1,5 @@
 [test]
-preload = "./happydom.ts"
+coverage = true
+coverageSkipTestFiles = true  
+coverageReport = "text"
+coverageDirectory = "./coverage"

--- a/app/bunfig.toml
+++ b/app/bunfig.toml
@@ -1,5 +1,2 @@
 [test]
-coverage = true
-coverageSkipTestFiles = true  
 coverageReport = "text"
-coverageDirectory = "./coverage"

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
         "pree2e": "vite build --mode=test",
         "e2e": "playwright test",
         "test": "bun test",
+        "coverage": "bun test --coverage",
         "lint": "eslint --fix .",
         "format": "prettier --write .",
         "increment_tag": "npm version patch",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I have used Bun’s built-in coverage support for test coverage tracking, which generates reports and provides insights into how much of your code is covered by tests.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [x] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
