### PR TITLE
Add grid drag-and-drop support

### DIFF
--- a/app/electron/preload/webview/elements/move/helpers.ts
+++ b/app/electron/preload/webview/elements/move/helpers.ts
@@ -49,3 +49,24 @@ export function findInsertionIndex(
     }
     return elements.length;
 }
+
+export function findGridInsertionIndex(
+    parent: HTMLElement,
+    siblings: Element[],
+    x: number,
+    y: number,
+): number {
+    const parentRect = parent.getBoundingClientRect();
+    const gridComputedStyle = window.getComputedStyle(parent);
+    const columns = gridComputedStyle.gridTemplateColumns.split(' ').length;
+    const rows = gridComputedStyle.gridTemplateRows.split(' ').length;
+
+    const cellWidth = parentRect.width / columns;
+    const cellHeight = parentRect.height / rows;
+
+    const gridX = Math.floor((x - parentRect.left) / cellWidth);
+    const gridY = Math.floor((y - parentRect.top) / cellHeight);
+
+    const targetIndex = gridY * columns + gridX;
+    return Math.min(Math.max(targetIndex, 0), siblings.length);
+}

--- a/app/electron/preload/webview/elements/move/stub.ts
+++ b/app/electron/preload/webview/elements/move/stub.ts
@@ -1,4 +1,9 @@
-import { DisplayDirection, findInsertionIndex, getDisplayDirection } from './helpers';
+import {
+    DisplayDirection,
+    findInsertionIndex as findFlexBlockInsertionIndex,
+    findGridInsertionIndex,
+    getDisplayDirection,
+} from './helpers';
 import { EditorAttributes } from '/common/constants';
 
 export function createStub(el: HTMLElement) {
@@ -38,28 +43,28 @@ export function moveStub(el: HTMLElement, x: number, y: number) {
     const isGridLayout = parentStyle.display === 'grid';
 
     const siblings = Array.from(parent.children).filter((child) => child !== el && child !== stub);
-    
+
     let insertionIndex;
     if (isGridLayout) {
-        // Handle grid layout
         insertionIndex = findGridInsertionIndex(parent, siblings, x, y);
     } else {
-        // Existing logic for flex and block layouts
-        insertionIndex = findInsertionIndex(siblings, x, y, displayDirection as DisplayDirection);
+        insertionIndex = findFlexBlockInsertionIndex(
+            siblings,
+            x,
+            y,
+            displayDirection as DisplayDirection,
+        );
     }
 
     stub.remove();
-    
-    // Allow placing the element back to its original position
-    const originalIndex = Array.from(parent.children).indexOf(el);
-    if (insertionIndex === originalIndex || insertionIndex === originalIndex + 1) {
-        parent.insertBefore(stub, el);
-    } else if (insertionIndex >= siblings.length) {
+
+    // Append element at the insertion index
+    if (insertionIndex >= siblings.length) {
         parent.appendChild(stub);
     } else {
         parent.insertBefore(stub, siblings[insertionIndex]);
     }
-    
+
     stub.style.display = 'block';
 }
 
@@ -79,21 +84,4 @@ export function getCurrentStubIndex(parent: HTMLElement, el: HTMLElement): numbe
 
     const siblings = Array.from(parent.children).filter((child) => child !== el);
     return siblings.indexOf(stub);
-}
-
-// New function to handle grid insertion index calculation
-function findGridInsertionIndex(parent: HTMLElement, siblings: Element[], x: number, y: number): number {
-    const parentRect = parent.getBoundingClientRect();
-    const gridComputedStyle = window.getComputedStyle(parent);
-    const columns = gridComputedStyle.gridTemplateColumns.split(' ').length;
-    const rows = gridComputedStyle.gridTemplateRows.split(' ').length;
-
-    const cellWidth = parentRect.width / columns;
-    const cellHeight = parentRect.height / rows;
-
-    const gridX = Math.floor((x - parentRect.left) / cellWidth);
-    const gridY = Math.floor((y - parentRect.top) / cellHeight);
-
-    const targetIndex = gridY * columns + gridX;
-    return Math.min(Math.max(targetIndex, 0), siblings.length);
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### issue number #584 

### Description

The code has been updated to support grid layouts in addition to the existing flex and block layout handling. This was achieved by modifying the moveStub function to detect grid layouts and apply specialized handling. Two new functions, findGridInsertionIndex and adjustStubPositionForGrid, were introduced to calculate insertion positions and correctly position the stub within grid cells, respectively.

with code correct

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ X] New feature
- [ ] Documentation update
- [X ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
