### PR TITLE
Make layer tab value nullable

### DIFF
--- a/apps/studio/src/lib/editor/engine/index.ts
+++ b/apps/studio/src/lib/editor/engine/index.ts
@@ -40,6 +40,7 @@ export class EditorEngine {
     private _settingsOpen: boolean = false;
     private _hotkeysOpen: boolean = false;
     private _publishOpen: boolean = false;
+    private _isLayersPanelLocked: boolean = false;
 
     private _editorMode: EditorMode = EditorMode.DESIGN;
     private _editorPanelTab: EditorTabValue = EditorTabValue.CHAT;
@@ -179,6 +180,13 @@ export class EditorEngine {
     }
     get pages() {
         return this.pagesManager;
+    }
+    get isLayersPanelLocked() {
+        return this._isLayersPanelLocked;
+    }
+
+    set isLayersPanelLocked(value: boolean) {
+        this._isLayersPanelLocked = value;
     }
 
     set mode(mode: EditorMode) {

--- a/apps/studio/src/lib/editor/engine/index.ts
+++ b/apps/studio/src/lib/editor/engine/index.ts
@@ -15,6 +15,7 @@ import { CodeManager } from './code';
 import { CopyManager } from './copy';
 import { ElementManager } from './element';
 import { ErrorManager } from './error';
+import { FontManager } from './font';
 import { GroupManager } from './group';
 import { HistoryManager } from './history';
 import { ImageManager } from './image';
@@ -27,7 +28,6 @@ import { StyleManager } from './style';
 import { TextEditingManager } from './text';
 import { ThemeManager } from './theme';
 import { WebviewManager } from './webview';
-import { FontManager } from './font';
 
 export class EditorEngine {
     private _plansOpen: boolean = false;
@@ -38,7 +38,7 @@ export class EditorEngine {
     private _editorMode: EditorMode = EditorMode.DESIGN;
     private _editorPanelTab: EditorTabValue = EditorTabValue.CHAT;
     private _settingsTab: SettingsTabValue = SettingsTabValue.PREFERENCES;
-    private _layersPanelTab: LayersPanelTabValue = LayersPanelTabValue.PAGES;
+    private _layersPanelTab: LayersPanelTabValue | null = null;
 
     private canvasManager: CanvasManager;
     private chatManager: ChatManager;
@@ -183,7 +183,7 @@ export class EditorEngine {
         this._settingsTab = tab;
     }
 
-    set layersPanelTab(tab: LayersPanelTabValue) {
+    set layersPanelTab(tab: LayersPanelTabValue | null) {
         this._layersPanelTab = tab;
     }
 

--- a/apps/studio/src/lib/editor/engine/index.ts
+++ b/apps/studio/src/lib/editor/engine/index.ts
@@ -1,4 +1,10 @@
-import { EditorMode, EditorTabValue, LayersPanelTabValue, SettingsTabValue } from '@/lib/models';
+import {
+    BrandTabValue,
+    EditorMode,
+    EditorTabValue,
+    LayersPanelTabValue,
+    SettingsTabValue,
+} from '@/lib/models';
 import type { ProjectsManager } from '@/lib/projects';
 import type { UserManager } from '@/lib/user';
 import { invokeMainChannel, sendAnalytics } from '@/lib/utils';
@@ -39,6 +45,7 @@ export class EditorEngine {
     private _editorPanelTab: EditorTabValue = EditorTabValue.CHAT;
     private _settingsTab: SettingsTabValue = SettingsTabValue.PREFERENCES;
     private _layersPanelTab: LayersPanelTabValue | null = null;
+    private _brandTab: BrandTabValue | null = null;
 
     private canvasManager: CanvasManager;
     private chatManager: ChatManager;
@@ -161,6 +168,9 @@ export class EditorEngine {
     get isHotkeysOpen() {
         return this._hotkeysOpen;
     }
+    get brandTab() {
+        return this._brandTab;
+    }
     get errors() {
         return this.errorManager;
     }
@@ -204,6 +214,10 @@ export class EditorEngine {
 
     set isPublishOpen(open: boolean) {
         this._publishOpen = open;
+    }
+
+    set brandTab(tab: BrandTabValue | null) {
+        this._brandTab = tab;
     }
 
     dispose() {

--- a/apps/studio/src/lib/models.ts
+++ b/apps/studio/src/lib/models.ts
@@ -34,7 +34,10 @@ export enum LayersPanelTabValue {
     IMAGES = 'images',
     WINDOWS = 'windows',
     BRAND = 'brand',
+    APPS = 'apps',
+}
+
+export enum BrandTabValue {
     COLORS = 'colors',
     FONTS = 'fonts',
-    APPS = 'apps',
 }

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/FontInput.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/FontInput.tsx
@@ -6,7 +6,7 @@ import type { SingleStyle } from '@/lib/editor/styles/models';
 import { Popover, PopoverContent, PopoverTrigger } from '@onlook/ui/popover';
 import type { Font } from '@onlook/models/assets';
 import { convertFontString } from '@onlook/utility';
-import { LayersPanelTabValue } from '@/lib/models';
+import { BrandTabValue, LayersPanelTabValue } from '@/lib/models';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@onlook/ui/tooltip';
 import { TooltipArrow } from '@radix-ui/react-tooltip';
 import { camelCase } from 'lodash';
@@ -43,7 +43,8 @@ export const FontInput = observer(
         };
 
         const handleAddNewFont = () => {
-            editorEngine.layersPanelTab = LayersPanelTabValue.FONTS;
+            editorEngine.layersPanelTab = LayersPanelTabValue.BRAND;
+            editorEngine.brandTab = BrandTabValue.FONTS;
         };
 
         const selectedFont = useMemo(

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/FontInput.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/FontInput.tsx
@@ -1,15 +1,15 @@
 import { useEditorEngine } from '@/components/Context';
-import { observer } from 'mobx-react-lite';
-import React, { useEffect, useState, useMemo } from 'react';
-import { Icons } from '@onlook/ui/icons';
 import type { SingleStyle } from '@/lib/editor/styles/models';
-import { Popover, PopoverContent, PopoverTrigger } from '@onlook/ui/popover';
-import type { Font } from '@onlook/models/assets';
-import { convertFontString } from '@onlook/utility';
 import { BrandTabValue, LayersPanelTabValue } from '@/lib/models';
+import type { Font } from '@onlook/models/assets';
+import { Icons } from '@onlook/ui/icons';
+import { Popover, PopoverContent, PopoverTrigger } from '@onlook/ui/popover';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@onlook/ui/tooltip';
+import { convertFontString } from '@onlook/utility';
 import { TooltipArrow } from '@radix-ui/react-tooltip';
 import { camelCase } from 'lodash';
+import { observer } from 'mobx-react-lite';
+import { useEffect, useMemo, useState } from 'react';
 
 export const FontInput = observer(
     ({
@@ -45,6 +45,7 @@ export const FontInput = observer(
         const handleAddNewFont = () => {
             editorEngine.layersPanelTab = LayersPanelTabValue.BRAND;
             editorEngine.brandTab = BrandTabValue.FONTS;
+            editorEngine.isLayersPanelLocked = true;
         };
 
         const selectedFont = useMemo(

--- a/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/BrandTab/ColorPanel/index.tsx
@@ -9,11 +9,7 @@ import { useEffect, useState } from 'react';
 import { BrandPalletGroup } from './ColorPalletGroup';
 import { ColorNameInput } from './ColorNameInput';
 
-interface ColorPanelProps {
-    onClose: () => void;
-}
-
-const ColorPanel = observer(({ onClose }: ColorPanelProps) => {
+const ColorPanel = observer(() => {
     const [theme, setTheme] = useState<Theme>(Theme.LIGHT);
     const [isAddingNewGroup, setIsAddingNewGroup] = useState(false);
 
@@ -68,7 +64,7 @@ const ColorPanel = observer(({ onClose }: ColorPanelProps) => {
     };
 
     const handleClose = () => {
-        onClose();
+        editorEngine.brandTab = null;
     };
 
     return (

--- a/apps/studio/src/routes/editor/LayersPanel/BrandTab/FontPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/BrandTab/FontPanel/index.tsx
@@ -1,20 +1,16 @@
+import { useEditorEngine } from '@/components/Context';
+import { FONT_VARIANTS } from '@onlook/models/constants';
 import { Button } from '@onlook/ui/button';
 import { Icons } from '@onlook/ui/icons';
 import { Input } from '@onlook/ui/input';
-import { observer } from 'mobx-react-lite';
-import { useRef, useState, useCallback, useEffect } from 'react';
 import debounce from 'lodash/debounce';
+import { observer } from 'mobx-react-lite';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FontFamily } from './FontFamily';
-import UploadModal from './UploadModal';
-import { useEditorEngine } from '@/components/Context';
 import type { FontFile } from './FontFiles';
-import { FONT_VARIANTS } from '@onlook/models/constants';
+import UploadModal from './UploadModal';
 
-interface FontPanelProps {
-    onClose?: () => void;
-}
-
-const FontPanel = observer(({ onClose }: FontPanelProps) => {
+const FontPanel = observer(() => {
     const [searchQuery, setSearchQuery] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
@@ -24,9 +20,7 @@ const FontPanel = observer(({ onClose }: FontPanelProps) => {
     const fontManager = editorEngine.font;
 
     const handleClose = () => {
-        if (onClose) {
-            onClose();
-        }
+        editorEngine.brandTab = null;
     };
 
     const handleUploadFont = () => {

--- a/apps/studio/src/routes/editor/LayersPanel/BrandTab/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/BrandTab/index.tsx
@@ -1,10 +1,10 @@
+import { useEditorEngine } from '@/components/Context';
+import { BrandTabValue } from '@/lib/models';
 import { Button } from '@onlook/ui/button';
 import { observer } from 'mobx-react-lite';
 import ColorPanel from './ColorPanel';
 import FontPanel from './FontPanel';
 import SystemFont from './FontPanel/SystemFont';
-import { useEditorEngine } from '@/components/Context';
-import { LayersPanelTabValue } from '@/lib/models';
 
 interface ColorSquareProps {
     color: string;
@@ -47,32 +47,14 @@ const BrandTab = observer(() => {
         '#ffd8de', // Pale Pink
     ];
 
-    // Toggle color panel visibility
-    const handleToggleColorPanel = () => {
-        if (editorEngine.layersPanelTab === LayersPanelTabValue.COLORS) {
-            editorEngine.layersPanelTab = LayersPanelTabValue.BRAND;
-        } else {
-            editorEngine.layersPanelTab = LayersPanelTabValue.COLORS;
-        }
-    };
-
-    // Toggle font panel visibility
-    const handleToggleFontPanel = () => {
-        if (editorEngine.layersPanelTab === LayersPanelTabValue.FONTS) {
-            editorEngine.layersPanelTab = LayersPanelTabValue.BRAND;
-        } else {
-            editorEngine.layersPanelTab = LayersPanelTabValue.FONTS;
-        }
-    };
-
     // If color panel is visible, show it instead of the main content
-    if (editorEngine.layersPanelTab === LayersPanelTabValue.COLORS) {
-        return <ColorPanel onClose={handleToggleColorPanel} />;
+    if (editorEngine.brandTab === BrandTabValue.COLORS) {
+        return <ColorPanel />;
     }
 
     // If font panel is visible, show it instead of the main content
-    if (editorEngine.layersPanelTab === LayersPanelTabValue.FONTS) {
-        return <FontPanel onClose={handleToggleFontPanel} />;
+    if (editorEngine.brandTab === BrandTabValue.FONTS) {
+        return <FontPanel />;
     }
 
     return (
@@ -94,7 +76,7 @@ const BrandTab = observer(() => {
                 <Button
                     variant="ghost"
                     className="w-full h-10 text-sm text-muted-foreground hover:text-foreground bg-background-secondary hover:bg-background-secondary/70 rounded-lg border border-white/5"
-                    onClick={handleToggleColorPanel}
+                    onClick={() => (editorEngine.brandTab = BrandTabValue.COLORS)}
                 >
                     Manage brand colors
                 </Button>
@@ -111,7 +93,7 @@ const BrandTab = observer(() => {
                 <Button
                     variant="ghost"
                     className="w-full h-10 text-sm text-muted-foreground hover:text-foreground bg-background-secondary hover:bg-background-secondary/70 rounded-lg border border-white/5"
-                    onClick={handleToggleFontPanel}
+                    onClick={() => (editorEngine.brandTab = BrandTabValue.FONTS)}
                 >
                     Manage site fonts
                 </Button>

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -22,7 +22,7 @@ export const LayersPanel = observer(() => {
     const editorEngine = useEditorEngine();
     const { t } = useTranslation();
 
-    const [selectedTab, setSelectedTab] = useState<LayersPanelTabValue>(LayersPanelTabValue.LAYERS);
+    const [selectedTab, setSelectedTab] = useState<LayersPanelTabValue | null>(null);
     const [isContentPanelOpen, setIsContentPanelOpen] = useState(false);
     const [isLocked, setIsLocked] = useState(false);
 
@@ -71,7 +71,7 @@ export const LayersPanel = observer(() => {
         }
     };
 
-    function tabChange(value: LayersPanelTabValue) {
+    function tabChange(value: LayersPanelTabValue | null) {
         setSelectedTab(value);
         editorEngine.layersPanelTab = value;
         setIsContentPanelOpen(true);

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -82,11 +82,6 @@ export const LayersPanel = observer(() => {
         tabChange(editorEngine.layersPanelTab);
     }, [editorEngine.layersPanelTab]);
 
-    const isBrandTab =
-        selectedTab === LayersPanelTabValue.COLORS ||
-        selectedTab === LayersPanelTabValue.FONTS ||
-        selectedTab === LayersPanelTabValue.BRAND;
-
     return (
         <div
             className={cn(
@@ -164,7 +159,7 @@ export const LayersPanel = observer(() => {
                 <button
                     className={cn(
                         'w-16 h-16 rounded-xl flex flex-col items-center justify-center gap-1.5 p-2',
-                        isBrandTab && isLocked
+                        selectedTab === LayersPanelTabValue.BRAND && isLocked
                             ? 'bg-accent text-foreground border-[0.5px] border-foreground/20'
                             : 'text-muted-foreground hover:text-foreground hover:bg-accent/50',
                     )}
@@ -236,7 +231,7 @@ export const LayersPanel = observer(() => {
                             {selectedTab === LayersPanelTabValue.PAGES && <PagesTab />}
                             {selectedTab === LayersPanelTabValue.IMAGES && <ImagesTab />}
                             {selectedTab === LayersPanelTabValue.WINDOWS && <WindowsTab />}
-                            {isBrandTab && <BrandTab />}
+                            {selectedTab === LayersPanelTabValue.BRAND && <BrandTab />}
                             {selectedTab === LayersPanelTabValue.APPS && <AppsTab />}
                         </div>
                     </div>

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -3,7 +3,6 @@ import { EditorMode, LayersPanelTabValue } from '@/lib/models';
 import { Icons } from '@onlook/ui/icons';
 import { cn } from '@onlook/ui/utils';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AppsTab from './AppsTab';
 import BrandTab from './BrandTab';
@@ -19,7 +18,7 @@ import ZoomControls from './ZoomControls';
 export const LayersPanel = observer(() => {
     const editorEngine = useEditorEngine();
     const { t } = useTranslation();
-    const [isLocked, setIsLocked] = useState(false);
+    const isLocked = editorEngine.isLayersPanelLocked;
     const selectedTab = editorEngine.layersPanelTab;
 
     const handleMouseEnter = (tab: LayersPanelTabValue) => {
@@ -59,10 +58,10 @@ export const LayersPanel = observer(() => {
 
     const handleClick = (tab: LayersPanelTabValue) => {
         if (selectedTab === tab && isLocked) {
-            setIsLocked(false);
+            editorEngine.isLayersPanelLocked = false;
         } else {
             editorEngine.layersPanelTab = tab;
-            setIsLocked(true);
+            editorEngine.isLayersPanelLocked = true;
         }
     };
 

--- a/apps/studio/src/routes/editor/LayersPanel/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/index.tsx
@@ -3,7 +3,7 @@ import { EditorMode, LayersPanelTabValue } from '@/lib/models';
 import { Icons } from '@onlook/ui/icons';
 import { cn } from '@onlook/ui/utils';
 import { observer } from 'mobx-react-lite';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import AppsTab from './AppsTab';
 import BrandTab from './BrandTab';
@@ -16,22 +16,17 @@ import PagesTab from './PageTab';
 import WindowsTab from './WindowsTab';
 import ZoomControls from './ZoomControls';
 
-const COMPONENT_DISCOVERY_ENABLED = false;
-
 export const LayersPanel = observer(() => {
     const editorEngine = useEditorEngine();
     const { t } = useTranslation();
-
-    const [selectedTab, setSelectedTab] = useState<LayersPanelTabValue | null>(null);
-    const [isContentPanelOpen, setIsContentPanelOpen] = useState(false);
     const [isLocked, setIsLocked] = useState(false);
+    const selectedTab = editorEngine.layersPanelTab;
 
     const handleMouseEnter = (tab: LayersPanelTabValue) => {
         if (isLocked) {
             return;
         }
-        setSelectedTab(tab);
-        setIsContentPanelOpen(true);
+        editorEngine.layersPanelTab = tab;
     };
 
     const isMouseInContentPanel = (e: React.MouseEvent<HTMLDivElement>): boolean => {
@@ -51,36 +46,25 @@ export const LayersPanel = observer(() => {
         if (!isLocked) {
             // This is to handle things like dropdown where the mouse is still in the content panel
             if (!isMouseInContentPanel(e)) {
-                setIsContentPanelOpen(false);
+                editorEngine.layersPanelTab = null;
             } else {
                 // TODO: Since mouse leave won't trigger anymore, we need to listen and check
                 //  if the mouse actually left the content panel and then close the content panel
             }
         } else {
             // If we're locked, return to the locked tab when mouse leaves
-            setSelectedTab(selectedTab);
+            editorEngine.layersPanelTab = selectedTab;
         }
     };
 
     const handleClick = (tab: LayersPanelTabValue) => {
         if (selectedTab === tab && isLocked) {
             setIsLocked(false);
-            setIsContentPanelOpen(false);
         } else {
-            tabChange(tab);
+            editorEngine.layersPanelTab = tab;
+            setIsLocked(true);
         }
     };
-
-    function tabChange(value: LayersPanelTabValue | null) {
-        setSelectedTab(value);
-        editorEngine.layersPanelTab = value;
-        setIsContentPanelOpen(true);
-        setIsLocked(true);
-    }
-
-    useEffect(() => {
-        tabChange(editorEngine.layersPanelTab);
-    }, [editorEngine.layersPanelTab]);
 
     return (
         <div
@@ -210,24 +194,14 @@ export const LayersPanel = observer(() => {
             </div>
 
             {/* Content panel */}
-            {isContentPanelOpen && (
+            {editorEngine.layersPanelTab && (
                 <>
-                    <div
-                        className="flex-1 w-[280px] bg-background/95 rounded-xl"
-                        onMouseEnter={() => setIsContentPanelOpen(true)}
-                    >
+                    <div className="flex-1 w-[280px] bg-background/95 rounded-xl">
                         <div className="border backdrop-blur-xl h-full shadow overflow-auto p-0 rounded-xl">
                             {selectedTab === LayersPanelTabValue.LAYERS && <LayersTab />}
-                            {selectedTab === LayersPanelTabValue.COMPONENTS &&
-                                (COMPONENT_DISCOVERY_ENABLED ? (
-                                    <ComponentsTab
-                                        components={editorEngine.projectInfo.components}
-                                    />
-                                ) : (
-                                    <div className="w-[260px] pt-96 text-center opacity-70">
-                                        Coming soon
-                                    </div>
-                                ))}
+                            {selectedTab === LayersPanelTabValue.COMPONENTS && (
+                                <ComponentsTab components={editorEngine.projectInfo.components} />
+                            )}
                             {selectedTab === LayersPanelTabValue.PAGES && <PagesTab />}
                             {selectedTab === LayersPanelTabValue.IMAGES && <ImagesTab />}
                             {selectedTab === LayersPanelTabValue.WINDOWS && <WindowsTab />}
@@ -237,12 +211,7 @@ export const LayersPanel = observer(() => {
                     </div>
 
                     {/* Invisible padding area that maintains hover state */}
-                    {!isLocked && (
-                        <div
-                            className="w-24 h-full"
-                            onMouseEnter={() => setIsContentPanelOpen(true)}
-                        />
-                    )}
+                    {!isLocked && <div className="w-24 h-full" />}
                 </>
             )}
         </div>


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make `LayersPanelTabValue` nullable and introduce `BrandTabValue` for managing brand-related tabs in the editor.
> 
>   - **Behavior**:
>     - Make `LayersPanelTabValue` nullable in `EditorEngine` to allow no tab selection.
>     - Introduce `BrandTabValue` to manage brand-related tabs (colors and fonts).
>     - Add `isLayersPanelLocked` to lock/unlock the layers panel in `EditorEngine`.
>   - **Components**:
>     - Update `FontInput.tsx` to set `layersPanelTab` to `BRAND` and `brandTab` to `FONTS` when adding a new font.
>     - Modify `ColorPanel` and `FontPanel` to clear `brandTab` on close.
>     - Refactor `BrandTab` to use `brandTab` for switching between `ColorPanel` and `FontPanel`.
>     - Adjust `LayersPanel` to handle nullable `layersPanelTab` and lock state.
>   - **Models**:
>     - Add `APPS` to `LayersPanelTabValue` and `BrandTabValue` enums in `models.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 12dd2bd79841788d6fdc30fc6cea2ac124e2c308. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->