### PR TITLE
fix: context-menu is closing after clicking outside the menu

### DIFF
--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -4,7 +4,15 @@ import { CheckIcon, ChevronRightIcon, DotFilledIcon } from '@radix-ui/react-icon
 
 import { cn } from '../utils';
 
-const ContextMenu = ContextMenuPrimitive.Root;
+const ContextMenu = ({
+    ...props
+}: React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Root>) => (
+    <ContextMenuPrimitive.Root
+        modal={false} // Setting modal to false allows clicks outside the menu to dismiss it, including canvas clicks
+        {...props}
+    />
+);
+ContextMenu.displayName = ContextMenuPrimitive.Root.displayName;
 
 const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
 


### PR DESCRIPTION
## Description

This PR fixes an issue with the context menu behavior in the editor where users couldn't dismiss the menu by clicking within the canvas area. Previously, users had to click outside the entire canvas to dismiss the context menu, which created a poor user experience.

The fix modifies the ContextMenu component in the UI package to set `modal={false}` on the underlying Radix UI component. This change helps fixing the right-click bug.

Here's the [radix docs](https://www.radix-ui.com/primitives/docs/components/context-menu#root) source for modal

## Related Issues

closes #1551 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Other (please describe):

## Testing

No tests added

## Screenshots (if applicable)


https://github.com/user-attachments/assets/77a42d3d-bc28-4530-8d66-ad023f6566be



## Additional Notes

<!-- Add any other context about the PR here -->
