### PR TITLE
refactor: change position of brand popover

### DIFF
--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
@@ -1,16 +1,16 @@
 import { useEditorEngine } from '@/components/Context';
+import type { CompoundStyle } from '@/lib/editor/styles/models';
 import type { ColorItem } from '@/routes/editor/LayersPanel/BrandTab/ColorPanel/ColorPalletGroup';
 import { Icons } from '@onlook/ui/icons/index';
 import { Input } from '@onlook/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@onlook/ui/popover';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@onlook/ui/tabs';
 import { Color } from '@onlook/utility';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
+import { isBackgroundImageEmpty } from '.';
 import ColorButton from './ColorButton';
 import ColorPickerContent from './ColorPicker';
 import ImagePickerContent from './ImagePicker';
-import type { CompoundStyle } from '@/lib/editor/styles/models';
-import { isBackgroundImageEmpty } from '.';
 
 interface ColorBrandPickerProps {
     color: Color;
@@ -131,7 +131,11 @@ const BrandPopoverPicker = memo(
                 <PopoverTrigger>
                     <ColorButton value={color} onClick={() => toggleOpen(!isOpen)} />
                 </PopoverTrigger>
-                <PopoverContent className="backdrop-blur-lg z-10 rounded-lg p-0 shadow-xl overflow-hidden w-56 fixed -left-60">
+                <PopoverContent
+                    className="backdrop-blur-lg z-10 rounded-lg p-0 shadow-xl overflow-hidden w-56"
+                    side="left"
+                    align="start"
+                >
                     <div>
                         <Tabs defaultValue={defaultValue} className="bg-transparent pb-0">
                             <TabsList className="bg-transparent px-2 m-0 gap-2">

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
@@ -131,10 +131,7 @@ const BrandPopoverPicker = memo(
                 <PopoverTrigger>
                     <ColorButton value={color} onClick={() => toggleOpen(!isOpen)} />
                 </PopoverTrigger>
-                <PopoverContent
-                    align="end"
-                    className="backdrop-blur-lg z-10 rounded-lg p-0 shadow-xl overflow-hidden w-56"
-                >
+                <PopoverContent className="backdrop-blur-lg z-10 rounded-lg p-0 shadow-xl overflow-hidden w-56 fixed -left-60">
                     <div>
                         <Tabs defaultValue={defaultValue} className="bg-transparent pb-0">
                             <TabsList className="bg-transparent px-2 m-0 gap-2">


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Keep the Brand Popover Picker stay in the left of input
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [x] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

https://github.com/user-attachments/assets/df0c93a9-a91b-4e5f-a03b-b38048324572


## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `BrandPopoverPicker` in `ColorBrandPicker.tsx` to align `PopoverContent` to the start and position it on the left.
> 
>   - **Behavior**:
>     - In `ColorBrandPicker.tsx`, `PopoverContent` in `BrandPopoverPicker` now aligns to the `start` and appears on the `left` side of the input.
>   - **Imports**:
>     - Reorder imports in `ColorBrandPicker.tsx` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 1a2edbb506add78efa0b0beb467bd9e7b668a966. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->