### PR TITLE
feat: add assets management

### DIFF
--- a/apps/studio/electron/main/assets/index.ts
+++ b/apps/studio/electron/main/assets/index.ts
@@ -21,10 +21,20 @@ async function scanImagesDirectory(projectRoot: string): Promise<ImageContentDat
                     const imagePath = path.join(imagesPath, entry.name);
                     const image = readFileSync(imagePath, { encoding: 'base64' });
 
+                    const mimeTypes: { [key: string]: string } = {
+                        '.jpg': 'image/jpeg',
+                        '.jpeg': 'image/jpeg',
+                        '.png': 'image/png',
+                        '.gif': 'image/gif',
+                        '.webp': 'image/webp',
+                        '.svg': 'image/svg+xml',
+                        '.ico': 'image/x-icon',
+                    };
+
                     images.push({
                         fileName: entry.name,
-                        content: `data:image/png;base64,${image}`,
-                        mimeType: 'image/png',
+                        content: `data:${mimeTypes[extension]};base64,${image}`,
+                        mimeType: mimeTypes[extension],
                     });
                 }
             }
@@ -46,7 +56,7 @@ export async function scanNextJsImages(projectRoot: string): Promise<ImageConten
     }
 }
 
-export async function uploadImage(
+export async function saveImageToProject(
     projectRoot: string,
     image: string,
     fileName: string,

--- a/apps/studio/electron/main/assets/index.ts
+++ b/apps/studio/electron/main/assets/index.ts
@@ -1,0 +1,63 @@
+import { existsSync, promises as fs, unlinkSync } from 'fs';
+import * as path from 'path';
+import { writeFile } from '../code/files';
+import { DefaultSettings } from '@onlook/models/constants';
+async function scanImagesDirectory(projectRoot: string): Promise<string[]> {
+    const imagesPath = path.join(projectRoot, DefaultSettings.IMAGE_FOLDER);
+    const images: string[] = [];
+
+    try {
+        const entries = await fs.readdir(imagesPath, { withFileTypes: true });
+
+        for (const entry of entries) {
+            if (entry.isFile()) {
+                const extension = path.extname(entry.name).toLowerCase();
+                // Common image extensions
+                if (
+                    ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.ico'].includes(extension)
+                ) {
+                    images.push(
+                        `${DefaultSettings.IMAGE_FOLDER.replace(/^public\//, '')}/${entry.name}`,
+                    );
+                }
+            }
+        }
+
+        return images;
+    } catch (error) {
+        console.error('Error scanning images directory:', error);
+        return [];
+    }
+}
+
+export async function scanNextJsImages(projectRoot: string): Promise<string[]> {
+    try {
+        return await scanImagesDirectory(projectRoot);
+    } catch (error) {
+        console.error('Error scanning images:', error);
+        throw error;
+    }
+}
+
+export async function uploadImage(projectRoot: string, image: string, fileName: string) {
+    try {
+        const imageFolder = `${projectRoot}/${DefaultSettings.IMAGE_FOLDER}`;
+        const imagePath = path.join(imageFolder, fileName);
+        await writeFile(imagePath, image, 'base64');
+        return imagePath;
+    } catch (error) {
+        console.error('Error uploading image:', error);
+        throw error;
+    }
+}
+
+export async function deleteImage(image: string) {
+    try {
+        if (existsSync(image)) {
+            unlinkSync(image);
+        }
+    } catch (error) {
+        console.error('Error deleting image:', error);
+        throw error;
+    }
+}

--- a/apps/studio/electron/main/events/asset.ts
+++ b/apps/studio/electron/main/events/asset.ts
@@ -1,6 +1,6 @@
-import { ipcMain } from 'electron';
 import { MainChannels } from '@onlook/models/constants';
-import { scanNextJsImages, saveImageToProject } from '../assets';
+import { ipcMain } from 'electron';
+import { saveImageToProject, scanNextJsImages } from '../assets';
 
 export function listenForAssetMessages() {
     ipcMain.handle(MainChannels.SCAN_IMAGES_IN_PROJECT, async (_event, projectRoot: string) => {
@@ -10,8 +10,19 @@ export function listenForAssetMessages() {
 
     ipcMain.handle(
         MainChannels.SAVE_IMAGE_TO_PROJECT,
-        async (_event, image: string, fileName: string, mimeType: string) => {
-            const imagePath = await saveImageToProject(image, fileName, mimeType);
+        async (
+            _event,
+            {
+                projectFolder,
+                content,
+                fileName,
+            }: {
+                projectFolder: string;
+                content: string;
+                fileName: string;
+            },
+        ) => {
+            const imagePath = await saveImageToProject(projectFolder, content, fileName);
             return imagePath;
         },
     );

--- a/apps/studio/electron/main/events/asset.ts
+++ b/apps/studio/electron/main/events/asset.ts
@@ -1,0 +1,22 @@
+import { ipcMain } from 'electron';
+import { MainChannels } from '@onlook/models/constants';
+import { deleteImage, scanNextJsImages, uploadImage } from '../assets';
+
+export function listenForAssetMessages() {
+    ipcMain.handle(MainChannels.SCAN_IMAGES, async (_event, projectRoot: string) => {
+        const images = await scanNextJsImages(projectRoot);
+        return images;
+    });
+
+    ipcMain.handle(
+        MainChannels.UPLOAD_IMAGES,
+        async (_event, image: string, fileName: string, mimeType: string) => {
+            const imagePath = await uploadImage(image, fileName, mimeType);
+            return imagePath;
+        },
+    );
+
+    ipcMain.handle(MainChannels.DELETE_IMAGE, async (_event, image: string) => {
+        await deleteImage(image);
+    });
+}

--- a/apps/studio/electron/main/events/asset.ts
+++ b/apps/studio/electron/main/events/asset.ts
@@ -1,17 +1,17 @@
 import { ipcMain } from 'electron';
 import { MainChannels } from '@onlook/models/constants';
-import { scanNextJsImages, uploadImage } from '../assets';
+import { scanNextJsImages, saveImageToProject } from '../assets';
 
 export function listenForAssetMessages() {
-    ipcMain.handle(MainChannels.SCAN_IMAGES, async (_event, projectRoot: string) => {
+    ipcMain.handle(MainChannels.SCAN_IMAGES_IN_PROJECT, async (_event, projectRoot: string) => {
         const images = await scanNextJsImages(projectRoot);
         return images;
     });
 
     ipcMain.handle(
-        MainChannels.UPLOAD_IMAGES,
+        MainChannels.SAVE_IMAGE_TO_PROJECT,
         async (_event, image: string, fileName: string, mimeType: string) => {
-            const imagePath = await uploadImage(image, fileName, mimeType);
+            const imagePath = await saveImageToProject(image, fileName, mimeType);
             return imagePath;
         },
     );

--- a/apps/studio/electron/main/events/asset.ts
+++ b/apps/studio/electron/main/events/asset.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import { MainChannels } from '@onlook/models/constants';
-import { deleteImage, scanNextJsImages, uploadImage } from '../assets';
+import { scanNextJsImages, uploadImage } from '../assets';
 
 export function listenForAssetMessages() {
     ipcMain.handle(MainChannels.SCAN_IMAGES, async (_event, projectRoot: string) => {
@@ -15,8 +15,4 @@ export function listenForAssetMessages() {
             return imagePath;
         },
     );
-
-    ipcMain.handle(MainChannels.DELETE_IMAGE, async (_event, image: string) => {
-        await deleteImage(image);
-    });
 }

--- a/apps/studio/electron/main/events/index.ts
+++ b/apps/studio/electron/main/events/index.ts
@@ -14,7 +14,7 @@ import { listenForPaymentMessages } from './payments';
 import { listenForRunMessages } from './run';
 import { listenForStorageMessages } from './storage';
 import { listenForPageMessages } from './page';
-
+import { listenForAssetMessages } from './asset';
 export function listenForIpcMessages() {
     listenForGeneralMessages();
     listenForAnalyticsMessages();
@@ -27,6 +27,7 @@ export function listenForIpcMessages() {
     listenForHostingMessages();
     listenForPaymentMessages();
     listenForPageMessages();
+    listenForAssetMessages();
 }
 
 export function removeIpcListeners() {

--- a/apps/studio/electron/main/events/index.ts
+++ b/apps/studio/electron/main/events/index.ts
@@ -5,16 +5,17 @@ import { mainWindow } from '..';
 import { imageStorage } from '../storage/images';
 import { updater } from '../update';
 import { listenForAnalyticsMessages } from './analytics';
+import { listenForAssetMessages } from './asset';
 import { listenForAuthMessages } from './auth';
 import { listenForChatMessages } from './chat';
 import { listenForCodeMessages } from './code';
 import { listenForCreateMessages } from './create';
 import { listenForHostingMessages } from './hosting';
+import { listenForPageMessages } from './page';
 import { listenForPaymentMessages } from './payments';
 import { listenForRunMessages } from './run';
 import { listenForStorageMessages } from './storage';
-import { listenForPageMessages } from './page';
-import { listenForAssetMessages } from './asset';
+
 export function listenForIpcMessages() {
     listenForGeneralMessages();
     listenForAnalyticsMessages();

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -103,7 +103,6 @@
         "@types/istextorbinary": "^2.3.4",
         "@types/js-string-escape": "^1.0.3",
         "@types/lodash": "^4.17.7",
-        "@types/mime-types": "^2.1.4",
         "@types/node": "^22.8.6",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",

--- a/apps/studio/src/lib/editor/engine/chat/index.ts
+++ b/apps/studio/src/lib/editor/engine/chat/index.ts
@@ -226,9 +226,5 @@ export class ChatManager {
         if (this.conversation) {
             this.conversation.current = null;
         }
-
-        // Clear references
-        this.editorEngine = null as any;
-        this.projectsManager = null as any;
     }
 }

--- a/apps/studio/src/lib/editor/engine/image/index.ts
+++ b/apps/studio/src/lib/editor/engine/image/index.ts
@@ -143,10 +143,6 @@ export class ImageManager {
     }
 
     dispose() {
-        // Clear references
-        this.editorEngine = null as any;
-        this.projectsManager = null as any;
-
         // Clean up images
         this.images = [];
     }

--- a/apps/studio/src/lib/editor/engine/image/index.ts
+++ b/apps/studio/src/lib/editor/engine/image/index.ts
@@ -1,5 +1,5 @@
 import { sendAnalytics, compressImage, invokeMainChannel } from '@/lib/utils';
-import type { ActionTarget, InsertImageAction } from '@onlook/models/actions';
+import type { ActionTarget, ImageContentData, InsertImageAction } from '@onlook/models/actions';
 import { getExtension } from 'mime-lite';
 import { nanoid } from 'nanoid/non-secure';
 import type { EditorEngine } from '..';
@@ -8,7 +8,7 @@ import { makeAutoObservable } from 'mobx';
 import { MainChannels } from '@onlook/models/constants';
 
 export class ImageManager {
-    private images: string[] = [];
+    private images: ImageContentData[] = [];
 
     constructor(
         private editorEngine: EditorEngine,
@@ -149,7 +149,7 @@ export class ImageManager {
             console.warn('No project root found');
             return;
         }
-        const images = await invokeMainChannel<string, string[]>(
+        const images = await invokeMainChannel<string, ImageContentData[]>(
             MainChannels.SCAN_IMAGES,
             projectRoot,
         );
@@ -163,5 +163,9 @@ export class ImageManager {
     dispose() {
         // Clear references
         this.editorEngine = null as any;
+        this.projectsManager = null as any;
+
+        // Clean up images
+        this.images = [];
     }
 }

--- a/apps/studio/src/lib/editor/engine/image/index.ts
+++ b/apps/studio/src/lib/editor/engine/image/index.ts
@@ -53,7 +53,7 @@ export class ImageManager {
             }
 
             await invokeMainChannel<string, string>(
-                MainChannels.UPLOAD_IMAGES,
+                MainChannels.SAVE_IMAGE_TO_PROJECT,
                 projectFolder,
                 base64Image,
                 file.name,
@@ -67,17 +67,22 @@ export class ImageManager {
     }
 
     async delete(imageName: string): Promise<void> {
-        const projectFolder = this.projectsManager.project?.folderPath;
-        if (!projectFolder) {
-            console.error('Failed to delete image, projectFolder not found');
-            return;
+        try {
+            const projectFolder = this.projectsManager.project?.folderPath;
+            if (!projectFolder) {
+                console.error('Failed to delete image, projectFolder not found');
+                return;
+            }
+            await invokeMainChannel<string, string>(
+                MainChannels.DELETE_IMAGE_FROM_PROJECT,
+                projectFolder,
+                imageName,
+            );
+            this.scanImages();
+        } catch (error) {
+            console.error('Error deleting image:', error);
+            throw error;
         }
-        await invokeMainChannel<string, string>(
-            MainChannels.DELETE_IMAGE,
-            projectFolder,
-            imageName,
-        );
-        this.scanImages();
     }
 
     async insert(base64Image: string, mimeType: string): Promise<InsertImageAction | undefined> {
@@ -150,7 +155,7 @@ export class ImageManager {
             return;
         }
         const images = await invokeMainChannel<string, ImageContentData[]>(
-            MainChannels.SCAN_IMAGES,
+            MainChannels.SCAN_IMAGES_IN_PROJECT,
             projectRoot,
         );
         if (images?.length) {

--- a/apps/studio/src/lib/editor/engine/image/index.ts
+++ b/apps/studio/src/lib/editor/engine/image/index.ts
@@ -2,7 +2,7 @@ import type { ProjectsManager } from '@/lib/projects';
 import { compressImage, invokeMainChannel, sendAnalytics } from '@/lib/utils';
 import type { ActionTarget, ImageContentData, InsertImageAction } from '@onlook/models/actions';
 import { MainChannels } from '@onlook/models/constants';
-import { getExtension } from 'mime-lite';
+import mime from 'mime-lite';
 import { makeAutoObservable } from 'mobx';
 import { nanoid } from 'nanoid/non-secure';
 import type { EditorEngine } from '..';
@@ -36,7 +36,9 @@ export class ImageManager {
                 fileName: file.name,
             });
 
-            this.scanImages();
+            setTimeout(() => {
+                this.scanImages();
+            }, 100);
         } catch (error) {
             console.error('Error uploading image:', error);
             throw error;
@@ -83,7 +85,7 @@ export class ImageManager {
             return;
         }
 
-        const fileName = `${nanoid(4)}.${getExtension(mimeType)}`;
+        const fileName = `${nanoid(4)}.${mime.getExtension(mimeType)}`;
         const action: InsertImageAction = {
             type: 'insert-image',
             targets: targets,
@@ -95,6 +97,9 @@ export class ImageManager {
         };
 
         this.editorEngine.action.run(action);
+        setTimeout(() => {
+            this.scanImages();
+        }, 2000);
         sendAnalytics('image-inserted', { mimeType });
     }
 
@@ -143,7 +148,6 @@ export class ImageManager {
     }
 
     dispose() {
-        // Clean up images
         this.images = [];
     }
 }

--- a/apps/studio/src/lib/editor/engine/index.ts
+++ b/apps/studio/src/lib/editor/engine/index.ts
@@ -170,8 +170,6 @@ export class EditorEngine {
         this.groupManager?.dispose();
         this.canvasManager?.clear();
         this.imageManager?.dispose();
-        // Clear references
-        this.projectsManager = null as any;
         this.editorMode = EditorMode.DESIGN;
         this.editorPanelTab = EditorTabValue.STYLES;
     }

--- a/apps/studio/src/lib/editor/engine/index.ts
+++ b/apps/studio/src/lib/editor/engine/index.ts
@@ -37,6 +37,7 @@ export class EditorEngine {
     private codeManager: CodeManager;
     private pagesManager: PagesManager;
     private errorManager: ErrorManager;
+    private imageManager: ImageManager;
 
     private astManager: AstManager = new AstManager(this);
     private historyManager: HistoryManager = new HistoryManager(this);
@@ -49,7 +50,6 @@ export class EditorEngine {
     private styleManager: StyleManager = new StyleManager(this);
     private copyManager: CopyManager = new CopyManager(this);
     private groupManager: GroupManager = new GroupManager(this);
-    private imageManager: ImageManager = new ImageManager(this);
 
     constructor(private projectsManager: ProjectsManager) {
         makeAutoObservable(this);
@@ -60,6 +60,7 @@ export class EditorEngine {
         this.codeManager = new CodeManager(this, this.projectsManager);
         this.pagesManager = new PagesManager(this, this.projectsManager);
         this.errorManager = new ErrorManager(this, this.projectsManager);
+        this.imageManager = new ImageManager(this, this.projectsManager);
     }
 
     get elements() {

--- a/apps/studio/src/lib/editor/engine/webview/index.ts
+++ b/apps/studio/src/lib/editor/engine/webview/index.ts
@@ -169,10 +169,6 @@ export class WebviewManager {
         // Run all disposers
         this.disposers.forEach((dispose) => dispose());
         this.disposers = [];
-
-        // Clear references
-        this.editorEngine = null as any;
-        this.projectsManager = null as any;
     }
 
     disposeWebview(id: string) {

--- a/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
@@ -136,17 +136,7 @@ const ImagesTab = observer(() => {
     };
 
     return (
-        <div
-            className={cn(
-                'w-full h-full',
-                '[&[data-dragging-image=true]]:bg-teal-500/40',
-                isDragging && 'cursor-copy',
-            )}
-            onDrop={handleDrop}
-            onDragOver={handleDragOver}
-            onDragEnter={handleDragEnter}
-            onDragLeave={handleDragLeave}
-        >
+        <div className="w-full h-full flex flex-col gap-2">
             <input
                 type="file"
                 accept="image/*"
@@ -160,52 +150,60 @@ const ImagesTab = observer(() => {
                     {uploadError}
                 </div>
             )}
-            {imageAssets.length === 0 ? (
-                <div className="h-screen flex items-center justify-center text-center opacity-70">
-                    <div>
-                        <Button
-                            onClick={handleClickAddButton}
-                            variant={'ghost'}
-                            size={'icon'}
-                            className="p-2 w-fit h-fit hover:bg-background-onlook"
-                        >
-                            <Icons.Plus />
-                        </Button>
-                        <span className="block w-2/3 mx-auto text-sm">
-                            Upload images using the Plus icon
-                        </span>
-                    </div>
-                </div>
-            ) : (
-                <div className="w-full flex flex-col gap-2">
-                    <div className="flex items-center gap-2">
-                        <div className="relative w-full">
-                            <input
-                                placeholder="Search"
-                                className="flex h-9 w-full rounded border-none bg-secondary px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:bg-background-active focus-visible:border-border-active focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
-                                type="text"
-                                onChange={handleSearch}
-                            />
-                            <div className="absolute pointer-events-none inset-y-0 right-0 h-full flex px-2 items-center justify-center">
-                                <Icons.MagnifyingGlass className="text-foreground-secondary" />
-                            </div>
+            {!!imageAssets.length && (
+                <div className="flex items-center gap-2">
+                    <div className="relative w-full">
+                        <input
+                            placeholder="Search"
+                            className="flex h-9 w-full rounded border-none bg-secondary px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:bg-background-active focus-visible:border-border-active focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
+                            type="text"
+                            onChange={handleSearch}
+                        />
+                        <div className="absolute pointer-events-none inset-y-0 right-0 h-full flex px-2 items-center justify-center">
+                            <Icons.MagnifyingGlass className="text-foreground-secondary" />
                         </div>
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant={'ghost'}
-                                    size={'icon'}
-                                    onClick={handleClickAddButton}
-                                >
-                                    <Icons.Plus />
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipPortal>
-                                <TooltipContent>Upload an image</TooltipContent>
-                            </TooltipPortal>
-                        </Tooltip>
                     </div>
-                    <div className="w-full flex flex-wrap gap-2">
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button variant={'ghost'} size={'icon'} onClick={handleClickAddButton}>
+                                <Icons.Plus />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipPortal>
+                            <TooltipContent>Upload an image</TooltipContent>
+                        </TooltipPortal>
+                    </Tooltip>
+                </div>
+            )}
+            <div
+                className={cn(
+                    'flex-1 overflow-y-auto',
+                    '[&[data-dragging-image=true]]:bg-teal-500/40',
+                    isDragging && 'cursor-copy',
+                )}
+                onDrop={handleDrop}
+                onDragOver={handleDragOver}
+                onDragEnter={handleDragEnter}
+                onDragLeave={handleDragLeave}
+            >
+                {imageAssets.length === 0 ? (
+                    <div className="h-full flex items-center justify-center text-center opacity-70">
+                        <div>
+                            <Button
+                                onClick={handleClickAddButton}
+                                variant={'ghost'}
+                                size={'icon'}
+                                className="p-2 w-fit h-fit hover:bg-background-onlook"
+                            >
+                                <Icons.Plus />
+                            </Button>
+                            <span className="block w-2/3 mx-auto text-sm">
+                                Upload images using the Plus icon
+                            </span>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="w-full flex flex-wrap gap-2 p-2">
                         {filteredImages.map((image) => (
                             <div
                                 key={image.fileName}
@@ -285,8 +283,8 @@ const ImagesTab = observer(() => {
                             </div>
                         ))}
                     </div>
-                </div>
-            )}
+                )}
+            </div>
         </div>
     );
 });

--- a/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
@@ -7,6 +7,7 @@ import {
     DropdownMenuTrigger,
 } from '@onlook/ui/dropdown-menu';
 import { Icons } from '@onlook/ui/icons';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@onlook/ui/tooltip';
 import { debounce } from 'lodash';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -120,9 +121,18 @@ const ImagesTab = observer(() => {
                                 <Icons.MagnifyingGlass className="text-foreground-secondary" />
                             </div>
                         </div>
-                        <Button variant={'ghost'} size={'icon'} onClick={handleClickAddButton}>
-                            <Icons.Plus />
-                        </Button>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    variant={'ghost'}
+                                    size={'icon'}
+                                    onClick={handleClickAddButton}
+                                >
+                                    <Icons.Plus />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Upload an image</TooltipContent>
+                        </Tooltip>
                     </div>
                     <div className="w-full flex flex-wrap gap-2">
                         {filteredImages.map((image) => (
@@ -160,7 +170,11 @@ const ImagesTab = observer(() => {
                                                 <Icons.DotsHorizontal className="text-foreground dark:text-white w-4 h-4" />
                                             </Button>
                                         </DropdownMenuTrigger>
-                                        <DropdownMenuContent className="rounded-md bg-background">
+                                        <DropdownMenuContent
+                                            className="rounded-md bg-background"
+                                            align="start"
+                                            side="right"
+                                        >
                                             <DropdownMenuItem asChild>
                                                 <Button
                                                     variant={'ghost'}

--- a/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
@@ -1,3 +1,4 @@
+import { useEditorEngine, useProjectsManager } from '@/components/Context';
 import { Button } from '@onlook/ui/button';
 import {
     DropdownMenu,
@@ -6,19 +7,79 @@ import {
     DropdownMenuTrigger,
 } from '@onlook/ui/dropdown-menu';
 import { Icons } from '@onlook/ui/icons';
+import { debounce } from 'lodash';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const ImagesTab = observer(() => {
-    const [imageFiles, setImageFiles] = useState<string[]>([]);
     const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+    const [search, setSearch] = useState('');
+    const editorEngine = useEditorEngine();
+    const projectsManager = useProjectsManager();
 
-    return (
+    useEffect(() => {
+        scanImages();
+    }, []);
+
+    const imageAssets = useMemo(() => {
+        return editorEngine.image.assets;
+    }, [editorEngine.image.assets]);
+
+    const scanImages = () => {
+        editorEngine.image.scanImages();
+    };
+
+    const handleUploadFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = Array.from(e.target.files || []);
+        const imageFile = files.find((file) => file.type.startsWith('image/'));
+        if (imageFile) {
+            editorEngine.image.upload(imageFile);
+        }
+    };
+
+    const handleClickAddButton = () => {
+        const input = document.getElementById('images-upload');
+        if (input) {
+            input.click();
+        }
+    };
+
+    const debouncedSearch = useCallback(
+        debounce((value: string) => {
+            setSearch(value);
+        }, 300),
+        [],
+    );
+
+    const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+        debouncedSearch(e.target.value);
+    };
+
+    useEffect(() => {
+        return () => {
+            debouncedSearch.cancel();
+        };
+    }, [debouncedSearch]);
+
+    const filteredImages = useMemo(() => {
+        return imageAssets.filter((image) => image.includes(search));
+    }, [imageAssets, search]);
+
+    return projectsManager.runner?.isRunning ? (
         <div className="w-full">
-            {imageFiles.length === 0 ? (
+            <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                id="images-upload"
+                onChange={handleUploadFile}
+                // multiple TODO: add multiple
+            />
+            {imageAssets.length === 0 ? (
                 <div className="h-screen flex items-center justify-center text-center opacity-70">
                     <div>
                         <Button
+                            onClick={handleClickAddButton}
                             variant={'ghost'}
                             size={'icon'}
                             className="p-2 w-fit h-fit hover:bg-background-onlook"
@@ -31,79 +92,99 @@ const ImagesTab = observer(() => {
                     </div>
                 </div>
             ) : (
-                <div className="w-full flex flex-wrap gap-2">
-                    {imageFiles.map((imageName) => (
-                        <div key={imageName} className="relative group flex-shrink-0 w-[120px]">
-                            <div className="w-full h-[120px] flex flex-col justify-center rounded-lg overflow-hidden items-center">
-                                <img
-                                    className="w-full h-full object-cover"
-                                    src={imageName}
-                                    alt={imageName.split('/').pop()}
-                                />
-                            </div>
-                            <span className="text-xs block w-full text-center truncate">
-                                {imageName.split('/').pop()}
-                            </span>
-                            <div
-                                className={`absolute right-2 top-2 ${
-                                    activeDropdown === imageName ? 'opacity-100' : 'opacity-0'
-                                } group-hover:opacity-100 transition-opacity duration-300`}
-                            >
-                                <DropdownMenu
-                                    onOpenChange={(isOpen) =>
-                                        setActiveDropdown(isOpen ? imageName : null)
-                                    }
-                                >
-                                    <DropdownMenuTrigger>
-                                        <Button
-                                            variant={'ghost'}
-                                            className="bg-background p-1 inline-flex items-center justify-center h-auto w-auto rounded shadow-sm"
-                                        >
-                                            <Icons.DotsHorizontal className="text-foreground dark:text-white w-4 h-4" />
-                                        </Button>
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent className="rounded-md bg-background">
-                                        <DropdownMenuItem asChild>
-                                            <Button
-                                                variant={'ghost'}
-                                                className="hover:bg-background-secondary focus:bg-background-secondary w-full rounded-sm group"
-                                            >
-                                                <span className="flex w-full text-smallPlus">
-                                                    <Icons.Pencil className="mr-2 h-4 w-4 text-foreground-secondary group-hover:text-foreground-active" />
-                                                    <span>Rename</span>
-                                                </span>
-                                            </Button>
-                                        </DropdownMenuItem>
-                                        <DropdownMenuItem asChild>
-                                            <Button
-                                                variant={'ghost'}
-                                                className="hover:bg-background-secondary focus:bg-background-secondary w-full rounded-sm group"
-                                            >
-                                                <span className="flex w-full text-smallPlus">
-                                                    <Icons.Trash className="mr-2 h-4 w-4 text-foreground-secondary group-hover:text-foreground-active" />
-                                                    <span>Delete</span>
-                                                </span>
-                                            </Button>
-                                        </DropdownMenuItem>
-                                        <DropdownMenuItem asChild>
-                                            <Button
-                                                variant={'ghost'}
-                                                className="hover:bg-background-secondary focus:bg-background-secondary w-full rounded-sm group"
-                                            >
-                                                <span className="flex w-full text-smallPlus">
-                                                    <Icons.File className="mr-2 h-4 w-4 text-foreground-secondary group-hover:text-foreground-active" />
-                                                    <span>Open Folder</span>
-                                                </span>
-                                            </Button>
-                                        </DropdownMenuItem>
-                                    </DropdownMenuContent>
-                                </DropdownMenu>
+                <div className="w-full flex flex-col gap-2">
+                    <div className="flex items-center gap-2">
+                        <div className="relative w-full">
+                            <input
+                                placeholder="Search"
+                                className="flex h-9 w-full rounded border-none bg-secondary px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:bg-background-active focus-visible:border-border-active focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50"
+                                type="text"
+                                onChange={handleSearch}
+                            />
+                            <div className="absolute pointer-events-none inset-y-0 right-0 h-full flex px-2 items-center justify-center">
+                                <Icons.MagnifyingGlass className="text-foreground-secondary" />
                             </div>
                         </div>
-                    ))}
+                        <Button variant={'ghost'} size={'icon'} onClick={handleClickAddButton}>
+                            <Icons.Plus />
+                        </Button>
+                    </div>
+                    <div className="w-full flex flex-wrap gap-2">
+                        {filteredImages.map((imageName) => (
+                            <div key={imageName} className="relative group flex-shrink-0 w-[120px]">
+                                <div className="w-full h-[120px] flex flex-col justify-center rounded-lg overflow-hidden items-center">
+                                    <img
+                                        className="w-full h-full object-cover"
+                                        src={`${projectsManager.project?.url}/${imageName}`}
+                                        alt={imageName.split('/').pop()}
+                                    />
+                                </div>
+                                <span className="text-xs block w-full text-center truncate">
+                                    {imageName.split('/').pop()}
+                                </span>
+                                <div
+                                    className={`absolute right-2 top-2 ${
+                                        activeDropdown === imageName ? 'opacity-100' : 'opacity-0'
+                                    } group-hover:opacity-100 transition-opacity duration-300`}
+                                >
+                                    <DropdownMenu
+                                        onOpenChange={(isOpen) =>
+                                            setActiveDropdown(isOpen ? imageName : null)
+                                        }
+                                    >
+                                        <DropdownMenuTrigger>
+                                            <Button
+                                                variant={'ghost'}
+                                                className="bg-background p-1 inline-flex items-center justify-center h-auto w-auto rounded shadow-sm"
+                                            >
+                                                <Icons.DotsHorizontal className="text-foreground dark:text-white w-4 h-4" />
+                                            </Button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent className="rounded-md bg-background">
+                                            <DropdownMenuItem asChild>
+                                                <Button
+                                                    variant={'ghost'}
+                                                    className="hover:bg-background-secondary focus:bg-background-secondary w-full rounded-sm group"
+                                                >
+                                                    <span className="flex w-full text-smallPlus items-center">
+                                                        <Icons.Pencil className="mr-2 h-4 w-4 text-foreground-secondary group-hover:text-foreground-active" />
+                                                        <span>Rename</span>
+                                                    </span>
+                                                </Button>
+                                            </DropdownMenuItem>
+                                            <DropdownMenuItem asChild>
+                                                <Button
+                                                    variant={'ghost'}
+                                                    className="hover:bg-background-secondary focus:bg-background-secondary w-full rounded-sm group"
+                                                >
+                                                    <span className="flex w-full text-smallPlus items-center">
+                                                        <Icons.Trash className="mr-2 h-4 w-4 text-foreground-secondary group-hover:text-foreground-active" />
+                                                        <span>Delete</span>
+                                                    </span>
+                                                </Button>
+                                            </DropdownMenuItem>
+                                            <DropdownMenuItem asChild>
+                                                <Button
+                                                    variant={'ghost'}
+                                                    className="hover:bg-background-secondary focus:bg-background-secondary w-full rounded-sm group"
+                                                >
+                                                    <span className="flex w-full text-smallPlus items-center">
+                                                        <Icons.File className="mr-2 h-4 w-4 text-foreground-secondary group-hover:text-foreground-active" />
+                                                        <span>Open Folder</span>
+                                                    </span>
+                                                </Button>
+                                            </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                    </DropdownMenu>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
                 </div>
             )}
         </div>
+    ) : (
+        <div></div>
     );
 });
 

--- a/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
@@ -1,4 +1,6 @@
-import { useEditorEngine } from '@/components/Context';
+import { useEditorEngine, useProjectsManager } from '@/components/Context';
+import { invokeMainChannel, platformSlash } from '@/lib/utils';
+import { DefaultSettings, MainChannels } from '@onlook/models/constants';
 import { Button } from '@onlook/ui/button';
 import {
     DropdownMenu,
@@ -14,11 +16,16 @@ import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const ImagesTab = observer(() => {
+    const editorEngine = useEditorEngine();
+    const projectsManager = useProjectsManager();
+
     const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
     const [search, setSearch] = useState('');
     const [uploadError, setUploadError] = useState<string | null>(null);
     const [isDragging, setIsDragging] = useState(false);
-    const editorEngine = useEditorEngine();
+    const imageFolder: string | null = projectsManager.project?.folderPath
+        ? `${projectsManager.project.folderPath}${platformSlash}${DefaultSettings.IMAGE_FOLDER}`
+        : null;
 
     useEffect(() => {
         scanImages();
@@ -270,6 +277,15 @@ const ImagesTab = observer(() => {
                                                 <Button
                                                     variant={'ghost'}
                                                     className="hover:bg-background-secondary focus:bg-background-secondary w-full rounded-sm group"
+                                                    onClick={() => {
+                                                        if (!imageFolder) {
+                                                            return;
+                                                        }
+                                                        invokeMainChannel(
+                                                            MainChannels.OPEN_IN_EXPLORER,
+                                                            imageFolder,
+                                                        );
+                                                    }}
                                                 >
                                                     <span className="flex w-full text-smallPlus items-center">
                                                         <Icons.File className="mr-2 h-4 w-4 text-foreground-secondary group-hover:text-foreground-active" />

--- a/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/ImagesTab.tsx
@@ -81,7 +81,11 @@ const ImagesTab = observer(() => {
     }, [debouncedSearch]);
 
     const filteredImages = useMemo(() => {
-        return imageAssets.filter((image) => image.fileName.includes(search));
+        if (!search.trim()) {
+            return imageAssets;
+        }
+        const searchLower = search.toLowerCase();
+        return imageAssets.filter((image) => image.fileName?.toLowerCase()?.includes(searchLower));
     }, [imageAssets, search]);
 
     const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -85,7 +85,7 @@ const LayersPanel = observer(() => {
                             <div className="w-full pt-96 text-center opacity-70">Coming soon</div>
                         )}
                     </TabsContent>
-                    <TabsContent value={TabValue.IMAGES}>
+                    <TabsContent value={TabValue.IMAGES} className="h-full">
                         <ImagesTab />
                     </TabsContent>
                 </div>

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -54,7 +54,7 @@ const LayersPanel = observer(() => {
                             {capitalizeFirstLetter(TabValue.PAGES)}
                         </TabsTrigger>
                         <TabsTrigger
-                            className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover hidden"
+                            className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover"
                             value={TabValue.IMAGES}
                         >
                             <div className="flex items-center gap-1">

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -85,7 +85,7 @@ const LayersPanel = observer(() => {
                             <div className="w-full pt-96 text-center opacity-70">Coming soon</div>
                         )}
                     </TabsContent>
-                    <TabsContent value={TabValue.IMAGES} className="h-full">
+                    <TabsContent value={TabValue.IMAGES}>
                         <ImagesTab />
                     </TabsContent>
                 </div>

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -54,7 +54,7 @@ const LayersPanel = observer(() => {
                             {capitalizeFirstLetter(TabValue.PAGES)}
                         </TabsTrigger>
                         <TabsTrigger
-                            className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover"
+                            className="bg-transparent py-2 px-1 text-xs hover:text-foreground-hover hidden"
                             value={TabValue.IMAGES}
                         >
                             <div className="flex items-center gap-1">

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "apps/studio": {
       "name": "@onlook/studio",
-      "version": "0.1.43",
+      "version": "0.1.45",
       "dependencies": {
         "@ai-sdk/anthropic": "^0.0.53",
         "@anthropic-ai/sdk": "^0.33.1",
@@ -79,7 +79,6 @@
         "@types/istextorbinary": "^2.3.4",
         "@types/js-string-escape": "^1.0.3",
         "@types/lodash": "^4.17.7",
-        "@types/mime-types": "^2.1.4",
         "@types/node": "^22.8.6",
         "@types/react": "^18.2.64",
         "@types/react-dom": "^18.2.21",
@@ -910,8 +909,6 @@
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
-
-    "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 

--- a/packages/models/src/constants/ipc.ts
+++ b/packages/models/src/constants/ipc.ts
@@ -135,7 +135,7 @@ export enum MainChannels {
     CREATE_PAGE = 'create-page',
 
     // Images
-    SCAN_IMAGES = 'scan-images',
-    UPLOAD_IMAGES = 'upload-images',
-    DELETE_IMAGE = 'delete-image',
+    SCAN_IMAGES_IN_PROJECT = 'scan-images-in-project',
+    SAVE_IMAGE_TO_PROJECT = 'save-image-to-project',
+    DELETE_IMAGE_FROM_PROJECT = 'delete-image-from-project',
 }

--- a/packages/models/src/constants/ipc.ts
+++ b/packages/models/src/constants/ipc.ts
@@ -133,4 +133,9 @@ export enum MainChannels {
     // Pages
     SCAN_PAGES = 'scan-pages',
     CREATE_PAGE = 'create-page',
+
+    // Images
+    SCAN_IMAGES = 'scan-images',
+    UPLOAD_IMAGES = 'upload-images',
+    DELETE_IMAGE = 'delete-image',
 }

--- a/packages/ui/src/components/icons/index.tsx
+++ b/packages/ui/src/components/icons/index.tsx
@@ -73,6 +73,7 @@ import {
     ListBulletIcon,
     LockClosedIcon,
     LockOpen1Icon,
+    MagnifyingGlassIcon,
     MagicWandIcon,
     MinusCircledIcon,
     MinusIcon,
@@ -1245,6 +1246,7 @@ export const Icons = {
     LockOpen: LockOpen1Icon,
     LockClosed: LockClosedIcon,
 
+    MagnifyingGlass: MagnifyingGlassIcon,
     MagicWand: MagicWandIcon,
     Minus: MinusIcon,
     MinusCircled: MinusCircledIcon,


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

Currently, these features below are built and hidden on the LayersPanel side

- Scan for the standard Next.js assets folder and find any images that can be used and loaded images into the sidepanel
- Allowed the ability to add image which will put it in the expected next.js standard folder
- Added a search bar that just filters based on filename

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
- Related to #1241
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

https://github.com/user-attachments/assets/b6adaf45-8b15-4fd8-9963-9230b50d0a7e


<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
