### PR TITLE
Don't strip messages from users messages

### DIFF
--- a/apps/studio/src/lib/editor/engine/chat/conversation.ts
+++ b/apps/studio/src/lib/editor/engine/chat/conversation.ts
@@ -52,13 +52,7 @@ export class ChatConversationImpl implements ChatConversation {
 
     getCoreMessages() {
         const messages: CoreMessage[] = this.messages
-            .map((m, index) => {
-                if (index === this.messages.length - 1) {
-                    return m.toCurrentMessage();
-                } else {
-                    return m.toPreviousMessage();
-                }
-            })
+            .map((m) => m.toCurrentMessage())
             .filter((m) => m !== undefined && m.content !== '');
         return messages;
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Previously, we were stripping down the users' past messages to save cost. But this can cause issue so we'll just pass the full history context to the model and eat the cost. 

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [X] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
