### PR TITLE
Fix handling of dynamic className in tailwind input

### DIFF
--- a/apps/studio/electron/main/code/classes.ts
+++ b/apps/studio/electron/main/code/classes.ts
@@ -35,5 +35,23 @@ function getNodeClasses(node: t.JSXElement): string[] {
         return classNameAttr.value.expression.value.split(/\s+/).filter(Boolean);
     }
 
+    if (
+        t.isJSXExpressionContainer(classNameAttr.value) &&
+        t.isTemplateLiteral(classNameAttr.value.expression)
+    ) {
+        const templateLiteral = classNameAttr.value.expression;
+
+        // Checks if all classes in the expression are static
+        const allStatic = templateLiteral.expressions.length === 0;
+
+        // Returns the classes if all are static, otherwise returns a message
+        if (allStatic) {
+            const quasis = templateLiteral.quasis.map((quasi) => quasi.value.raw.split(/\s+/));
+            return quasis.flat().filter(Boolean);
+        } else {
+            return ['Dynamic classes detected.'];
+        }
+    }
+
     return [];
 }

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/TailwindInput/index.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/TailwindInput/index.tsx
@@ -211,6 +211,19 @@ const TailwindInput = observer(() => {
         textarea.style.height = `${textarea.scrollHeight + 20}px`;
     };
 
+    const navigateToTemplateNode = async (oid: string | null) => {
+        if (!oid) {
+            console.error('No templateNode ID provided for navigation.');
+            return;
+        }
+
+        try {
+            await window.api.invoke(MainChannels.VIEW_SOURCE_CODE, oid);
+        } catch (error) {
+            console.error('Error opening TemplateNode in IDE:', error);
+        }
+    };
+
     useEffect(() => {
         if (instanceRef.current) {
             adjustHeight(instanceRef.current);
@@ -295,7 +308,12 @@ const TailwindInput = observer(() => {
                                     : 'bg-background-secondary/75 focus:bg-background-tertiary',
                             )}
                             placeholder="Add tailwind classes here"
-                            value={rootHistory.present}
+                            value={
+                                rootHistory.present.includes('Dynamic classes detected')
+                                    ? 'Warning: A dynamic classname is used. Open the code to edit.'
+                                    : rootHistory.present
+                            }
+                            readOnly={rootHistory.present.includes('Dynamic classes detected')}
                             onInput={(e) => handleInput(e, rootHistory, setRootHistory)}
                             onKeyDown={(e) => handleKeyDown(e, rootHistory, setRootHistory)}
                             onBlur={(e) => {
@@ -331,7 +349,21 @@ const TailwindInput = observer(() => {
                             />
                         )}
                     </div>
-                    {isRootFocused && <EnterIndicator />}
+                    {rootHistory.present.includes('Dynamic classes detected') ? (
+                        <div className="absolute bottom-1 right-2 text-xs flex items-center text-blue-500 cursor-pointer">
+                            <button
+                                onClick={(e) => {
+                                    e.stopPropagation(); // Prevents unfocusing the textarea
+                                    navigateToTemplateNode(selectedEl?.oid);
+                                }}
+                                className="underline"
+                            >
+                                Go to source
+                            </button>
+                        </div>
+                    ) : (
+                        isRootFocused && <EnterIndicator />
+                    )}
                 </div>
             )}
 
@@ -374,7 +406,12 @@ const TailwindInput = observer(() => {
                                     : 'bg-background-secondary/75 text-foreground-muted border-background-secondary/75 group-hover:bg-purple-100/50 group-hover:text-purple-900 group-hover:border-purple-200 dark:group-hover:bg-purple-900/30 dark:group-hover:text-purple-100 dark:group-hover:border-purple-900/30 cursor-pointer',
                             )}
                             placeholder="Add tailwind classes here"
-                            value={instanceHistory.present}
+                            value={
+                                instanceHistory.present.includes('Dynamic classes detected')
+                                    ? 'Warning: A dynamic classname is used. Open the code to edit.'
+                                    : instanceHistory.present
+                            }
+                            readOnly={instanceHistory.present.includes('Dynamic classes detected')}
                             onInput={(e) => handleInput(e, instanceHistory, setInstanceHistory)}
                             onKeyDown={(e) => handleKeyDown(e, instanceHistory, setInstanceHistory)}
                             onBlur={(e) => {
@@ -410,7 +447,21 @@ const TailwindInput = observer(() => {
                             />
                         )}
                     </div>
-                    {isInstanceFocused && <EnterIndicator isInstance={true} />}
+                    {rootHistory.present.includes('Dynamic classes detected') ? (
+                        <div className="absolute bottom-1 right-2 text-xs flex items-center text-blue-500 cursor-pointer">
+                            <button
+                                onClick={(e) => {
+                                    e.stopPropagation(); // Prevents unfocusing the textarea
+                                    navigateToTemplateNode(selectedEl?.oid);
+                                }}
+                                className="underline"
+                            >
+                                Go to source
+                            </button>
+                        </div>
+                    ) : (
+                        isInstanceFocused && <EnterIndicator />
+                    )}
                 </div>
             )}
         </div>


### PR DESCRIPTION
### Description

- Added logic to display a warning message when dynamic variables are used in className.
- Displays Tailwind classes if no dynamic variables are present in the template literal.
- Shows a button in the UI to navigate to the relevant templateNode source code when dynamic variables are used.
- Updated the button name to improve user clarity.

### With template literals
Now properly displays Tailwind Classes even if template literals were used, but no dynamic variables were used.

**Selected div for reference**:
```typescript
<div
  className={`w-full min-h-screen flex items-center justify-center bg-red-50 relative overflow-hidden flex-col`}
  data-oid=":gge2lo"
>
// ...
</div>
```

**Tailwind Classes textarea**:
![image](https://github.com/user-attachments/assets/8dff82a3-df68-434c-ac97-b9f75cbd26eb)

### Template literals with dynamic variables

**Selected div for reference**:
```typescript
const someClassName = "text-center text-gray-900 relative z-10";

<div className={`m-8 p-8 ${someClassName}`} data-oid="adqx-me">
// ...
</div>
```

**Tailwind Classes textarea**:
![image](https://github.com/user-attachments/assets/b24f15bc-15f3-4d6d-9a7b-94f187c68bf7)

As asked, clicking the `Go to source` button in the textarea brings the user to the relevant template node in the source code.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
