### PR TITLE
feat: add slow connection message during project creation

### DIFF
--- a/apps/studio/src/lib/projects/create.ts
+++ b/apps/studio/src/lib/projects/create.ts
@@ -32,11 +32,11 @@ export class CreateManager {
 
         // Set a new timer for 10 seconds
         this.slowConnectionTimer = setTimeout(() => {
-            if (this.state === CreateState.CREATE_LOADING && this.progress < 300) {
+            if (this.state === CreateState.CREATE_LOADING) {
                 this.message =
                     'This is taking longer than usual. This could be due to a slow internet connection...';
             }
-        }, 10000); // 10 seconds
+        }, 10000);
     }
 
     private clearSlowConnectionTimer() {
@@ -109,6 +109,8 @@ export class CreateManager {
                     images,
                 );
             }
+
+            this.clearSlowConnectionTimer();
 
             setTimeout(() => {
                 this.projectsManager.runner?.start();


### PR DESCRIPTION
- Add timer to detect slow project creation (>30s)

- Show helpful message when connection might be slow

- Properly handle timer cleanup to prevent memory leaks

Closes #1192

<!-- Thank you for contributing! -->

### Description

This PR adds a helpful message to inform users when project creation is taking longer than expected. After 10 seconds of loading, if the project hasn't finished creating, we show a message suggesting that the delay might be due to a slow internet connection. The timer is properly managed to avoid memory leaks and is automatically cleaned up when the component is unmounted or when the loading state changes.

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [X] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other