### PR TITLE
Text area focus hint

### DIFF
--- a/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
+++ b/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
@@ -1,8 +1,9 @@
 import { useEditorEngine } from '@/components/Context';
 import { Textarea } from '@/components/ui/textarea';
 import { sendAnalytics } from '@/lib/utils';
+import { ResetIcon } from '@radix-ui/react-icons';
 import { observer } from 'mobx-react-lite';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { MainChannels } from '/common/constants';
 import { CodeDiffRequest } from '/common/models/code';
 import { TemplateNode } from '/common/models/element/templateNode';
@@ -128,15 +129,12 @@ const TailwindInput = observer(() => {
                             onFocus={() => setTextFocus(true)}
                         />
                     </div>
-                    {textFocus &&
+                    {textFocus && (
                         <div className="absolute bottom-1 right-2 text-xs text-gray-500 flex items-center">
                             <span>enter to apply</span>
-                            <img
-                                src="https://private-user-images.githubusercontent.com/14104075/376804165-1c07a8f8-38be-45ff-9cfe-63cffa95aabc.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjkwMzY0MTcsIm5iZiI6MTcyOTAzNjExNywicGF0aCI6Ii8xNDEwNDA3NS8zNzY4MDQxNjUtMWMwN2E4ZjgtMzhiZS00NWZmLTljZmUtNjNjZmZhOTVhYWJjLnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDE1VDIzNDgzN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTk0NWVhYjM4ZWQ2MTM1Nzc4Njg2MjBmMzIzOWNkOTZmNDEwMTM3ZDAwNGRiOGYyM2ZiMDA3MmUwMTRiMjUyOGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.6XV_3cTYSIIbmy5hP3-Dr9Sbo_iLLDfAZI8lHs6Sj5k"
-                                className="ml-1"
-                            />
+                            <ResetIcon className="ml-1" />
                         </div>
-                    }
+                    )}
                 </div>
             )}
 
@@ -153,7 +151,7 @@ const TailwindInput = observer(() => {
                             onKeyDown={handleKeyDown}
                             onBlur={(e) => {
                                 setTextRootFocus(false);
-                                root && createCodeDiffRequest(root, e.target.value)
+                                root && createCodeDiffRequest(root, e.target.value);
                             }}
                             onFocus={() => setTextRootFocus(true)}
                         />
@@ -161,13 +159,9 @@ const TailwindInput = observer(() => {
                     {textRootFocus && (
                         <div className="absolute bottom-1 right-2 text-xs text-gray-500 flex items-center">
                             <span>enter to apply</span>
-                            <img
-                                src="https://private-user-images.githubusercontent.com/14104075/376804165-1c07a8f8-38be-45ff-9cfe-63cffa95aabc.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjkwMzY0MTcsIm5iZiI6MTcyOTAzNjExNywicGF0aCI6Ii8xNDEwNDA3NS8zNzY4MDQxNjUtMWMwN2E4ZjgtMzhiZS00NWZmLTljZmUtNjNjZmZhOTVhYWJjLnN2Zz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEwMTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMDE1VDIzNDgzN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTk0NWVhYjM4ZWQ2MTM1Nzc4Njg2MjBmMzIzOWNkOTZmNDEwMTM3ZDAwNGRiOGYyM2ZiMDA3MmUwMTRiMjUyOGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.6XV_3cTYSIIbmy5hP3-Dr9Sbo_iLLDfAZI8lHs6Sj5k"
-                                className="ml-1"
-                            />
+                            <ResetIcon className="ml-1" />
                         </div>
                     )}
-
                 </div>
             )}
         </div>

--- a/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
+++ b/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState, useRef } from 'react';
 import { MainChannels } from '/common/constants';
 import { CodeDiffRequest } from '/common/models/code';
 import { TemplateNode } from '/common/models/element/templateNode';
-import { set } from 'lodash';
 
 const TailwindInput = observer(() => {
     const editorEngine = useEditorEngine();

--- a/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
+++ b/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
@@ -14,10 +14,10 @@ const TailwindInput = observer(() => {
     const [root, setRoot] = useState<TemplateNode | undefined>();
     const [instanceClasses, setInstanceClasses] = useState<string>('');
     const [rootClasses, setRootClasses] = useState<string>('');
-    const [twInput, setTwInput] = useState(false);
-    const [twInputRoot, setTwInputRoot] = useState(false);
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
-    const textareaRootRef = useRef<HTMLTextAreaElement>(null);
+    const [textFocus, setTextFocus] = useState(false);
+    const [textRootFocus, setTextRootFocus] = useState(false);
+    const textAreaSize = useRef<HTMLTextAreaElement>(null);
+    const textAreaRootSize = useRef<HTMLTextAreaElement>(null);
 
     useEffect(() => {
         if (editorEngine.elements.selected.length) {
@@ -98,14 +98,14 @@ const TailwindInput = observer(() => {
     };
 
     useEffect(() => {
-        if (textareaRef.current) {
-            adjustHeight(textareaRef.current);
+        if (textAreaSize.current) {
+            adjustHeight(textAreaSize.current);
         }
     }, [instanceClasses]);
 
     useEffect(() => {
-        if (textareaRootRef.current) {
-            adjustHeight(textareaRootRef.current);
+        if (textAreaRootSize.current) {
+            adjustHeight(textAreaRootSize.current);
         }
     }, [rootClasses]);
 
@@ -116,20 +116,20 @@ const TailwindInput = observer(() => {
                 <div className="relative">
                     <div>
                         <Textarea
-                            ref={textareaRef}
+                            ref={textAreaSize}
                             className="w-full text-xs text-foreground-active break-normal bg-background-onlook/75 focus-visible:ring-0"
                             placeholder="Add tailwind classes here"
                             value={instanceClasses}
                             onInput={(e: any) => setInstanceClasses(e.target.value)}
                             onKeyDown={handleKeyDown}
                             onBlur={(e) => {
-                                setTwInput(false);
+                                setTextFocus(false);
                                 instance && createCodeDiffRequest(instance, e.target.value);
                             }}
-                            onFocus={() => setTwInput(true)}
+                            onFocus={() => setTextFocus(true)}
                         />
                     </div>
-                    {twInput &&
+                    {textFocus &&
                         <div className="absolute bottom-1 right-2 text-xs text-gray-500 flex items-center">
                             <span>enter to apply</span>
                             <img
@@ -146,20 +146,20 @@ const TailwindInput = observer(() => {
                 <div className="relative">
                     <div>
                         <Textarea
-                            ref={textareaRootRef}
+                            ref={textAreaRootSize}
                             className="w-full text-xs text-foreground-active break-normal bg-background-onlook/75 focus-visible:ring-0 resize-none"
                             placeholder="Add tailwind classes here"
                             value={rootClasses}
                             onInput={(e: any) => setRootClasses(e.target.value)}
                             onKeyDown={handleKeyDown}
                             onBlur={(e) => {
-                                setTwInputRoot(false);
+                                setTextRootFocus(false);
                                 root && createCodeDiffRequest(root, e.target.value)
                             }}
-                            onFocus={() => setTwInputRoot(true)}
+                            onFocus={() => setTextRootFocus(true)}
                         />
                     </div>
-                    {twInputRoot && (
+                    {textRootFocus && (
                         <div className="absolute bottom-1 right-2 text-xs text-gray-500 flex items-center">
                             <span>enter to apply</span>
                             <img

--- a/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
+++ b/app/src/routes/editor/EditPanel/inputs/single/TailwindInput.tsx
@@ -10,14 +10,16 @@ import { TemplateNode } from '/common/models/element/templateNode';
 
 const TailwindInput = observer(() => {
     const editorEngine = useEditorEngine();
+
+    const instanceRef = useRef<HTMLTextAreaElement>(null);
     const [instance, setInstance] = useState<TemplateNode | undefined>();
-    const [root, setRoot] = useState<TemplateNode | undefined>();
     const [instanceClasses, setInstanceClasses] = useState<string>('');
+    const [isInstanceFocused, setIsInstanceFocused] = useState(false);
+
+    const rootRef = useRef<HTMLTextAreaElement>(null);
+    const [root, setRoot] = useState<TemplateNode | undefined>();
     const [rootClasses, setRootClasses] = useState<string>('');
-    const [textFocus, setTextFocus] = useState(false);
-    const [textRootFocus, setTextRootFocus] = useState(false);
-    const textAreaSize = useRef<HTMLTextAreaElement>(null);
-    const textAreaRootSize = useRef<HTMLTextAreaElement>(null);
+    const [isRootFocused, setIsRootFocused] = useState(false);
 
     useEffect(() => {
         if (editorEngine.elements.selected.length) {
@@ -98,16 +100,25 @@ const TailwindInput = observer(() => {
     };
 
     useEffect(() => {
-        if (textAreaSize.current) {
-            adjustHeight(textAreaSize.current);
+        if (instanceRef.current) {
+            adjustHeight(instanceRef.current);
         }
     }, [instanceClasses]);
 
     useEffect(() => {
-        if (textAreaRootSize.current) {
-            adjustHeight(textAreaRootSize.current);
+        if (rootRef.current) {
+            adjustHeight(rootRef.current);
         }
     }, [rootClasses]);
+
+    const EnterIndicator = () => {
+        return (
+            <div className="absolute bottom-1 right-2 text-xs text-gray-500 flex items-center">
+                <span>enter to apply</span>
+                <ResetIcon className="ml-1" />
+            </div>
+        );
+    };
 
     return (
         <div className="flex flex-col gap-2 text-xs text-foreground-onlook">
@@ -116,25 +127,20 @@ const TailwindInput = observer(() => {
                 <div className="relative">
                     <div>
                         <Textarea
-                            ref={textAreaSize}
+                            ref={instanceRef}
                             className="w-full text-xs text-foreground-active break-normal bg-background-onlook/75 focus-visible:ring-0"
                             placeholder="Add tailwind classes here"
                             value={instanceClasses}
                             onInput={(e: any) => setInstanceClasses(e.target.value)}
                             onKeyDown={handleKeyDown}
                             onBlur={(e) => {
-                                setTextFocus(false);
+                                setIsInstanceFocused(false);
                                 instance && createCodeDiffRequest(instance, e.target.value);
                             }}
-                            onFocus={() => setTextFocus(true)}
+                            onFocus={() => setIsInstanceFocused(true)}
                         />
                     </div>
-                    {textFocus && (
-                        <div className="absolute bottom-1 right-2 text-xs text-gray-500 flex items-center">
-                            <span>enter to apply</span>
-                            <ResetIcon className="ml-1" />
-                        </div>
-                    )}
+                    {isInstanceFocused && <EnterIndicator />}
                 </div>
             )}
 
@@ -143,25 +149,20 @@ const TailwindInput = observer(() => {
                 <div className="relative">
                     <div>
                         <Textarea
-                            ref={textAreaRootSize}
+                            ref={rootRef}
                             className="w-full text-xs text-foreground-active break-normal bg-background-onlook/75 focus-visible:ring-0 resize-none"
                             placeholder="Add tailwind classes here"
                             value={rootClasses}
                             onInput={(e: any) => setRootClasses(e.target.value)}
                             onKeyDown={handleKeyDown}
                             onBlur={(e) => {
-                                setTextRootFocus(false);
+                                setIsRootFocused(false);
                                 root && createCodeDiffRequest(root, e.target.value);
                             }}
-                            onFocus={() => setTextRootFocus(true)}
+                            onFocus={() => setIsRootFocused(true)}
                         />
                     </div>
-                    {textRootFocus && (
-                        <div className="absolute bottom-1 right-2 text-xs text-gray-500 flex items-center">
-                            <span>enter to apply</span>
-                            <ResetIcon className="ml-1" />
-                        </div>
-                    )}
+                    {isRootFocused && <EnterIndicator />}
                 </div>
             )}
         </div>


### PR DESCRIPTION
# Description

As per issue https://github.com/onlook-dev/onlook/issues/549, the 'textArea' where a user can input tailwind classes for an object needed a hint or message at the bottom saying "enter to apply" when the object is in focus. This is done to let the user know that while in focus, changes may not be saved, and to save changes they must click the enter key.

I was provided with that piece of information, as well as an SVG for an arrow ![image](https://github.com/user-attachments/assets/d14c0157-7f89-45e9-8141-12b5b99422d1), and a reference picture: 

![image](https://github.com/user-attachments/assets/ae482f37-5a8c-410e-9d05-b52e4ac2bc3c)

My current implementation looks as so:

![image](https://github.com/user-attachments/assets/5543be61-d541-48f2-8ad6-c45dec5c6048)

I was able to implement this feature, albeit with some minor changes to the textArea.  Currently it is being auto resized with the user's text and some extra space as the sizing option.

![image](https://github.com/user-attachments/assets/cabf30fc-04b9-4d40-b3d0-1dd62df8e4e3)

Was informed by @Kitenite that users should still be able to resize the box and this can be done so eventually with custom drag areas. However, at the moment I was only able to keep the resize with the text outside of the textArea and in this position:

![image](https://github.com/user-attachments/assets/488451e9-c0f1-4613-8c69-ac83f6fa344e)

Please let me know if you have any issues with this request or any changes are needed.

# What is the purpose of this pull request? 

- [ ] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [X] Other
