### PR TITLE
Enable brand panel

### DIFF
--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
@@ -7,8 +7,7 @@ import { Icons } from '@onlook/ui/icons';
 import { Color, isColorEmpty } from '@onlook/utility';
 import { observer } from 'mobx-react-lite';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-// import { BrandPopoverPicker } from './ColorBrandPicker';
-import { PopoverPicker } from './Popover';
+import { BrandPopoverPicker } from './ColorBrandPicker';
 
 const stripUrlWrapper = (url: string) => {
     return url.replace(/^url\((['"]?)(.*)\1\)/, '$2');
@@ -200,21 +199,21 @@ const ColorInput = observer(
         };
         return (
             <div className="w-32 p-[6px] gap-2 flex flex-row rounded cursor-pointer bg-background-onlook/75">
-                {/* <BrandPopoverPicker
-                    color={color}
-                    onChange={sendStyleUpdate}
-                    onChangeEnd={sendStyleUpdate}
-                    backgroundImage={backgroundImage}
-                    compoundStyle={compoundStyle}
-                /> */}
-
-                <PopoverPicker
+                <BrandPopoverPicker
                     color={color}
                     onChange={sendStyleUpdate}
                     onChangeEnd={sendStyleUpdate}
                     backgroundImage={backgroundImage}
                     compoundStyle={compoundStyle}
                 />
+
+                {/* <PopoverPicker
+                        color={color}
+                        onChange={sendStyleUpdate}
+                        onChangeEnd={sendStyleUpdate}
+                        backgroundImage={backgroundImage}
+                        compoundStyle={compoundStyle}
+                    /> */}
                 <ColorTextInput
                     value={value}
                     isFocused={isFocused}

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -156,7 +156,7 @@ export const LayersPanel = observer(() => {
 
                 <button
                     className={cn(
-                        'w-16 h-16 rounded-xl flex flex-col items-center justify-center gap-1.5 p-2 hidden',
+                        'w-16 h-16 rounded-xl flex flex-col items-center justify-center gap-1.5 p-2',
                         selectedTab === TabValue.BRAND && isLocked
                             ? 'bg-accent text-foreground border-[0.5px] border-foreground/20'
                             : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable brand panel by activating `BrandPopoverPicker` in `ColorInput` and making brand tab visible in `LayersPanel`.
> 
>   - **Behavior**:
>     - Enable `BrandPopoverPicker` in `ColorInput` by uncommenting its usage in `index.tsx`.
>     - Make brand tab visible in `LayersPanel` by removing `hidden` class from the button in `index.tsx`.
>   - **Misc**:
>     - Comment out `PopoverPicker` in `ColorInput` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 6a1046f12431f09efdbfcf9fba3575405f222ef8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->