### PR TITLE
Set new div className to relative instead of absolute

### DIFF
--- a/apps/studio/src/lib/editor/engine/insert/index.ts
+++ b/apps/studio/src/lib/editor/engine/insert/index.ts
@@ -41,7 +41,7 @@ export class InsertManager {
                         width: '100px',
                         height: '100px',
                         backgroundColor: colors.blue[100],
-                        position: 'absolute',
+                        position: 'relative',
                     },
                     textContent: null,
                 };


### PR DESCRIPTION
## Description

fixed the issue: When a new div is dragged on the canvas, set it to relative instead of absolute.

## Related Issues

fixes#1614

## Type of Change

Changed the Tailwind CSS property of absolute to relative

- [x ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `position` from `absolute` to `relative` for new divs in `InsertManager.getDefaultProperties()` in `index.ts`.
> 
>   - **Behavior**:
>     - Change `position` from `absolute` to `relative` for new `div` elements in `InsertManager.getDefaultProperties()` in `index.ts`.
>     - Affects divs dragged onto the canvas, ensuring they are positioned relative to their container.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 2a59a78ea4bfae2d2ead45c065cd70be1176767a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->