### PR TITLE
Remove "first" from "The first browser-powered visual editor."

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <div align="center">
 <h3 align="center">Onlook</h3>
   <p align="center">
-    The first browser-powered visual editor.
+    The browser-powered visual editor.
     <br />
     <a href="https://github.com/onlook-dev/onlook/wiki"><strong>Explore the docs »</strong></a>
     <br />


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Being totally pedantic: Utopia.app was [launched ~2021](https://github.com/concrete-utopia/utopia/graphs/contributors) and we [created blocks-ui.com in 2019](https://github.com/blocks/blocks), so Onlook isn't the _first_ visual editor for React apps that runs in the browser by a few years.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [x] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
