### PR TITLE
Add Weave badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 [![Discord][discord-shield]][discord-url]
 [![LinkedIn][linkedin-shield]][linkedin-url]
 [![Twitter][twitter-shield]][twitter-url]
+[![Weave][weave-shield]][weave-url]
 
 </div>
 
@@ -179,3 +180,5 @@ Distributed under the Apache 2.0 License. See [LICENSE.md](LICENSE.md) for more 
 [Vite.js]: https://img.shields.io/badge/vite-%23646CFF.svg?logo=vite&logoColor=white
 [Vite-url]: https://vitejs.dev/
 [product-screenshot]: assets/brand.png
+[weave-shield]: https://img.shields.io/endpoint?url=https%3A%2F%2Fapp.workweave.ai%2Fapi%2Frepository%2Fbadge%2Forg_pWcXBHJo3Li2Te2Y4WkCPA33%2F820087727&cacheSeconds=3600&labelColor=#131313
+[weave-url]: https://app.workweave.ai/reports/repository/org_pWcXBHJo3Li2Te2Y4WkCPA33/820087727


### PR DESCRIPTION
## Description

Adds a [Weave](https://workweave.dev/) badge to the README, so everyone can see how cracked the Onlook team is 😄 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [x] Other (please describe): README update