### PR TITLE
fix: do not allow edit img as text

### DIFF
--- a/apps/studio/electron/main/code/diff/text.ts
+++ b/apps/studio/electron/main/code/diff/text.ts
@@ -29,6 +29,14 @@ export async function isChildTextEditable(oid: string): Promise<boolean | null> 
         return null;
     }
 
+    // Check if element is an img tag
+    if (
+        jsxElement.openingElement.name.type === 'JSXIdentifier' &&
+        jsxElement.openingElement.name?.name?.toLowerCase() === 'img'
+    ) {
+        return false;
+    }
+
     const children = jsxElement.children;
 
     // If no children, element is empty and can be edited


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- When click on a selected img, we don't want to start editing it as a text.
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

Uploading Screen Recording 2025-02-17 at 10.41.06.mov…


## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
