### PR TITLE
Tool-tip bug in Layer panel resolved

### DIFF
--- a/app/src/components/ui/tooltip.tsx
+++ b/app/src/components/ui/tooltip.tsx
@@ -4,11 +4,10 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const TooltipProvider = TooltipPrimitive.Provider;
-
 const Tooltip = TooltipPrimitive.Root;
-
 const TooltipTrigger = TooltipPrimitive.Trigger;
 const TooltipPortal = TooltipPrimitive.Portal;
+
 const TooltipContent = React.forwardRef<
     React.ElementRef<typeof TooltipPrimitive.Content>,
     React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
@@ -16,12 +15,15 @@ const TooltipContent = React.forwardRef<
     <TooltipPrimitive.Content
         ref={ref}
         sideOffset={sideOffset}
+        align="center" // Align the tooltip content to the center of the trigger
         className={cn(
             'z-50 overflow-hidden rounded-md bg-primary px-2 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
             className,
         )}
         {...props}
-    />
+    >
+        <TooltipPrimitive.Arrow className="fill-current text-primary" />
+    </TooltipPrimitive.Content>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 


### PR DESCRIPTION
Tooltip errors in Layer Panel
Fixed Two errors :

1. The arrow pointing to the text loads in AFTER the rest of the tooltip
2 .Occasionally the tooltip will go too far to the right on hover. It's very inconsistent. Perhaps it's appending it to the end of the string location