### PR TITLE
Enable linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
                 os:
                     - macos-latest
                     - windows-latest
-                    # - ubuntu-latest
+                    - ubuntu-latest
 
         steps:
             - name: Checkout Code


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This starts building and hopefully shipping for linux

The directory path is based on https://github.com/tutao/tutanota/blob/1337c4650a69be845a7765c9ee6d6c1da096041f/buildSrc/electron-package-json-template.js#L167 and should allow us to build a multiplatform flatpak easily

### What is the purpose of this pull request? 

- [ ] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [x] Release
- [ ] Other
