### PR TITLE
darkmode preview

### DIFF
--- a/app/electron/preload/webview/api.ts
+++ b/app/electron/preload/webview/api.ts
@@ -12,7 +12,7 @@ import {
     startEditingText,
     stopEditingText,
 } from './elements/text';
-import { darkmodeToggle } from './theme';
+import { getTheme, toggleTheme } from './theme';
 
 export function setApi() {
     contextBridge.exposeInMainWorld('api', {
@@ -22,7 +22,8 @@ export function setApi() {
         isElementInserted: isElementInserted,
 
         // Theme
-        darkmodeToggle: darkmodeToggle,
+        getTheme: getTheme,
+        toggleTheme: toggleTheme,
 
         // Insert
         getInsertLocation: getInsertLocation,

--- a/app/electron/preload/webview/api.ts
+++ b/app/electron/preload/webview/api.ts
@@ -12,6 +12,7 @@ import {
     startEditingText,
     stopEditingText,
 } from './elements/text';
+import { darkmodeToggle } from './theme';
 
 export function setApi() {
     contextBridge.exposeInMainWorld('api', {
@@ -19,6 +20,9 @@ export function setApi() {
         getElementWithSelector: getElementWithSelector,
         processDom: processDom,
         isElementInserted: isElementInserted,
+
+        // Theme
+        darkmodeToggle: darkmodeToggle,
 
         // Insert
         getInsertLocation: getInsertLocation,

--- a/app/electron/preload/webview/theme/index.ts
+++ b/app/electron/preload/webview/theme/index.ts
@@ -1,0 +1,15 @@
+export function darkmodeToggle() {
+    const mode = window?.localStorage.getItem('theme') || 'light';
+
+    if (mode === 'dark') {
+        document.documentElement.classList.remove('dark');
+        window?.localStorage.setItem('theme', 'light');
+
+        return false;
+    } else {
+        document.documentElement.classList.add('dark');
+        window?.localStorage.setItem('theme', 'dark');
+
+        return true;
+    }
+}

--- a/app/electron/preload/webview/theme/index.ts
+++ b/app/electron/preload/webview/theme/index.ts
@@ -1,5 +1,9 @@
-export function darkmodeToggle() {
-    const mode = window?.localStorage.getItem('theme') || 'light';
+export function getTheme() {
+    return window?.localStorage.getItem('theme') || 'light';
+}
+
+export function toggleTheme() {
+    const mode = getTheme();
 
     if (mode === 'dark') {
         document.documentElement.classList.remove('dark');

--- a/app/src/routes/editor/WebviewArea/BrowserControl.tsx
+++ b/app/src/routes/editor/WebviewArea/BrowserControl.tsx
@@ -8,7 +8,9 @@ import {
     CircleBackslashIcon,
     ExclamationTriangleIcon,
     ExternalLinkIcon,
+    MoonIcon,
     ReloadIcon,
+    SunIcon,
 } from '@radix-ui/react-icons';
 import clsx from 'clsx';
 import { Links } from '/common/constants';
@@ -20,6 +22,8 @@ interface BrowserControlsProps {
     selected: boolean;
     hovered: boolean;
     setHovered: React.Dispatch<React.SetStateAction<boolean>>;
+    darkmode: boolean;
+    setDarkmode: React.Dispatch<React.SetStateAction<boolean>>;
     onlookEnabled: boolean;
 }
 
@@ -30,6 +34,8 @@ function BrowserControls({
     selected,
     hovered,
     setHovered,
+    darkmode,
+    setDarkmode,
     onlookEnabled,
 }: BrowserControlsProps) {
     function goForward() {
@@ -81,6 +87,15 @@ function BrowserControls({
         webview.src = validUrl;
         webview.loadURL(validUrl);
         e.currentTarget.blur();
+    }
+
+    function toggleTheme() {
+        const webview = webviewRef.current as Electron.WebviewTag | null;
+        if (!webview) {
+            return;
+        }
+
+        webview.executeJavaScript(`window.api?.darkmodeToggle()`).then((res) => setDarkmode(res));
     }
 
     return (
@@ -162,6 +177,9 @@ function BrowserControls({
                     </div>
                 </PopoverContent>
             </Popover>
+            <Button variant="outline" className="bg-transparent" size="icon" onClick={toggleTheme}>
+                {darkmode ? <MoonIcon /> : <SunIcon />}
+            </Button>
         </div>
     );
 }

--- a/app/src/routes/editor/WebviewArea/BrowserControl.tsx
+++ b/app/src/routes/editor/WebviewArea/BrowserControl.tsx
@@ -95,7 +95,7 @@ function BrowserControls({
             return;
         }
 
-        webview.executeJavaScript(`window.api?.darkmodeToggle()`).then((res) => setDarkmode(res));
+        webview.executeJavaScript(`window.api?.toggleTheme()`).then((res) => setDarkmode(res));
     }
 
     return (
@@ -123,6 +123,9 @@ function BrowserControls({
                 onChange={(e) => setWebviewSrc(e.target.value)}
                 onKeyDown={updateUrl}
             />
+            <Button variant="outline" className="bg-transparent" size="icon" onClick={toggleTheme}>
+                {darkmode ? <MoonIcon /> : <SunIcon />}
+            </Button>
             <Popover>
                 <PopoverTrigger asChild>
                     <Button
@@ -177,9 +180,6 @@ function BrowserControls({
                     </div>
                 </PopoverContent>
             </Popover>
-            <Button variant="outline" className="bg-transparent" size="icon" onClick={toggleTheme}>
-                {darkmode ? <MoonIcon /> : <SunIcon />}
-            </Button>
         </div>
     );
 }

--- a/app/src/routes/editor/WebviewArea/Frame.tsx
+++ b/app/src/routes/editor/WebviewArea/Frame.tsx
@@ -85,6 +85,12 @@ const Frame = observer(
             const body = await editorEngine.dom.getBodyFromWebview(webview);
             setDomFailed(body.children.length === 0);
             checkForOnlookEnabled(body);
+            setTimeout(() => getDarkMode(webview), 100);
+        }
+
+        async function getDarkMode(webview: Electron.WebviewTag) {
+            const darkmode = (await webview.executeJavaScript(`window.api?.getTheme()`)) || 'light';
+            setDarkmode(darkmode === 'dark');
         }
 
         function checkForOnlookEnabled(body: Element) {

--- a/app/src/routes/editor/WebviewArea/Frame.tsx
+++ b/app/src/routes/editor/WebviewArea/Frame.tsx
@@ -27,6 +27,7 @@ const Frame = observer(
         const [selected, setSelected] = useState<boolean>(false);
         const [focused, setFocused] = useState<boolean>(false);
         const [hovered, setHovered] = useState<boolean>(false);
+        const [darkmode, setDarkmode] = useState<boolean>(false);
         const [domFailed, setDomFailed] = useState(false);
         const [onlookEnabled, setOnlookEnabled] = useState(false);
 
@@ -118,6 +119,8 @@ const Frame = observer(
                     selected={selected}
                     hovered={hovered}
                     setHovered={setHovered}
+                    darkmode={darkmode}
+                    setDarkmode={setDarkmode}
                     onlookEnabled={onlookEnabled}
                 />
                 <div className="relative">


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
dark mode toggle (browser top-right corner):
it's works perfectly with new feature tailwind input. `bg-blue-900 dark:bg-blue-300`

![image](https://github.com/user-attachments/assets/75e75dba-f0b3-4ce7-a662-5b9ac2472465)


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [X] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
