### PR TITLE
Make the logo the proper foreground color for light / dark mode

### DIFF
--- a/app/src/assets/word-logo.svg
+++ b/app/src/assets/word-logo.svg
@@ -1,8 +1,8 @@
 <svg width="139" height="17" viewBox="0 0 139 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M26.7578 16.502V4.40195H28.7485L43.3051 15.4019H44.7981V3.30195" stroke="white" style="stroke:white;stroke-opacity:1;" stroke-width="2.73715"/>
-<path d="M50.7734 3.30237V15.4023L67.0719 15.4023" stroke="white" style="stroke:white;stroke-opacity:1;" stroke-width="2.73715"/>
-<rect x="2" y="4.62305" width="19.4089" height="10.56" rx="5.27999" stroke="white" style="stroke:white;stroke-opacity:1;" stroke-width="2.73715"/>
-<rect x="69.6797" y="4.62305" width="19.4089" height="10.56" rx="5.27999" stroke="white" style="stroke:white;stroke-opacity:1;" stroke-width="2.73715"/>
-<rect x="94.0703" y="4.62305" width="19.4089" height="10.56" rx="5.27999" stroke="white" style="stroke:white;stroke-opacity:1;" stroke-width="2.73715"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M120.823 10.3906V16.502H118.086V9.022V3.30204H120.823V7.65343H128.075L133.781 3.30213H138.295L130.657 9.126L138.583 16.502H134.565L127.999 10.3906H120.823ZM137.735 0.442137L137.66 0.34375L137.531 0.442137H137.735Z" fill="white" style="fill:white;fill-opacity:1;"/>
+  <path d="M26.7578 16.502V4.40195H28.7485L43.3051 15.4019H44.7981V3.30195" stroke="black" style="stroke:black;stroke-opacity:1;" stroke-width="2.73715"/>
+  <path d="M50.7734 3.30237V15.4023L67.0719 15.4023" stroke="black" style="stroke:black;stroke-opacity:1;" stroke-width="2.73715"/>
+  <rect x="2" y="4.62305" width="19.4089" height="10.56" rx="5.27999" stroke="black" style="stroke:black;stroke-opacity:1;" stroke-width="2.73715"/>
+  <rect x="69.6797" y="4.62305" width="19.4089" height="10.56" rx="5.27999" stroke="black" style="stroke:black;stroke-opacity:1;" stroke-width="2.73715"/>
+  <rect x="94.0703" y="4.62305" width="19.4089" height="10.56" rx="5.27999" stroke="black" style="stroke:black;stroke-opacity:1;" stroke-width="2.73715"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M120.823 10.3906V16.502H118.086V9.022V3.30204H120.823V7.65343H128.075L133.781 3.30213H138.295L130.657 9.126L138.583 16.502H134.565L127.999 10.3906H120.823ZM137.735 0.442137L137.66 0.34375L137.531 0.442137H137.735Z" fill="black" style="fill:black;fill-opacity:1;"/>
 </svg>

--- a/app/src/components/Announcement/index.tsx
+++ b/app/src/components/Announcement/index.tsx
@@ -1,5 +1,4 @@
 import mountains from '@/assets/mountains.png';
-import wordLogo from '@/assets/word-logo.svg';
 import { DialogTitle } from '@radix-ui/react-dialog';
 import {
     BoxIcon,
@@ -14,6 +13,7 @@ import { Dialog, DialogContent } from '../ui/dialog';
 import { Input } from '../ui/input';
 import { Toggle } from '../ui/toggle';
 import { toast } from '../ui/use-toast';
+import { WordLogo } from '../ui/logo';
 import { Links, MainChannels } from '/common/constants';
 import { UserSettings } from '/common/models/settings';
 import supabase from '/data/clients';
@@ -77,7 +77,7 @@ function Announcement() {
                         alt="Onlook logo"
                     />
                     <div className="absolute top-10 w-full items-center flex flex-col space-y-2">
-                        <img className="w-1/4" src={wordLogo} alt="Onlook logo" />
+                        <WordLogo className="invert"/>
                         <DialogTitle className="text-xs">
                             Version {window.env.APP_VERSION}
                         </DialogTitle>

--- a/app/src/components/ui/logo.tsx
+++ b/app/src/components/ui/logo.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import wordLogo from '@/assets/word-logo.svg';
+import { ImgHTMLAttributes } from 'react';
+import { cn } from '@/lib/utils';
+
+const WordLogo = React.forwardRef<HTMLImageElement, ImgHTMLAttributes<HTMLImageElement>>(
+    ({ className, ...props }, ref) => (
+        <img
+            ref={ref}
+            src={wordLogo}
+            alt="Onlook logo"
+            className={cn(
+              'w-1/4 dark:invert', 
+              className,
+            )}
+            {...props}
+        />
+    ),
+);
+WordLogo.displayName = 'WordLogo';
+
+export { WordLogo };

--- a/app/src/routes/projects/TopBar/index.tsx
+++ b/app/src/routes/projects/TopBar/index.tsx
@@ -1,4 +1,3 @@
-import wordLogo from '@/assets/word-logo.svg';
 import { useAuthManager } from '@/components/Context';
 import { Button } from '@/components/ui/button';
 import {
@@ -8,6 +7,7 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
+import { WordLogo } from '@/components/ui/logo';
 import { CreateMethod } from '@/routes/projects/helpers';
 import { DownloadIcon, FilePlusIcon, PlusIcon, ExitIcon, GearIcon } from '@radix-ui/react-icons';
 import { observer } from 'mobx-react-lite';
@@ -46,7 +46,7 @@ export const TopBar = observer(
         return (
             <div className="flex flex-row h-12 px-12 items-center">
                 <div className="flex-1 flex items-center justify-start mt-3">
-                    <img className="w-24" src={wordLogo} alt="Onlook logo" />
+                    <WordLogo className="w-24" />
                 </div>
                 <div className="flex-1 flex justify-end space-x-2 mt-4 items-center">
                     <DropdownMenu>

--- a/app/src/routes/signin/index.tsx
+++ b/app/src/routes/signin/index.tsx
@@ -1,6 +1,6 @@
 import dunes from '@/assets/dunes-login.png';
 import googleLogo from '@/assets/google-logo.svg';
-import wordLogo from '@/assets/word-logo.svg';
+import { WordLogo } from '@/components/ui/logo';
 import { useAuthManager } from '@/components/Context';
 import { Button } from '@/components/ui/button';
 import { GitHubLogoIcon } from '@radix-ui/react-icons';
@@ -40,7 +40,7 @@ const SignIn = observer(() => {
         <div className="flex h-[calc(100vh-2.5rem)]">
             <div className="flex flex-col justify-between w-full h-full max-w-xl p-16 space-y-8 overflow-auto">
                 <div className="flex items-center space-x-2">
-                    <img className="w-1/4" src={wordLogo} alt="Onlook logo" />
+                    <WordLogo />
                 </div>
                 <div className="space-y-8">
                     <div className="space-y-2 uppercase rounded-full p-1 px-2 w-auto inline-block text-micro border-[0.5px] text-blue-400 border-blue-400">


### PR DESCRIPTION
### Description

Fix #531.

- I've created `WordLogo` component for better code maintainability
- Refactored `Announcement`, `TopBar`, and `SignIn` components to use the new `WordLogo` component instead of direct image imports

This could be solved by simply adding a class to the <img/> tag, but creating this component allows us to easily transform other images into components as well.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
