### PR TITLE
Remove legacy onlook plugins on start

### DIFF
--- a/apps/studio/electron/main/events/run.ts
+++ b/apps/studio/electron/main/events/run.ts
@@ -4,7 +4,7 @@ import run from '../run';
 import terminal from '../run/terminal';
 
 export async function listenForRunMessages() {
-    ipcMain.handle(MainChannels.RUN_SETUP, (e: Electron.IpcMainInvokeEvent, args) => {
+    ipcMain.handle(MainChannels.RUN_START, (e: Electron.IpcMainInvokeEvent, args) => {
         const { id, folderPath, command } = args as {
             id: string;
             folderPath: string;
@@ -16,6 +16,15 @@ export async function listenForRunMessages() {
     ipcMain.handle(MainChannels.RUN_STOP, (e: Electron.IpcMainInvokeEvent, args) => {
         const { id, folderPath } = args as { id: string; folderPath: string };
         return run.stop(id, folderPath);
+    });
+
+    ipcMain.handle(MainChannels.RUN_RESTART, (e: Electron.IpcMainInvokeEvent, args) => {
+        const { id, folderPath, command } = args as {
+            id: string;
+            folderPath: string;
+            command: string;
+        };
+        return run.restart(id, folderPath, command);
     });
 
     ipcMain.handle(MainChannels.GET_TEMPLATE_NODE, (e: Electron.IpcMainInvokeEvent, args) => {

--- a/apps/studio/src/lib/projects/run.ts
+++ b/apps/studio/src/lib/projects/run.ts
@@ -22,7 +22,7 @@ export class RunManager {
     }
 
     async start() {
-        return await invokeMainChannel(MainChannels.RUN_SETUP, {
+        return await invokeMainChannel(MainChannels.RUN_START, {
             id: this.project.id,
             folderPath: this.project.folderPath,
             command: this.project.runCommand || 'npm run dev',
@@ -33,6 +33,14 @@ export class RunManager {
         return await invokeMainChannel(MainChannels.RUN_STOP, {
             id: this.project.id,
             folderPath: this.project.folderPath,
+        });
+    }
+
+    async restart() {
+        return await invokeMainChannel(MainChannels.RUN_RESTART, {
+            id: this.project.id,
+            folderPath: this.project.folderPath,
+            command: this.project.runCommand || 'npm run dev',
         });
     }
 

--- a/apps/studio/src/routes/editor/Toolbar/Terminal/RunButton.tsx
+++ b/apps/studio/src/routes/editor/Toolbar/Terminal/RunButton.tsx
@@ -33,6 +33,8 @@ const RunButton = observer(() => {
             runner.start();
         } else if (runner.state === RunState.RUNNING) {
             runner.stop();
+        } else if (runner.state === RunState.ERROR) {
+            runner.restart();
         } else {
             console.error('Unexpected state:', runner.state);
         }

--- a/packages/foundation/src/frameworks/remove.ts
+++ b/packages/foundation/src/frameworks/remove.ts
@@ -58,3 +58,50 @@ export const removeViteConfig = async (targetPath: string): Promise<void> => {
     }
 };
 
+export const removeDependencies = async (targetPath: string, dependencies: string[]): Promise<void> => {
+    const packageJsonPath = path.join(targetPath, 'package.json');
+
+    try {
+        const content = await fs.promises.readFile(packageJsonPath, 'utf8');
+        const packageJson = JSON.parse(content);
+        let modified = false;
+
+        // Check and remove from dependencies
+        if (packageJson.dependencies) {
+            dependencies.forEach(dep => {
+                if (packageJson.dependencies[dep]) {
+                    delete packageJson.dependencies[dep];
+                    modified = true;
+                }
+            });
+        }
+
+        // Check and remove from devDependencies
+        if (packageJson.devDependencies) {
+            dependencies.forEach(dep => {
+                if (packageJson.devDependencies[dep]) {
+                    delete packageJson.devDependencies[dep];
+                    modified = true;
+                }
+            });
+        }
+
+        if (modified) {
+            await fs.promises.writeFile(
+                packageJsonPath,
+                JSON.stringify(packageJson, null, 2) + '\n',
+                'utf8'
+            );
+            console.log(`Removed dependencies from ${packageJsonPath}`);
+        } else {
+            console.log('No matching dependencies found to remove');
+        }
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            console.log(`No package.json found in ${targetPath}`);
+        } else {
+            throw error;
+        }
+    }
+};
+

--- a/packages/foundation/src/frameworks/remove.ts
+++ b/packages/foundation/src/frameworks/remove.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import { CONFIG_BASE_NAME } from "src/constants";
+
+export const removeNextConfig = async (targetPath: string): Promise<void> => {
+    const configPath = path.join(targetPath, `${CONFIG_BASE_NAME.NEXTJS}*`);
+    const files = await fs.promises.readdir(path.dirname(configPath));
+    const configFile = files.find(file => file.startsWith(CONFIG_BASE_NAME.NEXTJS));
+
+    if (configFile) {
+        const fullPath = path.join(targetPath, configFile);
+        let content = await fs.promises.readFile(fullPath, 'utf8');
+
+        // Remove the Onlook plugin configuration with any object
+        content = content.replace(/swcPlugins:\s*\[\s*\[\s*"@onlook\/nextjs"(,\s*\{[^}]*\})?\s*\]\s*\]/, '');
+
+        // Remove empty experimental object if it exists
+        content = content.replace(/experimental:\s*{\s*},?/, '');
+
+        // Remove trailing commas if any
+        content = content.replace(/,(\s*[}\]])/g, '$1');
+
+        await fs.promises.writeFile(fullPath, content, 'utf8');
+        console.log(`Onlook plugin configuration removed from ${fullPath}`);
+    } else {
+        console.log(`No Next.js config file found in ${targetPath}`);
+    }
+};
+
+
+

--- a/packages/foundation/src/frameworks/remove.ts
+++ b/packages/foundation/src/frameworks/remove.ts
@@ -14,6 +14,9 @@ export const removeNextConfig = async (targetPath: string): Promise<void> => {
         // Remove the Onlook plugin configuration with any object
         content = content.replace(/swcPlugins:\s*\[\s*\[\s*"@onlook\/nextjs"(,\s*\{[^}]*\})?\s*\]\s*\]/, '');
 
+        // Remove empty swcPlugins array if it exists
+        content = content.replace(/swcPlugins:\s*\[\s*\],?\s*/g, '');
+
         // Remove empty experimental object if it exists
         content = content.replace(/experimental:\s*{\s*},?/, '');
 
@@ -27,5 +30,31 @@ export const removeNextConfig = async (targetPath: string): Promise<void> => {
     }
 };
 
+export const removeViteConfig = async (targetPath: string): Promise<void> => {
+    const configPath = path.join(targetPath, `${CONFIG_BASE_NAME.VITEJS}*`);
+    const files = await fs.promises.readdir(path.dirname(configPath));
+    const configFile = files.find(file => file.startsWith(CONFIG_BASE_NAME.VITEJS));
 
+    if (configFile) {
+        const fullPath = path.join(targetPath, configFile);
+        let content = await fs.promises.readFile(fullPath, 'utf8');
+
+        // Remove the Onlook babel plugin from the plugins array
+        content = content.replace(/,?\s*"@onlook\/babel-plugin-react"(?=\s*[\],])/g, '');
+
+        // Remove empty babel plugins array if it exists
+        content = content.replace(/plugins:\s*\[\s*\],?\s*/g, '');
+
+        // Remove empty babel object if it exists
+        content = content.replace(/babel:\s*{\s*},?\s*/g, '');
+
+        // Remove trailing commas if any
+        content = content.replace(/,(\s*[}\]])/g, '$1');
+
+        await fs.promises.writeFile(fullPath, content, 'utf8');
+        console.log(`Onlook babel plugin removed from ${fullPath}`);
+    } else {
+        console.log(`No Vite config file found in ${targetPath}`);
+    }
+};
 

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -1,4 +1,5 @@
 export { createProject } from './create';
+export { revertLegacyOnlook } from './revert';
 export { setupProject } from './setup';
 export { verifyProject } from './verify';
 

--- a/packages/foundation/src/revert/index.ts
+++ b/packages/foundation/src/revert/index.ts
@@ -2,6 +2,17 @@ import { removeDependencies, removeNextConfig, removeViteConfig } from 'src/fram
 import { ONLOOK_PLUGIN } from '../constants';
 import { hasDependency } from '../utils';
 
+export const revertLegacyOnlook = async (targetPath: string): Promise<boolean> => {
+    try {
+        await removePlugins(targetPath);
+        await removeNpmDependencies(targetPath);
+        return !(await onlookFound(targetPath));
+    } catch (e: any) {
+        console.error(e);
+        return false;
+    }
+};
+
 export const onlookFound = async (targetPath: string): Promise<boolean> => {
     try {
         return (
@@ -20,6 +31,6 @@ export const removePlugins = async (targetPath: string): Promise<void> => {
     await removeViteConfig(targetPath);
 };
 
-export const removePluginsDependencies = async (targetPath: string): Promise<void> => {
+export const removeNpmDependencies = async (targetPath: string): Promise<void> => {
     await removeDependencies(targetPath, [ONLOOK_PLUGIN.BABEL, ONLOOK_PLUGIN.NEXTJS, ONLOOK_PLUGIN.WEBPACK]);
 };

--- a/packages/foundation/src/revert/index.ts
+++ b/packages/foundation/src/revert/index.ts
@@ -1,0 +1,20 @@
+import { removeNextConfig } from 'src/frameworks/remove';
+import { ONLOOK_PLUGIN } from '../constants';
+import { hasDependency } from '../utils';
+
+export const onlookFound = async (targetPath: string): Promise<boolean> => {
+    try {
+        return (
+            await hasDependency(ONLOOK_PLUGIN.BABEL, targetPath) ||
+            await hasDependency(ONLOOK_PLUGIN.NEXTJS, targetPath) ||
+            await hasDependency(ONLOOK_PLUGIN.WEBPACK, targetPath)
+        );
+    } catch (e: any) {
+        console.error(e);
+        return false;
+    }
+};
+
+export const removePlugins = async (targetPath: string): Promise<void> => {
+    await removeNextConfig(targetPath);
+};

--- a/packages/foundation/src/revert/index.ts
+++ b/packages/foundation/src/revert/index.ts
@@ -1,4 +1,4 @@
-import { removeNextConfig, removeViteConfig } from 'src/frameworks/remove';
+import { removeDependencies, removeNextConfig, removeViteConfig } from 'src/frameworks/remove';
 import { ONLOOK_PLUGIN } from '../constants';
 import { hasDependency } from '../utils';
 
@@ -18,4 +18,8 @@ export const onlookFound = async (targetPath: string): Promise<boolean> => {
 export const removePlugins = async (targetPath: string): Promise<void> => {
     await removeNextConfig(targetPath);
     await removeViteConfig(targetPath);
+};
+
+export const removePluginsDependencies = async (targetPath: string): Promise<void> => {
+    await removeDependencies(targetPath, [ONLOOK_PLUGIN.BABEL, ONLOOK_PLUGIN.NEXTJS, ONLOOK_PLUGIN.WEBPACK]);
 };

--- a/packages/foundation/src/revert/index.ts
+++ b/packages/foundation/src/revert/index.ts
@@ -1,4 +1,4 @@
-import { removeNextConfig } from 'src/frameworks/remove';
+import { removeNextConfig, removeViteConfig } from 'src/frameworks/remove';
 import { ONLOOK_PLUGIN } from '../constants';
 import { hasDependency } from '../utils';
 
@@ -17,4 +17,5 @@ export const onlookFound = async (targetPath: string): Promise<boolean> => {
 
 export const removePlugins = async (targetPath: string): Promise<void> => {
     await removeNextConfig(targetPath);
+    await removeViteConfig(targetPath);
 };

--- a/packages/foundation/tests/revert.test.ts
+++ b/packages/foundation/tests/revert.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { onlookFound, removePlugins } from "../src/revert";
+
+test("test Onlook found", async () => {
+    console.log('v15');
+    const result = await onlookFound("/Users/kietho/workplace/onlook/test/v15");
+    expect(result).toBe(false);
+});
+
+test("test Onlook found", async () => {
+    console.log('hn_clone');
+    const result = await onlookFound("/Users/kietho/workplace/onlook/test/hn_clone");
+    expect(result).toBe(true);
+});
+
+test("test revert Onlook", async () => {
+    await removePlugins("/Users/kietho/workplace/onlook/test/hn_clone");
+});

--- a/packages/foundation/tests/revert.test.ts
+++ b/packages/foundation/tests/revert.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { onlookFound, removePlugins } from "../src/revert";
+import { onlookFound, removePlugins, removePluginsDependencies } from "../src/revert";
 
 test("test Onlook found", async () => {
     console.log('v15');
@@ -19,4 +19,9 @@ test("test revert Onlook Next.js", async () => {
 
 test("test revert Onlook Vite", async () => {
     await removePlugins("/Users/kietho/workplace/onlook/test/remix");
+});
+
+test("test revert Onlook dependencies", async () => {
+    await removePluginsDependencies("/Users/kietho/workplace/onlook/test/remix");
+    await removePluginsDependencies("/Users/kietho/workplace/onlook/test/hn_clone");
 });

--- a/packages/foundation/tests/revert.test.ts
+++ b/packages/foundation/tests/revert.test.ts
@@ -1,20 +1,21 @@
 import { expect, test } from "bun:test";
 import { onlookFound, removeNpmDependencies, removePlugins } from "../src/revert";
 
+const TEST_FOLDER = '';
+
 test("test Onlook found", async () => {
-    const result = await onlookFound("/Users/kietho/workplace/onlook/test/v15");
+    const result = await onlookFound(TEST_FOLDER);
     expect(result).toBe(false);
 });
 
 test("test revert Onlook Next.js", async () => {
-    await removePlugins("/Users/kietho/workplace/onlook/test/hn_clone");
+    await removePlugins(TEST_FOLDER);
 });
 
 test("test revert Onlook Vite", async () => {
-    await removePlugins("/Users/kietho/workplace/onlook/test/remix");
+    await removePlugins(TEST_FOLDER);
 });
 
 test("test revert Onlook dependencies", async () => {
-    await removeNpmDependencies("/Users/kietho/workplace/onlook/test/remix");
-    await removeNpmDependencies("/Users/kietho/workplace/onlook/test/hn_clone");
+    await removeNpmDependencies(TEST_FOLDER);
 });

--- a/packages/foundation/tests/revert.test.ts
+++ b/packages/foundation/tests/revert.test.ts
@@ -1,16 +1,9 @@
 import { expect, test } from "bun:test";
-import { onlookFound, removePlugins, removePluginsDependencies } from "../src/revert";
+import { onlookFound, removeNpmDependencies, removePlugins } from "../src/revert";
 
 test("test Onlook found", async () => {
-    console.log('v15');
     const result = await onlookFound("/Users/kietho/workplace/onlook/test/v15");
     expect(result).toBe(false);
-});
-
-test("test Onlook found", async () => {
-    console.log('hn_clone');
-    const result = await onlookFound("/Users/kietho/workplace/onlook/test/hn_clone");
-    expect(result).toBe(true);
 });
 
 test("test revert Onlook Next.js", async () => {
@@ -22,6 +15,6 @@ test("test revert Onlook Vite", async () => {
 });
 
 test("test revert Onlook dependencies", async () => {
-    await removePluginsDependencies("/Users/kietho/workplace/onlook/test/remix");
-    await removePluginsDependencies("/Users/kietho/workplace/onlook/test/hn_clone");
+    await removeNpmDependencies("/Users/kietho/workplace/onlook/test/remix");
+    await removeNpmDependencies("/Users/kietho/workplace/onlook/test/hn_clone");
 });

--- a/packages/foundation/tests/revert.test.ts
+++ b/packages/foundation/tests/revert.test.ts
@@ -13,6 +13,10 @@ test("test Onlook found", async () => {
     expect(result).toBe(true);
 });
 
-test("test revert Onlook", async () => {
+test("test revert Onlook Next.js", async () => {
     await removePlugins("/Users/kietho/workplace/onlook/test/hn_clone");
+});
+
+test("test revert Onlook Vite", async () => {
+    await removePlugins("/Users/kietho/workplace/onlook/test/remix");
 });

--- a/packages/models/src/constants/index.ts
+++ b/packages/models/src/constants/index.ts
@@ -117,8 +117,9 @@ export enum MainChannels {
     DELETE_CONVERSATION = 'delete-conversation',
 
     // Run
-    RUN_SETUP = 'run-setup',
+    RUN_START = 'run-start',
     RUN_STOP = 'run-stop',
+    RUN_RESTART = 'run-restart',
     GET_TEMPLATE_NODE = 'get-template-node',
     RUN_STATE_CHANGED = 'run-state-changed',
     GET_RUN_STATE = 'get-run-state',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Support running legacy projects by running a remove script on start. This will remove the Onlook plugins from configs and package.json files.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [X] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
