### PR TITLE
Fix: Prevent white outline when holding shift and clicking on UI elements

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -89,3 +89,8 @@ body,
     width: 100%;
     overflow: auto;
 }
+
+*:focus-visible {
+  outline: none !important;
+  box-shadow: unset !important;
+}


### PR DESCRIPTION
### Description

This PR addresses issue #278, where holding down the Shift key and clicking on elements in the UI occasionally adds a white border around those elements. This behavior is unintended and should not occur in the Onlook UI.

The issue occurs because of the `:focus-visible` pseudo-class which applies while an element matches the `:focus` pseudo-class and the UA determines via heuristics that the focus should be made evident on the element. Many browsers show a "focus ring" by default in this case, which is removed in this PR.

Although this fixes the issue of unintended white outline on shift click, it also removes the white outline on tab click which makes it harder to navigate the UI using the keyboard.

### What is the purpose of this pull request? 


- [ ] New feature
- [ ] Documentation update
- [X] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
