### PR TITLE
Enable start line and column for Zed only

### DIFF
--- a/app/common/ide.ts
+++ b/app/common/ide.ts
@@ -48,13 +48,16 @@ export class IDE {
         const endTag = templateNode.endTag || startTag;
         let codeCommand = `${this.command}://file/${filePath}`;
 
-        // Note: Zed API not handling lines https://github.com/zed-industries/zed/issues/14820
-        if (startTag && endTag && this.type !== IdeType.ZED) {
+        if (startTag && endTag) {
             const startRow = startTag.start.line;
             const startColumn = startTag.start.column;
             const endRow = endTag.end.line;
             const endColumn = endTag.end.column - 1;
-            codeCommand += `:${startRow}:${startColumn}:${endRow}:${endColumn}`;
+            codeCommand += `:${startRow}:${startColumn}`;
+            // Note: Zed API doesn't seem to handle end row/column (ref: https://github.com/zed-industries/zed/issues/18520)
+            if (this.type !== IdeType.ZED) {
+                codeCommand += `:${endRow}:${endColumn}`;
+            }
         }
         return codeCommand;
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR re-enables the Zed integration by addressing a specific edge case: it only appends the start line and column to the URL when the URL is specifically for Zed and not the end line and column _(see zed-industries/zed#18520 for more info)_

Closes #415

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [x] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
