### PR TITLE
refactor: refresh webview after update brand color

### DIFF
--- a/apps/studio/src/lib/editor/engine/style/index.ts
+++ b/apps/studio/src/lib/editor/engine/style/index.ts
@@ -33,9 +33,9 @@ export class StyleManager {
         );
     }
 
-    updateCustom(style: string, value: string) {
+    updateCustom(style: string, value: string, domIds: string[] = []) {
         const styleObj = { [style]: value };
-        const action = this.getUpdateStyleAction(styleObj, [], StyleChangeType.Custom);
+        const action = this.getUpdateStyleAction(styleObj, domIds, StyleChangeType.Custom);
         this.editorEngine.action.run(action);
         this.updateStyleNoAction(styleObj);
     }

--- a/apps/studio/src/lib/editor/engine/theme/index.ts
+++ b/apps/studio/src/lib/editor/engine/theme/index.ts
@@ -335,6 +335,7 @@ export class ThemeManager {
         newName: string,
         parentName?: string,
         theme?: Theme,
+        shouldSaveToConfig: boolean = false,
     ) {
         const projectRoot = this.projectsManager.project?.folderPath;
         if (!projectRoot) {
@@ -344,17 +345,37 @@ export class ThemeManager {
         try {
             // For new colors, pass empty originalKey and parentName
             const originalKey = this.brandColors[groupName]?.[index]?.originalKey || '';
-            await invokeMainChannel(MainChannels.UPDATE_TAILWIND_CONFIG, {
-                projectRoot,
-                originalKey,
-                newColor: newColor.toHex(),
-                newName,
-                parentName,
-                theme,
-            });
 
-            // Refresh colors after update
-            this.scanConfig();
+            // If is selected element, update the color in real-time
+            // Base on the class name, find the styles to update
+
+            // Only save to Tailwind config if explicitly requested
+            if (shouldSaveToConfig) {
+                await invokeMainChannel(MainChannels.UPDATE_TAILWIND_CONFIG, {
+                    projectRoot,
+                    originalKey,
+                    newColor: newColor.toHex(),
+                    newName,
+                    parentName,
+                    theme,
+                });
+
+                // Refresh colors after update
+                this.scanConfig();
+
+                // Force a theme refresh for all frames
+                await Promise.all(
+                    this.editorEngine.canvas.frames.map(async (frame) => {
+                        const webview = this.editorEngine.webviews.getWebview(frame.id);
+                        if (webview) {
+                            await webview.executeJavaScript(
+                                `window.api?.setTheme("${frame.theme}")`,
+                            );
+                            await this.editorEngine.elements.refreshSelectedElements(webview);
+                        }
+                    }),
+                );
+            }
         } catch (error) {
             console.error('Error updating color:', error);
         }

--- a/apps/studio/src/lib/editor/engine/theme/index.ts
+++ b/apps/studio/src/lib/editor/engine/theme/index.ts
@@ -371,7 +371,10 @@ export class ThemeManager {
                             await webview.executeJavaScript(
                                 `window.api?.setTheme("${frame.theme}")`,
                             );
-                            await this.editorEngine.elements.refreshSelectedElements(webview);
+
+                            setTimeout(() => {
+                                this.editorEngine.elements.refreshSelectedElements(webview);
+                            }, 500);
                         }
                     }),
                 );

--- a/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/ColorPalletGroup.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/ColorPalletGroup.tsx
@@ -43,6 +43,13 @@ interface BrandPalletGroupProps {
         newName: string,
         parentName?: string,
     ) => void;
+    onColorChangeEnd?: (
+        groupName: string,
+        colorIndex: number,
+        newColor: Color,
+        newName: string,
+        parentName?: string,
+    ) => void;
     onDuplicate?: (colorName: string) => void;
     isDefaultPalette?: boolean;
 }
@@ -54,6 +61,7 @@ export const BrandPalletGroup = ({
     onRename,
     onDelete,
     onColorChange,
+    onColorChangeEnd,
     onDuplicate,
     isDefaultPalette = false,
 }: BrandPalletGroupProps) => {
@@ -74,6 +82,17 @@ export const BrandPalletGroup = ({
     ) => {
         if (onColorChange) {
             onColorChange(title.toLowerCase(), index, newColor, newName, parentName);
+        }
+    };
+
+    const handleColorChangeEnd = (
+        index: number,
+        newColor: Color,
+        newName: string,
+        parentName?: string,
+    ) => {
+        if (onColorChangeEnd) {
+            onColorChangeEnd(title.toLowerCase(), index, newColor, newName, parentName);
         }
         setEditingColorIndex(null);
         setIsAddingNewColor(false);
@@ -232,6 +251,9 @@ export const BrandPalletGroup = ({
                                         onColorChange={(newColor, newName) =>
                                             handleColorChange(index, newColor, newName)
                                         }
+                                        onColorChangeEnd={(newColor, newName) =>
+                                            handleColorChangeEnd(index, newColor, newName)
+                                        }
                                         isDefaultPalette={isDefaultPalette}
                                         existedName={existedName}
                                     />
@@ -378,6 +400,14 @@ export const BrandPalletGroup = ({
                             onClose={() => setIsAddingNewColor(false)}
                             onColorChange={(newColor, newName) =>
                                 handleColorChange(
+                                    colors?.length || 0,
+                                    newColor,
+                                    newName,
+                                    title.toLowerCase(),
+                                )
+                            }
+                            onColorChangeEnd={(newColor, newName) =>
+                                handleColorChangeEnd(
                                     colors?.length || 0,
                                     newColor,
                                     newName,

--- a/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/ColorPopover.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/ColorPopover.tsx
@@ -9,6 +9,7 @@ export const ColorPopover = ({
     brandColor,
     onClose,
     onColorChange,
+    onColorChangeEnd,
     isDefaultPalette = false,
     existedName,
 }: {
@@ -16,6 +17,7 @@ export const ColorPopover = ({
     brandColor: string;
     onClose?: () => void;
     onColorChange?: (newColor: Color, newName: string) => void;
+    onColorChangeEnd?: (newColor: Color, newName: string) => void;
     isDefaultPalette?: boolean;
     existedName?: string[];
 }) => {
@@ -25,6 +27,9 @@ export const ColorPopover = ({
 
     const handleColorChange = (newColor: Color) => {
         setEditedColor(newColor);
+        if (onColorChange) {
+            onColorChange(newColor, editedName);
+        }
     };
 
     const handleSave = () => {
@@ -33,8 +38,8 @@ export const ColorPopover = ({
             return;
         }
 
-        if (onColorChange) {
-            onColorChange(editedColor, editedName);
+        if (onColorChangeEnd) {
+            onColorChangeEnd(editedColor, editedName);
         }
 
         if (onClose) {

--- a/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/index.tsx
@@ -41,7 +41,18 @@ const ColorPanel = observer(({ onClose }: ColorPanelProps) => {
         parentName?: string,
         theme?: Theme,
     ) => {
-        themeManager.update(groupName, index, newColor, newName, parentName, theme);
+        themeManager.update(groupName, index, newColor, newName, parentName, theme, false);
+    };
+
+    const handleColorChangeEnd = (
+        groupName: string,
+        index: number,
+        newColor: Color,
+        newName: string,
+        parentName?: string,
+        theme?: Theme,
+    ) => {
+        themeManager.update(groupName, index, newColor, newName, parentName, theme, true);
     };
 
     const handleDuplicate = (
@@ -123,6 +134,7 @@ const ColorPanel = observer(({ onClose }: ColorPanelProps) => {
                             onRename={handleRename}
                             onDelete={(colorName) => handleDelete(groupName, colorName)}
                             onColorChange={handleColorChange}
+                            onColorChangeEnd={handleColorChangeEnd}
                             onDuplicate={(colorName) => handleDuplicate(groupName, colorName)}
                         />
                     ))}
@@ -173,6 +185,9 @@ const ColorPanel = observer(({ onClose }: ColorPanelProps) => {
                         onRename={handleRename}
                         onDelete={(colorItem) => handleDelete(colorName, colorItem)}
                         onColorChange={(groupName, colorIndex, newColor) =>
+                            handleDefaultColorChange(colorName, colorIndex, newColor)
+                        }
+                        onColorChangeEnd={(groupName, colorIndex, newColor) =>
                             handleDefaultColorChange(colorName, colorIndex, newColor)
                         }
                         onDuplicate={(colorItem) => handleDuplicate(colorName, colorItem, true)}


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Refresh webview after updating brand color to get the latest setting
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

https://github.com/user-attachments/assets/c3dbe88d-a528-4468-977c-741d2f2d47d8


## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refresh webview after brand color updates in `ThemeManager` and add `onColorChangeEnd` handlers in color components.
> 
>   - **Behavior**:
>     - Refresh webview after updating brand color in `ThemeManager.update()` when `shouldSaveToConfig` is true.
>     - Execute JavaScript to set theme and refresh selected elements in webview.
>   - **Components**:
>     - Add `onColorChangeEnd` handler in `ColorPanel`, `ColorPalletGroup`, and `ColorPopover` to trigger updates when color editing is finished.
>     - Modify `ColorPopover` to save changes on close.
>   - **Functions**:
>     - Update `updateCustom()` in `StyleManager` to accept `domIds` parameter for targeted updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for c52bff7f57e84c18c743733c69356ae76d35845b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->