### PR TITLE
webview issue

### DIFF
--- a/app/src/routes/editor/Canvas/index.tsx
+++ b/app/src/routes/editor/Canvas/index.tsx
@@ -19,7 +19,14 @@ const Canvas = observer(({ children }: { children: ReactNode }) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const [isPanning, setIsPanning] = useState(false);
     const [scale, setScale] = useState(editorEngine.canvas.scale);
-    const [position, setPosition] = useState(editorEngine.canvas.position);
+
+    const x_number = window.innerWidth / 2 - (1536 * scale) / 2; // - webviewWidth;
+    const y_number = window.innerHeight / 2 - (960 * scale) / 2; // - webviewHeight;
+
+    const [position, setPosition] = useState<{ x: number; y: number }>({
+        x: x_number,
+        y: y_number,
+    });
 
     useEffect(() => {
         editorEngine.canvas.scale = scale;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Related to issue #307 
Previously, the react "window" inside the app, done with a <webview>, would be off center when onlook was quit with it off center and then reopened. This was because position was only being reset once the app was fully quit and the cache cleared. Now, the react "window" is reset each time onlook is reopened. I did not address the fact that scaling persists through closing and opening onlook because this was not what the issue was about, but changing that would require minimal edits right next to where my edits were made.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
