### PR TITLE
Fix/dimension label styling update

### DIFF
--- a/apps/studio/src/lib/editor/engine/overlay/rect.ts
+++ b/apps/studio/src/lib/editor/engine/overlay/rect.ts
@@ -300,13 +300,29 @@ export class ClickRect extends RectImpl {
         const rectX = (width - rectWidth) / 2;
         const rectY = height;
 
-        const textRect = document.createElementNS(this.svgNamespace, 'rect');
-        textRect.setAttribute('x', rectX.toString());
-        textRect.setAttribute('y', rectY.toString());
-        textRect.setAttribute('width', rectWidth.toString());
-        textRect.setAttribute('height', rectHeight.toString());
+        const textRect = document.createElementNS(this.svgNamespace, 'path');
+        const radius = 2;
+        const bottomLeftQuadCurve = `q0,${radius} ${radius},${radius}`;
+        const bottomRightQuadCurve = `q${radius},0 ${radius},-${radius}`;
+
+        if (rectWidth > width) {
+            const topLeftQuadCurve = `q-${radius},0 -${radius},${radius}`;
+            const topRightQuadCurve = `q0,${-radius} -${radius},-${radius}`;
+
+            textRect.setAttribute(
+                'd',
+                // M = Move, h<length> = horizontal, v<length> = vertical, q = quadratic bezier curve via control point, z = close the path
+                `M${rectX + radius},${rectY} ${topLeftQuadCurve} v${rectHeight - 2 * radius} ${bottomLeftQuadCurve} h${rectWidth - 2 * radius} ${bottomRightQuadCurve} v-${rectHeight - 2 * radius} ${topRightQuadCurve} z`,
+            );
+        } else {
+            textRect.setAttribute(
+                'd',
+                // M = Move, h<length> = horizontal, v<length> = vertical, q = quadratic bezier curve via control point, z = close the path
+                `M${rectX},${rectY} v${rectHeight - radius} ${bottomLeftQuadCurve} h${rectWidth - 2 * radius} ${bottomRightQuadCurve} v-${rectHeight - radius} z`,
+            );
+        }
+
         textRect.setAttribute('fill', isComponent ? colors.purple[500] : colors.red[500]);
-        textRect.setAttribute('rx', '2');
 
         // Adjust text position
         text.setAttribute('x', `${width / 2}`);

--- a/apps/studio/src/lib/editor/engine/overlay/rect.ts
+++ b/apps/studio/src/lib/editor/engine/overlay/rect.ts
@@ -287,7 +287,7 @@ export class ClickRect extends RectImpl {
         text.setAttribute('y', '0');
         text.setAttribute('fill', 'white');
         text.setAttribute('font-size', '12');
-        text.textContent = `${Number.parseInt(width.toString())} x ${Number.parseInt(height.toString())}`;
+        text.textContent = `${Number.parseInt(width.toString())} × ${Number.parseInt(height.toString())}`;
 
         // Temporarily add the text to measure it
         this.svgElement.appendChild(text);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR address two issues described in https://github.com/onlook-dev/onlook/issues/97#issuecomment-2323614687

- [X] The top of the label should not be rounded corners – the bottom of the labels look good, but the top of the label should be straight so that it blends in perfectly with the border
- [X] The character between the dimensions should be a multiplication sign (×) not an x.

Note: it does not address the third issue, ie. "The dimensions should reflect the hug or fill on an object as described above."

Before
<img width="748" alt="image" src="https://github.com/user-attachments/assets/cda8c84a-1236-406a-9061-d83aeba035ed">

After 
<img width="748" alt="image" src="https://github.com/user-attachments/assets/72b37fdd-09b4-47c4-9651-6eb40aa7c2b4">

edge case, when the text container's width is smaller than the box's width
<img width="198" alt="image" src="https://github.com/user-attachments/assets/562fd57b-05ba-4258-8bc2-363d8b0ce5d0">



### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [X] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
