### PR TITLE
Fix toast should not be showing

### DIFF
--- a/apps/studio/src/lib/projects/versions.ts
+++ b/apps/studio/src/lib/projects/versions.ts
@@ -48,9 +48,11 @@ export class VersionsManager {
     }> => {
         try {
             if (this.isSaving) {
-                toast({
-                    title: 'Backup already in progress',
-                });
+                if (showToast) {
+                    toast({
+                        title: 'Backup already in progress',
+                    });
+                }
                 return {
                     success: false,
                     errorReason: CreateCommitFailureReason.COMMIT_IN_PROGRESS,


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix conditional display of toast notification in `createCommit()` of `VersionsManager`.
> 
>   - **Behavior**:
>     - In `createCommit()` of `VersionsManager`, toast notification for 'Backup already in progress' is now conditional on `showToast` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 6d750605d7541d43bd6473e5feb531b10e70062f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->