### PR TITLE
Used more natural wording for "play" in Japanese translation

### DIFF
--- a/apps/studio/src/locales/ja/translation.json
+++ b/apps/studio/src/locales/ja/translation.json
@@ -188,7 +188,7 @@
         "runButton": {
             "portInUse": "ポートが使用中",
             "loading": "読み込み中",
-            "play": "再生",
+            "play": "起動",
             "retry": "再試行",
             "stop": "停止"
         }


### PR DESCRIPTION
## Description

Updated the Japanese translation for the "play" button text from "再生" (which means "playback/reproduction") to "起動" (which means "launch/start up"). This change provides a more natural wording in Japanese for the context of starting/running an application.

## Related Issues

<!-- Please add any related issues if available -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [x] Other: Translation improvement

## Testing

- Verified that the Japanese translation text is correctly displayed in the UI

- Confirmed the wording is more appropriate for the application context

## Additional Notes

This change only affects the Japanese localization file and improves the user experience for Japanese-speaking users by using more contextually appropriate terminology.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated Japanese translation for `play` button text in `translation.json` to use more contextually appropriate wording.
> 
>   - **Translation Update**:
>     - Changed Japanese translation for `play` button text from `"再生"` to `"起動"` in `translation.json`.
>     - Affects `runButton` section to better reflect the context of starting an application.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 32a3f06ae856fcfd7ae5e9e878920fd5db13109d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->