### PR TITLE
Fix: Detect Ctrl+C Interrupt in Terminal

### DIFF
--- a/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
+++ b/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
@@ -105,6 +105,9 @@ const Terminal = observer(({ hidden = false }: TerminalProps) => {
 
         const terminalDataListener = (message: TerminalMessage) => {
             if (message.id === projectsManager.project?.id) {
+                if (message.data && message.data == RunState.TERMINATE_BATCH) {
+                    runner.stop();
+                }
                 term.write(message.data);
             }
         };

--- a/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
+++ b/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
@@ -1,7 +1,7 @@
 import { useProjectsManager } from '@/components/Context';
 import { useTheme } from '@/components/ThemeProvider';
 import type { RunManager, TerminalMessage } from '@/lib/projects/run';
-import { MainChannels } from '@onlook/models/constants';
+import { MainChannels, TerminalCommands } from '@onlook/models/constants';
 import { RunState } from '@onlook/models/run';
 import { cn } from '@onlook/ui/utils';
 import { Terminal as XTerm, type ITheme } from '@xterm/xterm';
@@ -96,6 +96,10 @@ const Terminal = observer(({ hidden = false }: TerminalProps) => {
 
         // Set up event listeners
         term.onData((data) => {
+            if (data === TerminalCommands.CTRL_C) {
+                runner.stop();
+                return;
+            }
             runner.handleTerminalInput(data);
         });
 
@@ -105,10 +109,6 @@ const Terminal = observer(({ hidden = false }: TerminalProps) => {
 
         const terminalDataListener = (message: TerminalMessage) => {
             if (message.id === projectsManager.project?.id) {
-                if (message.data && message.data === RunState.TERMINATE_BATCH) {
-                    runner.stop();
-                    return;
-                }
                 term.write(message.data);
             }
         };

--- a/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
+++ b/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
@@ -105,8 +105,9 @@ const Terminal = observer(({ hidden = false }: TerminalProps) => {
 
         const terminalDataListener = (message: TerminalMessage) => {
             if (message.id === projectsManager.project?.id) {
-                if (message.data && message.data == RunState.TERMINATE_BATCH) {
+                if (message.data && message.data === RunState.TERMINATE_BATCH) {
                     runner.stop();
+                    return;
                 }
                 term.write(message.data);
             }

--- a/packages/models/src/constants/index.ts
+++ b/packages/models/src/constants/index.ts
@@ -2,3 +2,4 @@ export * from './api';
 export * from './dom';
 export * from './editor';
 export * from './ipc';
+export * from './terminal';

--- a/packages/models/src/constants/terminal.ts
+++ b/packages/models/src/constants/terminal.ts
@@ -1,0 +1,3 @@
+export const TerminalCommands = {
+    CTRL_C: String.fromCharCode(3),
+};

--- a/packages/models/src/run/index.ts
+++ b/packages/models/src/run/index.ts
@@ -4,4 +4,5 @@ export enum RunState {
     RUNNING = 'running',
     STOPPING = 'stopping',
     ERROR = 'error',
+    TERMINATE_BATCH = 'Terminate batch job (Y/N)? ',
 }

--- a/packages/models/src/run/index.ts
+++ b/packages/models/src/run/index.ts
@@ -4,5 +4,4 @@ export enum RunState {
     RUNNING = 'running',
     STOPPING = 'stopping',
     ERROR = 'error',
-    TERMINATE_BATCH = 'Terminate batch job (Y/N)? ',
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR introduces functionality to detect when a user interrupts the terminal session by pressing Ctrl+C, and it ensures that the current running manager exits appropriately

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
