### PR TITLE
fix: error when setting text color

### DIFF
--- a/apps/studio/common/helpers/twTranslator/index.ts
+++ b/apps/studio/common/helpers/twTranslator/index.ts
@@ -979,12 +979,13 @@ export const propertyMap: Map<
     ['clip-path', (val) => `[clip-path:${getCustomVal(val)}]`],
     [
         'color',
-        (val) =>
+        (val, isCustom = false) =>
             ({
                 transparent: 'text-transparent',
                 currentColor: 'text-current',
                 currentcolor: 'text-current',
-            })[val] ?? (isColor(val, true) ? `text-[${getCustomVal(val)}]` : ''),
+            })[val] ??
+            (isCustom ? `text-${val}` : isColor(val, true) ? `text-[${getCustomVal(val)}]` : ''),
     ],
     ['color-scheme', (val) => `[color-scheme:${getCustomVal(val)}]`],
     ['column-count', (val) => `[column-count:${getCustomVal(val)}]`],

--- a/apps/studio/electron/main/code/files.ts
+++ b/apps/studio/electron/main/code/files.ts
@@ -23,33 +23,51 @@ export async function writeFile(
     content: string,
     encoding: 'utf8' | 'base64' = 'utf8',
 ): Promise<void> {
+    if (!filePath) {
+        throw new Error('File path is required');
+    }
+
     try {
-        if (!content || content.trim() === '') {
-            throw new Error(`New content is empty: ${filePath}`);
-        }
         const fullPath = path.resolve(filePath);
         const isNewFile = !existsSync(fullPath);
+
+        let fileContent: string | Buffer = content;
+        if (encoding === 'base64') {
+            try {
+                // Strip data URL prefix if present and validate base64
+                const base64Data = content.replace(/^data:[^,]+,/, '');
+                if (!isValidBase64(base64Data)) {
+                    throw new Error('Invalid base64 content');
+                }
+                fileContent = Buffer.from(base64Data, 'base64');
+            } catch (e) {
+                throw new Error(`Invalid base64 content: ${e.message}`);
+            }
+        }
 
         // Ensure parent directory exists
         const parentDir = path.dirname(fullPath);
         await fs.mkdir(parentDir, { recursive: true });
 
-        // Handle base64 encoded content
-        let fileContent = content;
-        if (encoding === 'base64') {
-            // Strip data URL prefix if present
-            const base64Data = content.replace(/^data:[^,]+,/, '');
-            fileContent = Buffer.from(base64Data, 'base64').toString('base64');
-        }
-
-        writeFileAtomic(fullPath, fileContent, encoding);
+        // Perform atomic write with proper error handling
+        await writeFileAtomic(fullPath, fileContent, { encoding });
 
         if (isNewFile) {
             console.log('New file created:', fullPath);
         }
     } catch (error: any) {
-        console.error('Error writing to file:', error);
-        throw error;
+        const errorMessage = `Failed to write to ${filePath}: ${error.message}`;
+        console.error(errorMessage);
+        throw new Error(errorMessage);
+    }
+}
+
+// Helper function to validate base64 strings
+function isValidBase64(str: string): boolean {
+    try {
+        return Buffer.from(str, 'base64').toString('base64') === str;
+    } catch {
+        return false;
     }
 }
 

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
@@ -72,7 +72,9 @@ const ColorGroup = ({
                             className="w-5 h-5 rounded-sm"
                             style={{ backgroundColor: color.lightColor }}
                         />
-                        <span className="text-xs font-normal truncate max-w-32">{color.name}</span>
+                        <span className="text-xs font-normal truncate max-w-32">
+                            {toNormalCase(color.name)}
+                        </span>
                     </div>
                 ))}
         </div>


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- When selected a custom color for text, the classname have not been updated.
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes text color setting for custom colors and improves file writing error handling.
> 
>   - **Behavior**:
>     - Fixes text color setting for custom colors in `twTranslator/index.ts` by updating the `color` property mapping to handle `isCustom` flag.
>   - **Error Handling**:
>     - Adds file path validation and improves base64 content validation in `writeFile()` in `files.ts`.
>     - Enhances error messages for file writing failures in `files.ts`.
>   - **UI**:
>     - Normalizes color names in `ColorBrandPicker.tsx` using `toNormalCase()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 6a6b1f04f879f84c8bbb0501c0c65aeaf7f0b8cf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->