### PR TITLE
fix: messed up layer tree when copy/group/ungroup nested element

### DIFF
--- a/apps/studio/electron/preload/webview/elements/dom/group.ts
+++ b/apps/studio/electron/preload/webview/elements/dom/group.ts
@@ -39,8 +39,12 @@ export function groupElements(
 
     // Move children into container
     childrenWithIndices.forEach(({ element }) => {
-        containerEl.appendChild(element.cloneNode(true));
+        const newElement = element.cloneNode(true) as HTMLElement;
+
+        newElement.setAttribute(EditorAttributes.DATA_ONLOOK_INSERTED, 'true');
+        containerEl.appendChild(newElement);
         element.style.display = 'none';
+        removeIdsFromChildElement(element);
     });
 
     return getDomElement(containerEl, true);
@@ -83,4 +87,19 @@ function createContainerElement(target: GroupContainer): HTMLElement {
     containerEl.setAttribute(EditorAttributes.DATA_ONLOOK_DOM_ID, target.domId);
     containerEl.setAttribute(EditorAttributes.DATA_ONLOOK_ID, target.oid);
     return containerEl;
+}
+
+function removeIdsFromChildElement(el: HTMLElement) {
+    el.removeAttribute(EditorAttributes.DATA_ONLOOK_DOM_ID);
+    el.removeAttribute(EditorAttributes.DATA_ONLOOK_ID);
+    el.removeAttribute(EditorAttributes.DATA_ONLOOK_INSERTED);
+
+    const children = Array.from(el.children);
+    if (children.length === 0) {
+        return;
+    }
+
+    children.forEach((child) => {
+        removeIdsFromChildElement(child as HTMLElement);
+    });
 }

--- a/apps/studio/src/lib/editor/engine/ast/index.ts
+++ b/apps/studio/src/lib/editor/engine/ast/index.ts
@@ -86,11 +86,11 @@ export class AstManager {
             return;
         }
 
-        if (templateNode.dynamicType && !node.dynamicType) {
+        if (templateNode.dynamicType) {
             node.dynamicType = templateNode.dynamicType;
         }
 
-        if (templateNode.coreElementType && !node.coreElementType) {
+        if (templateNode.coreElementType) {
             node.coreElementType = templateNode.coreElementType;
         }
 

--- a/apps/studio/src/lib/editor/engine/ast/index.ts
+++ b/apps/studio/src/lib/editor/engine/ast/index.ts
@@ -8,7 +8,6 @@ import { LayersManager } from './layers';
 
 export class AstManager {
     private layersManager: LayersManager = new LayersManager();
-    private templateNodeCache = new Map<string, TemplateNode>();
 
     constructor(private editorEngine: EditorEngine) {
         makeAutoObservable(this);
@@ -185,12 +184,7 @@ export class AstManager {
             console.warn('Failed to getTemplateNodeById: No oid found');
             return null;
         }
-        if (this.templateNodeCache.has(oid)) {
-            return this.templateNodeCache.get(oid) as TemplateNode;
-        }
-        const templateNode = await invokeMainChannel(MainChannels.GET_TEMPLATE_NODE, { id: oid });
-        this.templateNodeCache.set(oid, templateNode as TemplateNode);
-        return templateNode as TemplateNode;
+        return invokeMainChannel(MainChannels.GET_TEMPLATE_NODE, { id: oid });
     }
 
     updateElementInstance(webviewId: string, domId: string, instanceId: string, component: string) {

--- a/apps/studio/src/lib/editor/engine/copy/index.ts
+++ b/apps/studio/src/lib/editor/engine/copy/index.ts
@@ -136,9 +136,17 @@ export class CopyManager {
             [EditorAttributes.DATA_ONLOOK_INSERTED]: 'true',
         };
 
+        // Process children recursively
+        const processedChildren = copiedEl.children?.map((child) => {
+            const newChildDomId = createDomId();
+            const newChildOid = createOid();
+            return this.getCleanedCopyEl(child, newChildDomId, newChildOid);
+        });
+
         return {
             ...copiedEl,
             attributes: filteredAttr,
+            children: processedChildren || [],
         };
     }
 

--- a/apps/studio/src/lib/editor/engine/group/index.ts
+++ b/apps/studio/src/lib/editor/engine/group/index.ts
@@ -56,13 +56,6 @@ export class GroupManager {
             }
             return null;
         }
-        // If there is only one element, we can't group it
-        if (elements.length === 1) {
-            if (log) {
-                console.error('Only one element selected');
-            }
-            return null;
-        }
 
         const webviewId = elements[0].webviewId;
         const sameWebview = elements.every((el) => el.webviewId === webviewId);

--- a/apps/studio/src/lib/editor/engine/group/index.ts
+++ b/apps/studio/src/lib/editor/engine/group/index.ts
@@ -56,6 +56,14 @@ export class GroupManager {
             }
             return null;
         }
+        // If there is only one element, we can't group it
+        if (elements.length === 1) {
+            if (log) {
+                console.error('Only one element selected');
+            }
+            return null;
+        }
+
         const webviewId = elements[0].webviewId;
         const sameWebview = elements.every((el) => el.webviewId === webviewId);
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- When user copy and paste nested elements, it makes the layer tree messed up sometimes
-  Root-cause:  Does not provide a fresh element for children in 
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
- fixes #994 
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

https://github.com/user-attachments/assets/0ca4e216-ab66-4e64-a0a6-cadcb6f7072f


## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
