### PR TITLE
Change overflow-hidden to overflow-auto

### DIFF
--- a/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
+++ b/apps/studio/src/routes/editor/Toolbar/Terminal/index.tsx
@@ -125,7 +125,7 @@ const Terminal = observer(({ hidden = false }: TerminalProps) => {
     return (
         <div
             className={cn(
-                'bg-background rounded-lg overflow-hidden transition-all duration-300',
+                'bg-background rounded-lg overflow-auto transition-all duration-300',
                 hidden ? 'h-0 w-0 invisible' : 'h-[22rem] w-[37rem]',
             )}
         >


### PR DESCRIPTION
## Description

Fix the issue where the last line of the terminal disappears after multiple commands have been entered

## Related Issues

Fixes #1291 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Other (please describe):

## Testing

I typed in multiple commands before and after the change and adding the change fixed the issue.

## Screenshots (if applicable)

#### Before fix:

![411130518-af099132-70cb-491b-be7f-d9cfc06c1b05](https://github.com/user-attachments/assets/6be704f4-9152-4ada-8c8a-ac0f8f5e4f05)

#### After fix:
![2025-02-07_19-26](https://github.com/user-attachments/assets/c1ab456f-4d3a-4291-804e-373adce00dbe)

