### PR TITLE
feat: merge style action instead of replacing it

### DIFF
--- a/apps/studio/src/lib/editor/engine/history/helpers.ts
+++ b/apps/studio/src/lib/editor/engine/history/helpers.ts
@@ -96,6 +96,42 @@ export function undoAction(action: Action): Action {
 export function updateTransactionActions(actions: Action[], newAction: Action): Action[] {
     // Only allow one action per type, otherwise, overwrite the existing action
     if (actions.some((a) => a.type === newAction.type)) {
+        if (newAction.type === 'update-style') {
+            const existingAction = actions.find(
+                (a) => a.type === 'update-style',
+            ) as UpdateStyleAction;
+            if (existingAction) {
+                // Create a new action with merged targets
+                const mergedAction: UpdateStyleAction = {
+                    type: 'update-style',
+                    targets: [...existingAction.targets],
+                };
+
+                // Update or add targets from newAction
+                newAction.targets.forEach((newTarget) => {
+                    const existingTarget = mergedAction.targets.find(
+                        (et) => et.domId === newTarget.domId,
+                    );
+                    if (existingTarget) {
+                        existingTarget.change = {
+                            updated: {
+                                ...existingTarget.change.updated,
+                                ...newTarget.change.updated,
+                            },
+                            original: {
+                                ...existingTarget.change.original,
+                                ...newTarget.change.original,
+                            },
+                        };
+                    } else {
+                        mergedAction.targets.push(newTarget);
+                    }
+                });
+
+                return actions.map((a) => (a.type === 'update-style' ? mergedAction : a));
+            }
+        }
+
         return actions.map((a) => (a.type === newAction.type ? newAction : a));
     }
     return [...actions, newAction];

--- a/apps/studio/tests/history.test.ts
+++ b/apps/studio/tests/history.test.ts
@@ -1,5 +1,6 @@
 import { updateTransactionActions } from '@/lib/editor/engine/history/helpers';
-import { type Action } from '@onlook/models/actions';
+import { type Action, type UpdateStyleAction } from '@onlook/models/actions';
+import { StyleChangeType } from '@onlook/models/style';
 import { describe, expect, it } from 'bun:test';
 
 describe('updateTransactionActions', () => {
@@ -13,13 +14,311 @@ describe('updateTransactionActions', () => {
         expect(result[1]).toBe(newAction);
     });
 
-    it('should replace existing action of same type', () => {
-        const actions = [{ type: 'update-style' } as Action];
-        const newAction = { type: 'update-style' } as Action;
+    // Test case 1: Adding a new action when no action of same type exists
+    it('should add new action when no action of same type exists', () => {
+        const existingActions: Action[] = [
+            {
+                type: 'insert-element',
+                targets: [{ webviewId: 'w1', domId: '1', oid: 'o1' }],
+                location: { type: 'append', targetDomId: 'parent', targetOid: 'parent-oid' },
+                element: {
+                    domId: '1',
+                    oid: 'o1',
+                    tagName: 'div',
+                    attributes: {},
+                    styles: {},
+                    textContent: null,
+                    children: [],
+                },
+                editText: false,
+                pasteParams: null,
+                codeBlock: null,
+            },
+        ];
+        const newAction: Action = {
+            type: 'remove-element',
+            targets: [{ webviewId: 'w1', domId: '2', oid: 'o2' }],
+            location: { type: 'append', targetDomId: 'parent', targetOid: 'parent-oid' },
+            element: {
+                domId: '2',
+                oid: 'o2',
+                tagName: 'div',
+                attributes: {},
+                styles: {},
+                textContent: null,
+                children: [],
+            },
+            editText: false,
+            pasteParams: null,
+            codeBlock: null,
+        };
 
-        const result = updateTransactionActions(actions, newAction);
+        const result = updateTransactionActions(existingActions, newAction);
+        expect(result).toHaveLength(2);
+        expect(result).toContainEqual(newAction);
+    });
 
+    // Test case 2: Replacing non-style action with new action of same type
+    it('should replace existing non-style action with new action of same type', () => {
+        const existingActions: Action[] = [
+            {
+                type: 'insert-element',
+                targets: [{ webviewId: 'w1', domId: '1', oid: 'o1' }],
+                location: { type: 'append', targetDomId: 'parent', targetOid: 'parent-oid' },
+                element: {
+                    domId: '1',
+                    oid: 'o1',
+                    tagName: 'div',
+                    attributes: {},
+                    styles: {},
+                    textContent: null,
+                    children: [],
+                },
+                editText: false,
+                pasteParams: null,
+                codeBlock: null,
+            },
+        ];
+        const newAction: Action = {
+            type: 'insert-element',
+            targets: [{ webviewId: 'w1', domId: '2', oid: 'o2' }],
+            location: { type: 'append', targetDomId: 'parent', targetOid: 'parent-oid' },
+            element: {
+                domId: '2',
+                oid: 'o2',
+                tagName: 'div',
+                attributes: {},
+                styles: {},
+                textContent: null,
+                children: [],
+            },
+            editText: false,
+            pasteParams: null,
+            codeBlock: null,
+        };
+
+        const result = updateTransactionActions(existingActions, newAction);
         expect(result).toHaveLength(1);
-        expect(result[0]).toBe(newAction);
+        expect(result[0]).toEqual(newAction);
+    });
+
+    // Test case 3: Merging style actions for same target
+    it('should merge style changes for same target', () => {
+        const existingAction: UpdateStyleAction = {
+            type: 'update-style',
+            targets: [
+                {
+                    domId: '1',
+                    webviewId: 'w1',
+                    oid: 'o1',
+                    change: {
+                        updated: { color: { value: 'red', type: StyleChangeType.Value } },
+                        original: { color: { value: 'blue', type: StyleChangeType.Value } },
+                    },
+                },
+            ],
+        };
+
+        const newAction: UpdateStyleAction = {
+            type: 'update-style',
+            targets: [
+                {
+                    domId: '1',
+                    webviewId: 'w1',
+                    oid: 'o1',
+                    change: {
+                        updated: { fontSize: { value: '16px', type: StyleChangeType.Value } },
+                        original: { fontSize: { value: '14px', type: StyleChangeType.Value } },
+                    },
+                },
+            ],
+        };
+
+        const result = updateTransactionActions([existingAction], newAction);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe('update-style');
+        const mergedTarget = (result[0] as UpdateStyleAction).targets[0];
+        expect(mergedTarget.change.updated).toEqual({
+            color: { value: 'red', type: StyleChangeType.Value },
+            fontSize: { value: '16px', type: StyleChangeType.Value },
+        });
+        expect(mergedTarget.change.original).toEqual({
+            color: { value: 'blue', type: StyleChangeType.Value },
+            fontSize: { value: '14px', type: StyleChangeType.Value },
+        });
+    });
+
+    // Test case 4: Handling multiple style targets
+    it('should handle multiple style targets correctly', () => {
+        const existingAction: UpdateStyleAction = {
+            type: 'update-style',
+            targets: [
+                {
+                    domId: '1',
+                    webviewId: 'w1',
+                    oid: 'o1',
+                    change: {
+                        updated: { color: { value: 'red', type: StyleChangeType.Value } },
+                        original: { color: { value: 'blue', type: StyleChangeType.Value } },
+                    },
+                },
+                {
+                    domId: '2',
+                    webviewId: 'w1',
+                    oid: 'o2',
+                    change: {
+                        updated: { color: { value: 'green', type: StyleChangeType.Value } },
+                        original: { color: { value: 'yellow', type: StyleChangeType.Value } },
+                    },
+                },
+            ],
+        };
+
+        const newAction: UpdateStyleAction = {
+            type: 'update-style',
+            targets: [
+                {
+                    domId: '1',
+                    webviewId: 'w1',
+                    oid: 'o1',
+                    change: {
+                        updated: { fontSize: { value: '16px', type: StyleChangeType.Value } },
+                        original: { fontSize: { value: '14px', type: StyleChangeType.Value } },
+                    },
+                },
+            ],
+        };
+
+        const result = updateTransactionActions([existingAction], newAction);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe('update-style');
+        const targets = (result[0] as UpdateStyleAction).targets;
+        expect(targets).toHaveLength(2);
+
+        // First target should be merged
+        expect(targets[0].change.updated).toEqual({
+            color: { value: 'red', type: StyleChangeType.Value },
+            fontSize: { value: '16px', type: StyleChangeType.Value },
+        });
+
+        // Second target should remain unchanged
+        expect(targets[1].change.updated).toEqual({
+            color: { value: 'green', type: StyleChangeType.Value },
+        });
+    });
+
+    // Test case 5: Empty actions array
+    it('should handle empty actions array', () => {
+        const newAction: Action = {
+            type: 'insert-element',
+            targets: [{ webviewId: 'w1', domId: '1', oid: 'o1' }],
+            location: { type: 'append', targetDomId: 'parent', targetOid: 'parent-oid' },
+            element: {
+                domId: '1',
+                oid: 'o1',
+                tagName: 'div',
+                attributes: {},
+                styles: {},
+                textContent: null,
+                children: [],
+            },
+            editText: false,
+            pasteParams: null,
+            codeBlock: null,
+        };
+        const result = updateTransactionActions([], newAction);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toEqual(newAction);
+    });
+
+    // Test case 6: Multiple actions of different types
+    it('should handle multiple actions of different types', () => {
+        const existingActions: Action[] = [
+            {
+                type: 'insert-element',
+                targets: [{ webviewId: 'w1', domId: '1', oid: 'o1' }],
+                location: { type: 'append', targetDomId: 'parent', targetOid: 'parent-oid' },
+                element: {
+                    domId: '1',
+                    oid: 'o1',
+                    tagName: 'div',
+                    attributes: {},
+                    styles: {},
+                    textContent: null,
+                    children: [],
+                },
+                editText: false,
+                pasteParams: null,
+                codeBlock: null,
+            },
+            { type: 'update-style', targets: [] },
+        ];
+        const newAction: Action = {
+            type: 'insert-element',
+            targets: [{ webviewId: 'w1', domId: '2', oid: 'o2' }],
+            location: { type: 'append', targetDomId: 'parent', targetOid: 'parent-oid' },
+            element: {
+                domId: '2',
+                oid: 'o2',
+                tagName: 'div',
+                attributes: {},
+                styles: {},
+                textContent: null,
+                children: [],
+            },
+            editText: false,
+            pasteParams: null,
+            codeBlock: null,
+        };
+
+        const result = updateTransactionActions(existingActions, newAction);
+        expect(result).toHaveLength(2);
+        expect(result.find((a) => a.type === 'insert-element')).toEqual(newAction);
+        expect(result.find((a) => a.type === 'update-style')).toBeDefined();
+    });
+
+    // Test case 7: Custom style changes
+    it('should handle custom style changes correctly', () => {
+        const existingAction: UpdateStyleAction = {
+            type: 'update-style',
+            targets: [
+                {
+                    domId: '1',
+                    webviewId: 'w1',
+                    oid: 'o1',
+                    change: {
+                        updated: { customStyle: { value: 'value1', type: StyleChangeType.Custom } },
+                        original: {
+                            customStyle: { value: 'original1', type: StyleChangeType.Custom },
+                        },
+                    },
+                },
+            ],
+        };
+
+        const newAction: UpdateStyleAction = {
+            type: 'update-style',
+            targets: [
+                {
+                    domId: '1',
+                    webviewId: 'w1',
+                    oid: 'o1',
+                    change: {
+                        updated: { customStyle: { value: 'value2', type: StyleChangeType.Custom } },
+                        original: {
+                            customStyle: { value: 'original2', type: StyleChangeType.Custom },
+                        },
+                    },
+                },
+            ],
+        };
+
+        const result = updateTransactionActions([existingAction], newAction);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe('update-style');
+        const mergedTarget = (result[0] as UpdateStyleAction).targets[0];
+        expect(mergedTarget.change.updated).toEqual({
+            customStyle: { value: 'value2', type: StyleChangeType.Custom },
+        });
     });
 });

--- a/packages/ai/test/prompt/data/system.txt
+++ b/packages/ai/test/prompt/data/system.txt
@@ -1,4 +1,4 @@
-<role>Act as an expert React and Tailwind developer. Your goal is to analyze the provided code, understand the requested modifications, and implement them accurately while explaining your thought process.
+<role>You are running in Onlook to help users develop their app. Act as an expert React, Next.js and Tailwind developer. Your goal is to analyze the provided code, understand the requested modifications, and implement them accurately while explaining your thought process.
 Always use best practices when coding. Respect and use existing conventions, libraries, etc that are already present in the code base. If you add new jsx tags, make sure to properly close them. For example: all open <div> tags must be closed with a </div> tag.
 You are diligent and tireless! You NEVER leave comments describing code without implementing it! You always COMPLETELY IMPLEMENT the needed code!
 Take requests for changes to the supplied code. If the request is ambiguous, ask questions.


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [x] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor style action handling in `updateTransactionActions` to merge updates, with new tests and a minor prompt update.
> 
>   - **Behavior**:
>     - Refactor `updateTransactionActions` in `helpers.ts` to merge `update-style` actions instead of replacing them.
>     - Introduce `handleUpdateStyleAction` to merge style changes for the same target.
>   - **Tests**:
>     - Add test cases in `history.test.ts` for merging style actions, handling multiple style targets, and custom style changes.
>   - **Misc**:
>     - Update role description in `system.txt` to include Next.js expertise.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for a14c329b136558d73101db6d81b9a9b31d635b96. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->