### PR TITLE
chore: handle rotate chevron icon when open dropdown menu

### DIFF
--- a/app/src/routes/editor/TopBar/ProjectSelect/index.tsx
+++ b/app/src/routes/editor/TopBar/ProjectSelect/index.tsx
@@ -67,9 +67,9 @@ const ProjectBreadcrumb = observer(() => {
             </Tooltip>
             <p className="mb-[2px] min-w-[4px] text-foreground-onlook">{'/'}</p>
             <DropdownMenu>
-                <DropdownMenuTrigger className="flex flex-row gap-2 items-center mx-0 max-w-[60px] md:max-w-[100px] lg:max-w-[200px] px-0 text-foreground-onlook text-small truncate hover:text-foreground-hover hover:bg-transparent">
+                <DropdownMenuTrigger className="group flex flex-row gap-2 items-center mx-0 max-w-[60px] md:max-w-[100px] lg:max-w-[200px] px-0 text-foreground-onlook text-small truncate hover:text-foreground-hover hover:bg-transparent">
                     {projectsManager.project?.name}
-                    <ChevronDownIcon />
+                    <ChevronDownIcon className="transition-all rotate-0 group-data-[state=open]:rotate-180 duration-200 ease-in-out" />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
                     <DropdownMenuItem onClick={handleOpenProjectFolder}>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
Link to issue: https://github.com/onlook-dev/onlook/issues/543

### Description

When the project menu is opened, animate and rotate the arrow icon 180º to point up.

#### Screenshot


https://github.com/user-attachments/assets/5777e5f8-85cf-46a9-afa0-2b49a9df2662


### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [x] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
