### PR TITLE
fix error when duplicate color

### DIFF
--- a/apps/studio/src/lib/editor/engine/theme/index.ts
+++ b/apps/studio/src/lib/editor/engine/theme/index.ts
@@ -464,15 +464,7 @@ export class ThemeManager {
                         : colorToDuplicate.lightColor,
                 );
 
-                await this.update(
-                    groupName,
-                    group.length,
-                    color,
-                    newName,
-                    groupName.toLowerCase(),
-                    theme,
-                    true,
-                );
+                await this.update(groupName, group.length, color, newName, groupName, theme, true);
 
                 this.scanConfig();
             }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Fix error when duplicate a color with more than 2 words (example: Test color)
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->
Before

https://github.com/user-attachments/assets/28f38e6e-5727-45ff-9037-57c19c99d650



After
https://github.com/user-attachments/assets/d72ef0a1-413b-47ae-83aa-e3a9e2a245f8


## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error in `ThemeManager.duplicate()` when duplicating colors with multi-word names by correcting `update()` parameters.
> 
>   - **Bug Fix**:
>     - Fixes error in `duplicate()` method in `index.ts` when duplicating colors with names containing more than two words.
>     - Changes `update()` call to use `groupName` instead of `groupName.toLowerCase()` for the `parentName` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 515a87fd9f6c9505c6d24a3fc858d2260251dd2d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->