### PR TITLE
Fix opacity input validation

### DIFF
--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/NumberUnitInput.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/NumberUnitInput.tsx
@@ -10,6 +10,9 @@ import { toast } from '@onlook/ui/use-toast';
 import { observer } from 'mobx-react-lite';
 import { type ChangeEvent, useEffect, useState } from 'react';
 
+const numberWithinRange = (number: number, min: number, max: number): number =>
+    Math.min(Math.max(number, min), max);
+
 const NumberUnitInput = observer(
     ({
         elementStyle,
@@ -97,7 +100,7 @@ const NumberUnitInput = observer(
                 const max = elementStyle.params?.max ?? Infinity;
 
                 const parsedValue = Number.parseFloat(numberValue);
-                const clampedValue = Math.min(Math.max(parsedValue, min), max);
+                const clampedValue = numberWithinRange(parsedValue, min, max);
 
                 const value = parsedValueToString(clampedValue.toString(), unitValue);
                 sendStyleUpdate(value);

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/NumberUnitInput.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/NumberUnitInput.tsx
@@ -93,10 +93,13 @@ const NumberUnitInput = observer(
 
         const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
             if (e.currentTarget.value !== prevNumberValue) {
-                const value = parsedValueToString(
-                    Number.parseFloat(numberValue).toString(),
-                    unitValue,
-                );
+                const min = elementStyle.params?.min ?? -Infinity;
+                const max = elementStyle.params?.max ?? Infinity;
+
+                const parsedValue = Number.parseFloat(numberValue);
+                const clampedValue = Math.min(Math.max(parsedValue, min), max);
+
+                const value = parsedValueToString(clampedValue.toString(), unitValue);
                 sendStyleUpdate(value);
             }
             editorEngine.history.commitTransaction();


### PR DESCRIPTION
## Description

Fixed the bug #1727 where users could enter values above the maximum allowed range for numeric inputs, specifically with the opacity setting. The NumberUnitInput component wasn't enforcing the min/max constraints defined in the style configuration. Added proper validation to clamp numeric values to their defined ranges when the input loses focus.

## Related Issues

fixes #1727 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Tested various out-of-range inputs:
 - Large positive values (10000, 10000000, 101) were correctly clamped to 100%
 - Negative values (-100, -1) were correctly clamped to 0%

Values were properly clamped when:
 - Clicking elsewhere on the interface
 - Pressing Enter key

## Additional Notes

This fix improves user experience by enforcing the style constraints defined in the style configuration. Before this fix, users could enter invalid values. The change respects the min/max range while still allowing flexible input during typing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes input validation in `NumberUnitInput` to clamp values to defined min/max range on blur, addressing bug #1727.
> 
>   - **Behavior**:
>     - Fixes input validation in `NumberUnitInput` to clamp values to min/max range on blur.
>     - Handles out-of-range inputs by clamping to 0% or 100% for opacity.
>   - **Functions**:
>     - Modifies `handleBlur` to clamp `numberValue` using `min` and `max` from `elementStyle.params`.
>     - Uses `Math.min` and `Math.max` to ensure values are within range.
>   - **Testing**:
>     - Validated clamping with large positive and negative values.
>     - Ensured clamping occurs on blur and Enter key press.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 16d770b95e249ae7a5fb5ee8e4c708ffdf31825e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->