### PR TITLE
Save when sending messages, not when applying code

### DIFF
--- a/apps/studio/src/lib/editor/engine/chat/code.ts
+++ b/apps/studio/src/lib/editor/engine/chat/code.ts
@@ -19,7 +19,7 @@ export class ChatCodeManager {
         this.processor = new CodeBlockProcessor();
     }
 
-    async applyCode(messageId: string, commitMessage?: string) {
+    async applyCode(messageId: string) {
         const message = this.chat.conversation.current?.getMessageById(messageId);
         if (!message) {
             console.error('No message found with id', messageId);
@@ -29,11 +29,6 @@ export class ChatCodeManager {
             console.error('Can only apply code to assistant messages');
             return;
         }
-
-        this.projectsManager.versions?.createCommit(
-            commitMessage ?? 'Save before applying code',
-            false,
-        );
 
         const fileToCodeBlocks = this.getFileToCodeBlocks(message);
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Shift commit creation from `applyCode` to `sendChatToAi` to save changes before sending messages to AI.
> 
>   - **Behavior**:
>     - Move commit creation from `applyCode` in `code.ts` to `sendChatToAi` in `index.ts`.
>     - Commits are now created before sending messages to AI, not before applying code.
>   - **Functions**:
>     - Remove `commitMessage` parameter from `applyCode()` in `code.ts`.
>     - Add commit creation in `sendChatToAi()` in `index.ts`.
>   - **Misc**:
>     - Remove `userPrompt` parameter from `handleChatResponse()`, `handleNewCoreMessages()`, and `autoApplyCode()` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 8f72c04a3619469d2912dd2562876418161465b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->