### PR TITLE
Use popover instead of dropdown for zoom control

### DIFF
--- a/apps/studio/src/routes/editor/TopBar/ZoomControls/index.tsx
+++ b/apps/studio/src/routes/editor/TopBar/ZoomControls/index.tsx
@@ -1,15 +1,10 @@
 import { HotKeyLabel } from '@/components/ui/hotkeys-label';
 import { DefaultSettings } from '@onlook/models/constants';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@onlook/ui/dropdown-menu';
 import { Input } from '@onlook/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@onlook/ui/popover';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Hotkey } from '/common/hotkeys';
 
 const ZoomControls = observer(
@@ -26,7 +21,11 @@ const ZoomControls = observer(
         const ZOOM_SENSITIVITY = 0.5;
         const MIN_ZOOM = 0.1;
         const MAX_ZOOM = 3;
-        const [inputValue, setInputValue] = useState('');
+        const [inputValue, setInputValue] = useState(`${Math.round(scale * 100)}%`);
+
+        useEffect(() => {
+            setInputValue(`${Math.round(scale * 100)}%`);
+        }, [scale]);
 
         const handleZoom = (factor: number) => {
             const container = document.getElementById('canvas-container');
@@ -83,12 +82,12 @@ const ZoomControls = observer(
 
         return (
             <div className="mx-2 flex flex-row items-center text-mini text-foreground-onlook hover:text-foreground-active transition-all duration-300 ease-in-out h-full p-1">
-                <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
-                    <DropdownMenuTrigger className="flex items-center px-2 py-1 rounded hover:bg-accent data-[state=open]:text-foreground-active">
+                <Popover open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+                    <PopoverTrigger className="flex items-center px-2 py-1 rounded hover:bg-accent data-[state=open]:text-foreground-active">
                         <span>{Math.round(scale * 100)}%</span>
                         <ChevronDownIcon className="ml-1 h-4 w-4" />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="flex flex-col p-1.5 bg-background/85 backdrop-blur-md w-42">
+                    </PopoverTrigger>
+                    <PopoverContent className="flex flex-col p-1.5 bg-background/85 backdrop-blur-md w-42 min-w-42">
                         <Input
                             value={inputValue}
                             onChange={(e) => setInputValue(e.target.value)}
@@ -100,32 +99,47 @@ const ZoomControls = observer(
                             className={`p-1 h-6 text-left text-smallPlus rounded border mb-1 focus-visible:border-red-500`}
                             autoFocus
                         />
-                        <DropdownMenuItem onClick={() => handleZoom(1)}>
+                        <button
+                            onClick={() => handleZoom(1)}
+                            className="w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+                        >
                             <HotKeyLabel
                                 className="w-full justify-between text-mini"
                                 hotkey={Hotkey.ZOOM_IN}
                             />
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => handleZoom(-1)}>
+                        </button>
+                        <button
+                            onClick={() => handleZoom(-1)}
+                            className="w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+                        >
                             <HotKeyLabel
                                 className="w-full justify-between text-mini"
                                 hotkey={Hotkey.ZOOM_OUT}
                             />
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={handleZoomToFit}>
+                        </button>
+                        <button
+                            onClick={handleZoomToFit}
+                            className="w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+                        >
                             <HotKeyLabel
                                 className="w-full justify-between text-mini"
                                 hotkey={Hotkey.ZOOM_FIT}
                             />
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => handleScale(1)}>
+                        </button>
+                        <button
+                            onClick={() => handleScale(1)}
+                            className="w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+                        >
                             <span className="flex-grow text-mini">Zoom 100%</span>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => handleScale(2)}>
+                        </button>
+                        <button
+                            onClick={() => handleScale(2)}
+                            className="w-full text-left px-2 py-1.5 rounded hover:bg-accent"
+                        >
                             <span className="flex-grow text-mini">Zoom 200%</span>
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                        </button>
+                    </PopoverContent>
+                </Popover>
             </div>
         );
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The input loses focus on hover because of dropdown. Use popover instead solves this.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [X] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
