### PR TITLE
Command to run a new project on Windows 

### DIFF
--- a/app/src/routes/projects/ProjectsTab/Create/New/Run.tsx
+++ b/app/src/routes/projects/ProjectsTab/Create/New/Run.tsx
@@ -19,7 +19,9 @@ export const NewRunProject = ({
 }) => {
     const [isRunning, setIsRunning] = useState<boolean>(false);
     const [hasCopied, setHasCopied] = useState<boolean>(false);
-    const codeContent = `cd ${projectData.folderPath} && npm run dev`;
+    
+    const platformCommand = process.platform === 'win32' ? 'cd /d' : 'cd';
+    const codeContent = `${platformCommand} ${projectData.folderPath} && npm run dev`;
 
     function copyToClipboard(text: string) {
         navigator.clipboard.writeText(text);


### PR DESCRIPTION
### Description
Fix #547 
- just add the [`/d` param](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cd#parameters) to cd command in windows.  
  - > `/d` Changes the current drive as well as the current directory for a drive.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
