### PR TITLE
Revert freestyle prepareDir

### DIFF
--- a/apps/studio/electron/main/hosting/index.ts
+++ b/apps/studio/electron/main/hosting/index.ts
@@ -21,18 +21,16 @@ import {
 } from '@onlook/models/hosting';
 import { isEmptyString, isNullOrUndefined } from '@onlook/utility';
 import {
-    type DeploymentSource,
     type FreestyleDeployWebConfiguration,
     type FreestyleDeployWebSuccessResponse,
-    type FreestyleFile,
 } from 'freestyle-sandboxes';
-import { prepareDirForDeployment } from 'freestyle-sandboxes/utils';
 import { mainWindow } from '..';
 import analytics from '../analytics';
 import { getRefreshedAuthTokens } from '../auth';
 import {
     postprocessNextBuild,
     preprocessNextBuild,
+    serializeFiles,
     updateGitignore,
     type FileRecord,
 } from './helpers';
@@ -87,15 +85,7 @@ class HostingManager {
 
             // Serialize the files for deployment
             const NEXT_BUILD_OUTPUT_PATH = `${folderPath}/${CUSTOM_OUTPUT_DIR}/standalone`;
-            const source: DeploymentSource = (await prepareDirForDeployment(
-                NEXT_BUILD_OUTPUT_PATH,
-            )) as {
-                files: {
-                    [key: string]: FreestyleFile;
-                };
-                kind: 'files';
-            };
-            const files: FileRecord = source.files;
+            const files = await serializeFiles(NEXT_BUILD_OUTPUT_PATH);
 
             this.emitState(PublishStatus.LOADING, 'Deploying project...');
             timer.log('Files serialized, sending to Freestyle...');


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `prepareDirForDeployment` usage in `HostingManager` and replaces it with `serializeFiles` for deployment file serialization.
> 
>   - **Behavior**:
>     - Reverts the use of `prepareDirForDeployment` in `HostingManager` class in `index.ts`.
>     - Replaces `prepareDirForDeployment` with `serializeFiles` for file serialization in deployment process.
>   - **Functions**:
>     - Removes `prepareDirForDeployment` usage and replaces it with `serializeFiles` in `publish()` method.
>   - **Misc**:
>     - Removes unused imports `DeploymentSource` and `FreestyleFile` from `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for d58a34498189fb5d25a518433104ca1e8d5ed886. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->