### PR TITLE
Fix: Correct positioning of "Chat with AI" button to prevent overlap with app bar

### DIFF
--- a/apps/studio/src/routes/editor/Canvas/Overlay/Chat.tsx
+++ b/apps/studio/src/routes/editor/Canvas/Overlay/Chat.tsx
@@ -118,7 +118,7 @@ export const OverlayChat = observer(
 
         const containerStyle: React.CSSProperties = {
             position: 'fixed',
-            top: selectedEl.top - 8,
+            top: Math.max(74 + 8, selectedEl.top - 8),
             left: selectedEl.left + selectedEl.width / 2,
             transform: 'translate(-50%, 0)',
             transformOrigin: 'center center',


### PR DESCRIPTION

## Description

Closes: #1503

This PR addresses the issue where the "Chat with AI" button floats above the app bar. The changes ensure that the button is properly positioned below the app bar.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
