### PR TITLE
feat: handle drag the broweser canvas

### DIFF
--- a/apps/studio/src/lib/editor/engine/overlay/index.ts
+++ b/apps/studio/src/lib/editor/engine/overlay/index.ts
@@ -68,6 +68,12 @@ export class OverlayManager {
         let top = 0,
             left = 0;
         while (element && element !== ancestor) {
+            const transform = window.getComputedStyle(element).transform;
+            const matrix = new DOMMatrix(transform);
+
+            top += matrix.m42;
+            left += matrix.m41;
+
             top += element.offsetTop || 0;
             left += element.offsetLeft || 0;
             element = element.offsetParent as HTMLElement;

--- a/apps/studio/src/routes/editor/WebviewArea/Frame.tsx
+++ b/apps/studio/src/routes/editor/WebviewArea/Frame.tsx
@@ -10,7 +10,7 @@ import { toast } from '@onlook/ui/use-toast';
 import { cn } from '@onlook/ui/utils';
 import { AnimatePresence, motion } from 'framer-motion';
 import { observer } from 'mobx-react-lite';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
 import BrowserControls from './BrowserControl';
 import GestureScreen from './GestureScreen';
 import ResizeHandles from './ResizeHandles';
@@ -43,6 +43,7 @@ const Frame = observer(
 
         const [webviewSize, setWebviewSize] = useState(settings.dimension);
         const [webviewSrc, setWebviewSrc] = useState<string>(settings.url);
+        const [webviewPosition, setWebviewPosition] = useState(settings.position);
         const [isCopied, setIsCopied] = useState<boolean>(false);
 
         const runProjectCommand = getRunProjectCommand(projectManager?.folderPath || '');
@@ -62,8 +63,9 @@ const Frame = observer(
             editorEngine.canvas.saveFrame(settings.id, {
                 url: webviewSrc,
                 dimension: webviewSize,
+                position: webviewPosition,
             });
-        }, [webviewSize, webviewSrc]);
+        }, [webviewSize, webviewSrc, webviewPosition]);
 
         useEffect(() => {
             let timer: Timer;
@@ -153,6 +155,38 @@ const Frame = observer(
             setFocused(false);
         }
 
+        function startMove(e: MouseEvent<HTMLDivElement, globalThis.MouseEvent>) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            editorEngine.overlay.clear();
+
+            const startX = e.clientX;
+            const startY = e.clientY;
+
+            const move: any = (e: MouseEvent) => {
+                const scale = editorEngine.canvas.scale;
+                const deltaX = (e.clientX - startX) / scale;
+                const deltaY = (e.clientY - startY) / scale;
+
+                setWebviewPosition({
+                    x: webviewPosition.x + deltaX,
+                    y: webviewPosition.y + deltaY,
+                });
+            };
+
+            const stopMove = (e: any) => {
+                e.preventDefault();
+                e.stopPropagation();
+
+                window.removeEventListener('mousemove', move);
+                window.removeEventListener('mouseup', stopMove);
+            };
+
+            window.addEventListener('mousemove', move);
+            window.addEventListener('mouseup', stopMove);
+        }
+
         function copyCommand() {
             navigator.clipboard.writeText(runProjectCommand);
             setIsCopied(true);
@@ -161,7 +195,18 @@ const Frame = observer(
         }
 
         return (
-            <div className="flex flex-col space-y-1.5">
+            <div
+                className="flex flex-col space-y-1.5"
+                style={{ transform: `translate(${webviewPosition.x}px, ${webviewPosition.y}px)` }}
+            >
+                <div
+                    onMouseDown={startMove}
+                    className={cn(
+                        'cursor-move opacity-10 hover:opacity-80 w-full flex justify-center',
+                    )}
+                >
+                    <Icons.DragHandleDots className="text-foreground-primary rotate-90" />
+                </div>
                 <BrowserControls
                     webviewRef={domReady ? webviewRef : null}
                     webviewSrc={webviewSrc}

--- a/apps/studio/src/routes/editor/WebviewArea/Frame.tsx
+++ b/apps/studio/src/routes/editor/WebviewArea/Frame.tsx
@@ -202,10 +202,11 @@ const Frame = observer(
                 <div
                     onMouseDown={startMove}
                     className={cn(
-                        'cursor-move opacity-10 hover:opacity-80 w-full flex justify-center',
+                        'cursor-move flex w-full opacity-10 hover:opacity-80',
+                        hovered && 'opacity-20',
                     )}
                 >
-                    <Icons.DragHandleDots className="text-foreground-primary rotate-90" />
+                    <Icons.DragHandleDots className="text-foreground-primary rotate-90 w-8 h-8" />
                 </div>
                 <BrowserControls
                     webviewRef={domReady ? webviewRef : null}

--- a/packages/ui/src/components/icons/index.tsx
+++ b/packages/ui/src/components/icons/index.tsx
@@ -92,6 +92,7 @@ import {
     ViewVerticalIcon,
     PlayIcon,
     SizeIcon,
+    DragHandleDots2Icon,
 } from '@radix-ui/react-icons';
 import H1Icon from './header-level-icons/h1Icon';
 import H2Icon from './header-level-icons/h2Icon';
@@ -105,7 +106,7 @@ export interface IconProps {
     [key: string]: any;
 }
 
-export const Icons: { [key: string]: React.FC<IconProps> } = {
+export const Icons = {
     OnlookLogo: ({ className, ...props }: IconProps) => (
         <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -864,4 +865,5 @@ export const Icons: { [key: string]: React.FC<IconProps> } = {
     Square: SquareIcon,
     LockOpen: LockOpen1Icon,
     LockClosed: LockClosedIcon,
-};
+    DragHandleDots: DragHandleDots2Icon,
+} satisfies { [key: string]: React.FC<IconProps> };


### PR DESCRIPTION
<!-- Thank you for contributing! -->
Link to issue: https://github.com/onlook-dev/onlook/issues/619

### Description

Ability for a user to select the top of the browser controls and drag the selected window around the infinite canvas. 

https://github.com/user-attachments/assets/79666d99-c8b1-40ac-b513-e333bd8b81a7




<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [x] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
