### PR TITLE
Remove selecting first element

### DIFF
--- a/apps/studio/src/routes/editor/WebviewArea/Frame.tsx
+++ b/apps/studio/src/routes/editor/WebviewArea/Frame.tsx
@@ -97,12 +97,6 @@ const Frame = observer(
             const state = editorEngine.webviews.computeState(body);
             editorEngine.webviews.setState(webview, state);
 
-            if (state === WebviewState.DOM_ONLOOK_ENABLED) {
-                setTimeout(() => {
-                    selectFirstElement(webview);
-                }, 1000);
-            }
-
             setTimeout(() => {
                 getDarkMode(webview);
             }, 100);
@@ -382,13 +376,6 @@ const Frame = observer(
                     )}
                 </>
             );
-        }
-
-        async function selectFirstElement(webview: Electron.WebviewTag) {
-            const domEl = await webview.executeJavaScript(`window.api?.getFirstOnlookElement()`);
-            if (domEl) {
-                editorEngine.elements.click([domEl], webview);
-            }
         }
 
         return (


### PR DESCRIPTION
## Description

Since this is no longer needed, it's doing more harm than good. 

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `selectFirstElement` function and its invocation in `Frame.tsx`, no longer selecting the first element for `WebviewState.DOM_ONLOOK_ENABLED`.
> 
>   - **Behavior**:
>     - Removes `selectFirstElement` function and its invocation in `Frame.tsx`.
>     - No longer selects the first element when `state === WebviewState.DOM_ONLOOK_ENABLED`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 4f1ba0a3fd65612ee2e99cc7aa83f39a097a24c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->