### PR TITLE
fix: Enable deletion of multiple selected elements

### DIFF
--- a/apps/studio/src/lib/editor/engine/element/index.ts
+++ b/apps/studio/src/lib/editor/engine/element/index.ts
@@ -135,48 +135,50 @@ export class ElementManager {
         if (selected.length === 0) {
             return;
         }
-        const selectedEl: DomElement = selected[0];
-        const webviewId = selectedEl.webviewId;
-        const webview = this.editorEngine.webviews.getWebview(webviewId);
-        if (!webview) {
-            return;
-        }
 
-        const { shouldDelete, error } = await this.shouldDelete(selectedEl, webview);
+        for (const selectedEl of selected) {
+            const webviewId = selectedEl.webviewId;
+            const webview = this.editorEngine.webviews.getWebview(webviewId);
+            if (!webview) {
+                return;
+            }
 
-        if (!shouldDelete) {
-            toast({
-                title: 'Cannot delete element',
-                description: error,
-                variant: 'destructive',
-            });
-            return;
-        }
+            const { shouldDelete, error } = await this.shouldDelete(selectedEl, webview);
 
-        const removeAction = (await webview.executeJavaScript(
-            `window.api?.getRemoveActionFromDomId('${selectedEl.domId}', '${webviewId}')`,
-        )) as RemoveElementAction | null;
-        if (!removeAction) {
-            console.error('Remove action not found');
-            toast({
-                title: 'Cannot delete element',
-                description: 'Remove action not found. Try refreshing the page.',
-                variant: 'destructive',
-            });
-            return;
-        }
-        const oid = selectedEl.instanceId || selectedEl.oid;
-        const codeBlock = await this.editorEngine.code.getCodeBlock(oid);
-        if (!codeBlock) {
-            toast({
-                title: 'Cannot delete element',
-                description: 'Code block not found. Try refreshing the page.',
-                variant: 'destructive',
-            });
-            return;
-        }
+            if (!shouldDelete) {
+                toast({
+                    title: 'Cannot delete element',
+                    description: error,
+                    variant: 'destructive',
+                });
+                return;
+            }
 
-        this.editorEngine.action.run(removeAction);
+            const removeAction = (await webview.executeJavaScript(
+                `window.api?.getRemoveActionFromDomId('${selectedEl.domId}', '${webviewId}')`,
+            )) as RemoveElementAction | null;
+            if (!removeAction) {
+                console.error('Remove action not found');
+                toast({
+                    title: 'Cannot delete element',
+                    description: 'Remove action not found. Try refreshing the page.',
+                    variant: 'destructive',
+                });
+                return;
+            }
+            const oid = selectedEl.instanceId || selectedEl.oid;
+            const codeBlock = await this.editorEngine.code.getCodeBlock(oid);
+            if (!codeBlock) {
+                toast({
+                    title: 'Cannot delete element',
+                    description: 'Code block not found. Try refreshing the page.',
+                    variant: 'destructive',
+                });
+                return;
+            }
+
+            this.editorEngine.action.run(removeAction);
+        }
     }
 
     private async shouldDelete(


### PR DESCRIPTION
## Description

Closes: #1350

This PR addresses an issue where only a single selected element was deleted, even when multiple elements were selected. The `delete()` function has been updated to iterate through all selected elements, enabling bulk deletion.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
