### PR TITLE
fix: Update zoom input value to reflect latest zoom scale value

### DIFF
--- a/apps/studio/src/routes/editor/TopBar/ZoomControls/index.tsx
+++ b/apps/studio/src/routes/editor/TopBar/ZoomControls/index.tsx
@@ -5,7 +5,7 @@ import { Input } from '@onlook/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@onlook/ui/popover';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Hotkey } from '/common/hotkeys';
 
 const ZoomControls = observer(() => {
@@ -14,6 +14,10 @@ const ZoomControls = observer(() => {
 
     const [inputValue, setInputValue] = useState(`${Math.round(scale * 100)}%`);
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+    useEffect(() => {
+        // setInputValue(`${Math.round(scale * 100)}%`);
+    }, [editorEngine.canvas.scale]);
 
     const ZOOM_SENSITIVITY = 0.5;
     const MIN_ZOOM = 0.1;

--- a/apps/studio/src/routes/editor/TopBar/ZoomControls/index.tsx
+++ b/apps/studio/src/routes/editor/TopBar/ZoomControls/index.tsx
@@ -16,7 +16,7 @@ const ZoomControls = observer(() => {
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
     useEffect(() => {
-        // setInputValue(`${Math.round(scale * 100)}%`);
+        setInputValue(`${Math.round(scale * 100)}%`);
     }, [editorEngine.canvas.scale]);
 
     const ZOOM_SENSITIVITY = 0.5;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR addresses an issue where the input field did not reflect the latest scale value from the `editorEngine`. Instead, it displayed outdated values, leading to confusion for users when interacting with the editor.

![Screenshot 2025-01-25 201318](https://github.com/user-attachments/assets/f40df1fd-a34d-4451-a6a7-34579a918178)


### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
