### PR TITLE
[bug] Rename input needs to be refreshed when a new project is selected

### DIFF
--- a/app/src/routes/projects/ProjectsTab/Select/ProjectSettingsButton.tsx
+++ b/app/src/routes/projects/ProjectsTab/Select/ProjectSettingsButton.tsx
@@ -30,6 +30,10 @@ export default function ProjectSettingsButton({ project }: { project: Project })
     const [projectName, setProjectName] = React.useState(project.name);
     const isProjectNameEmpty = React.useMemo(() => projectName.length === 0, [projectName]);
 
+    React.useEffect(() => {
+        setProjectName(project.name);
+    }, [project.name]);
+
     const handleDeleteProject = () => {
         projectsManager.deleteProject(project);
         setShowDeleteDialog(false);


### PR DESCRIPTION
@drfarrell  can you please add Labels on this for hacktoberfest-accepted? Thanks.

https://github.com/onlook-dev/onlook/issues/569

<!-- Thank you for contributing! -->

### Description
This PR addresses a bug where the rename input field fails to update when switching between projects. The input field is now properly refreshed upon project selection, ensuring that the correct project name is displayed in the rename field.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [X] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
