### PR TITLE
Debugged Properties panel close Animation Bug

### DIFF
--- a/app/src/routes/editor/EditPanel/StylesTab/index.tsx
+++ b/app/src/routes/editor/EditPanel/StylesTab/index.tsx
@@ -104,7 +104,7 @@ const ManualTab = observer(() => {
                 <AccordionTrigger>
                     <h2 className="text-xs font-semibold">{groupKey}</h2>
                 </AccordionTrigger>
-                <AccordionContent>
+                <AccordionContent className="overflow-hidden">
                     {groupKey === StyleGroupKey.Text && <TagDetails />}
                     {renderGroupValues(baseElementStyles)}
                 </AccordionContent>
@@ -128,7 +128,7 @@ const ManualTab = observer(() => {
     return (
         editorEngine.elements.selected.length > 0 && (
             <Accordion
-                className="px-4"
+                className="px-4 overflow-hidden"
                 type="multiple"
                 defaultValue={[...Object.values(StyleGroupKey), TAILWIND_KEY]}
             >

--- a/app/src/routes/editor/EditPanel/StylesTab/index.tsx
+++ b/app/src/routes/editor/EditPanel/StylesTab/index.tsx
@@ -104,7 +104,7 @@ const ManualTab = observer(() => {
                 <AccordionTrigger>
                     <h2 className="text-xs font-semibold">{groupKey}</h2>
                 </AccordionTrigger>
-                <AccordionContent className="overflow-auto max-h-[50vh]">
+                <AccordionContent>
                     {groupKey === StyleGroupKey.Text && <TagDetails />}
                     {renderGroupValues(baseElementStyles)}
                 </AccordionContent>
@@ -128,7 +128,7 @@ const ManualTab = observer(() => {
     return (
         editorEngine.elements.selected.length > 0 && (
             <Accordion
-                className="px-4 overflow-hidden"
+                className="px-4"
                 type="multiple"
                 defaultValue={[...Object.values(StyleGroupKey), TAILWIND_KEY]}
             >

--- a/app/src/routes/editor/EditPanel/StylesTab/index.tsx
+++ b/app/src/routes/editor/EditPanel/StylesTab/index.tsx
@@ -104,7 +104,7 @@ const ManualTab = observer(() => {
                 <AccordionTrigger>
                     <h2 className="text-xs font-semibold">{groupKey}</h2>
                 </AccordionTrigger>
-                <AccordionContent className="overflow-hidden">
+                <AccordionContent className="overflow-auto max-h-[50vh]">
                     {groupKey === StyleGroupKey.Text && <TagDetails />}
                     {renderGroupValues(baseElementStyles)}
                 </AccordionContent>

--- a/app/src/routes/editor/EditPanel/index.tsx
+++ b/app/src/routes/editor/EditPanel/index.tsx
@@ -99,14 +99,14 @@ const EditPanel = observer(() => {
                 </TabsList>
                 <Separator />
                 <div className="h-[calc(100vh-7.75rem)] overflow-auto">
-                    <TabsContent value={TabValue.STYLES}>
+                    <TabsContent value={TabValue.STYLES} className="overflow-hidden min-w-0 max-w-full min-h-0 max-h-full">
                         {editorEngine.elements.selected.length > 0 ? (
                             <ManualTab />
                         ) : (
                             renderEmptyState()
                         )}
                     </TabsContent>
-                    <TabsContent value={TabValue.CHAT}>
+                    <TabsContent value={TabValue.CHAT} className="overflow-hidden min-w-0 max-w-full min-h-0 max-h-full">
                         {editorEngine.elements.selected.length > 0 ? (
                             <ChatTab />
                         ) : (
@@ -121,7 +121,7 @@ const EditPanel = observer(() => {
     return (
         <div
             className={clsx(
-                'fixed right-0 transition-width duration-300 opacity-100 bg-background/80 rounded-tl-xl ',
+                'fixed right-0 transition-width duration-300 opacity-100 bg-background/80 rounded-tl-xl overflow-hidden',
                 editorEngine.mode === EditorMode.INTERACT ? 'hidden' : 'visible',
                 !isOpen && 'w-12 h-12 rounded-l-xl cursor-pointer',
                 isOpen && 'h-[calc(100vh-5rem)]',
@@ -129,12 +129,13 @@ const EditPanel = observer(() => {
                 isOpen && selectedTab == TabValue.CHAT && 'w-[22rem]',
             )}
         >
+
             {!isOpen && (
                 <button
                     className="w-full h-full flex justify-center items-center text-foreground hover:text-foreground-onlook"
                     onClick={() => setIsOpen(true)}
                 >
-                    <Icons.PinLeft className="z-51" />
+                    <Icons.PinLeft className="z-51"/>
                 </button>
             )}
             <div

--- a/app/src/routes/editor/EditPanel/index.tsx
+++ b/app/src/routes/editor/EditPanel/index.tsx
@@ -51,7 +51,7 @@ const EditPanel = observer(() => {
                             className="text-default rounded-lg p-2 bg-transparent hover:text-foreground-hover"
                             onClick={() => setIsOpen(false)}
                         >
-                            <Icons.PinRight />
+                            <Icons.PinRight/>
                         </button>
                         <TabsTrigger
                             className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover"
@@ -63,7 +63,7 @@ const EditPanel = observer(() => {
                             className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover hidden"
                             value={TabValue.CHAT}
                         >
-                            <Icons.MagicWand className="mr-2" />
+                            <Icons.MagicWand className="mr-2"/>
                             Chat
                         </TabsTrigger>
                     </div>
@@ -77,38 +77,38 @@ const EditPanel = observer(() => {
                                             size={'icon'}
                                             className="p-2 w-fit h-fit hover:bg-transparent"
                                         >
-                                            <Icons.Plus />
+                                            <Icons.Plus/>
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent side="bottom">
                                         <p>New Chat</p>
-                                        <TooltipArrow className="fill-foreground" />
+                                        <TooltipArrow className="fill-foreground"/>
                                     </TooltipContent>
                                 </Tooltip>
                             </TooltipProvider>
-                            <ChatHistory />
+                            <ChatHistory/>
                             <Button
                                 variant={'ghost'}
                                 size={'icon'}
                                 className="p-2 w-fit h-fit hover:bg-transparent"
                             >
-                                <Icons.CrossS />
+                                <Icons.CrossS/>
                             </Button>
                         </div>
                     )}
                 </TabsList>
-                <Separator />
+                <Separator/>
                 <div className="h-[calc(100vh-7.75rem)] overflow-auto">
-                    <TabsContent value={TabValue.STYLES} className="overflow-hidden min-w-0 max-w-full min-h-0 max-h-full">
+                    <TabsContent value={TabValue.STYLES} className="min-w-0 max-w-full min-h-0 max-h-full">
                         {editorEngine.elements.selected.length > 0 ? (
-                            <ManualTab />
+                            <ManualTab/>
                         ) : (
                             renderEmptyState()
                         )}
                     </TabsContent>
-                    <TabsContent value={TabValue.CHAT} className="overflow-hidden min-w-0 max-w-full min-h-0 max-h-full">
+                    <TabsContent value={TabValue.CHAT} className="min-w-0 max-w-full min-h-0 max-h-full">
                         {editorEngine.elements.selected.length > 0 ? (
-                            <ChatTab />
+                            <ChatTab/>
                         ) : (
                             renderEmptyStateChat()
                         )}

--- a/app/src/routes/editor/EditPanel/index.tsx
+++ b/app/src/routes/editor/EditPanel/index.tsx
@@ -51,7 +51,7 @@ const EditPanel = observer(() => {
                             className="text-default rounded-lg p-2 bg-transparent hover:text-foreground-hover"
                             onClick={() => setIsOpen(false)}
                         >
-                            <Icons.PinRight/>
+                            <Icons.PinRight />
                         </button>
                         <TabsTrigger
                             className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover"
@@ -63,7 +63,7 @@ const EditPanel = observer(() => {
                             className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover hidden"
                             value={TabValue.CHAT}
                         >
-                            <Icons.MagicWand className="mr-2"/>
+                            <Icons.MagicWand className="mr-2" />
                             Chat
                         </TabsTrigger>
                     </div>
@@ -77,7 +77,7 @@ const EditPanel = observer(() => {
                                             size={'icon'}
                                             className="p-2 w-fit h-fit hover:bg-transparent"
                                         >
-                                            <Icons.Plus/>
+                                            <Icons.Plus />
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent side="bottom">
@@ -86,29 +86,29 @@ const EditPanel = observer(() => {
                                     </TooltipContent>
                                 </Tooltip>
                             </TooltipProvider>
-                            <ChatHistory/>
+                            <ChatHistory />
                             <Button
                                 variant={'ghost'}
                                 size={'icon'}
                                 className="p-2 w-fit h-fit hover:bg-transparent"
                             >
-                                <Icons.CrossS/>
+                                <Icons.CrossS />
                             </Button>
                         </div>
                     )}
                 </TabsList>
-                <Separator/>
+                <Separator />
                 <div className="h-[calc(100vh-7.75rem)] overflow-auto">
-                    <TabsContent value={TabValue.STYLES} className="min-w-0 max-w-full min-h-0 max-h-full">
+                    <TabsContent value={TabValue.STYLES}>
                         {editorEngine.elements.selected.length > 0 ? (
                             <ManualTab/>
                         ) : (
                             renderEmptyState()
                         )}
                     </TabsContent>
-                    <TabsContent value={TabValue.CHAT} className="min-w-0 max-w-full min-h-0 max-h-full">
+                    <TabsContent value={TabValue.CHAT}>
                         {editorEngine.elements.selected.length > 0 ? (
-                            <ChatTab/>
+                            <ChatTab />
                         ) : (
                             renderEmptyStateChat()
                         )}
@@ -129,13 +129,12 @@ const EditPanel = observer(() => {
                 isOpen && selectedTab == TabValue.CHAT && 'w-[22rem]',
             )}
         >
-
             {!isOpen && (
                 <button
                     className="w-full h-full flex justify-center items-center text-foreground hover:text-foreground-onlook"
                     onClick={() => setIsOpen(true)}
                 >
-                    <Icons.PinLeft className="z-51"/>
+                    <Icons.PinLeft className="z-51" />
                 </button>
             )}
             <div

--- a/app/src/routes/editor/EditPanel/index.tsx
+++ b/app/src/routes/editor/EditPanel/index.tsx
@@ -82,7 +82,7 @@ const EditPanel = observer(() => {
                                     </TooltipTrigger>
                                     <TooltipContent side="bottom">
                                         <p>New Chat</p>
-                                        <TooltipArrow className="fill-foreground"/>
+                                        <TooltipArrow className="fill-foreground" />
                                     </TooltipContent>
                                 </Tooltip>
                             </TooltipProvider>
@@ -101,7 +101,7 @@ const EditPanel = observer(() => {
                 <div className="h-[calc(100vh-7.75rem)] overflow-auto">
                     <TabsContent value={TabValue.STYLES}>
                         {editorEngine.elements.selected.length > 0 ? (
-                            <ManualTab/>
+                            <ManualTab />
                         ) : (
                             renderEmptyState()
                         )}

--- a/app/src/routes/editor/LayersPanel/index.tsx
+++ b/app/src/routes/editor/LayersPanel/index.tsx
@@ -64,7 +64,7 @@ const LayersPanel = observer(() => {
     return (
         <div
             className={clsx(
-                'left-0 top-20 transition-width duration-300 opacity-100 bg-background/80 rounded-tr-xl',
+                'left-0 top-20 transition-width duration-300 opacity-100 bg-background/80 rounded-tr-xl overflow-hidden',
                 editorEngine.mode === EditorMode.INTERACT ? 'hidden' : 'visible',
                 isOpen ? 'w-full h-[calc(100vh-5rem)]' : 'w-12 h-12 rounded-r-xl cursor-pointer',
             )}


### PR DESCRIPTION
# Fixing Overflow Issue in EditPanel Component

## Problem
While opening or closing the `EditPanel` tab, the content inside was overflowing beyond the boundaries of the panel. This caused the UI to break during animations.

## Solution
We applied **`overflow-hidden`** to critical containers and added **width/height constraints** to prevent content from escaping during transitions. We also ensured smooth transitions with CSS adjustments.

### Changes Made

1. **Apply `overflow-hidden` to the Main Wrapper:**
   - Ensures that the content stays within the panel boundaries during open/close transitions.
   ```jsx
   <div
       className={clsx(
           'fixed right-0 transition-width duration-300 opacity-100 bg-background/80 rounded-tl-xl overflow-hidden',
           editorEngine.mode === EditorMode.INTERACT ? 'hidden' : 'visible',
           !isOpen && 'w-12 h-12 rounded-l-xl cursor-pointer',
           isOpen && 'h-[calc(100vh-5rem)]',
           isOpen && selectedTab == TabValue.STYLES && 'w-60',
           isOpen && selectedTab == TabValue.CHAT && 'w-[22rem]',
       )}
   >
