### PR TITLE
Self-healing tool-calls on invalid format

### DIFF
--- a/apps/studio/electron/main/chat/index.ts
+++ b/apps/studio/electron/main/chat/index.ts
@@ -13,6 +13,7 @@ import {
 import { MainChannels } from '@onlook/models/constants';
 import {
     generateObject,
+    NoSuchToolError,
     RetryError,
     streamText,
     type CoreMessage,
@@ -100,6 +101,38 @@ class LlmManager {
                 },
                 onError: (error) => {
                     throw error;
+                },
+                experimental_repairToolCall: async ({
+                    toolCall,
+                    tools,
+                    parameterSchema,
+                    error,
+                }) => {
+                    if (NoSuchToolError.isInstance(error)) {
+                        return null; // do not attempt to fix invalid tool names
+                    }
+                    const tool = tools[toolCall.toolName as keyof typeof tools];
+
+                    console.log(
+                        'Invalid parameter for tool',
+                        toolCall.toolName,
+                        'attempting to fix',
+                    );
+
+                    const { object: repairedArgs } = await generateObject({
+                        model,
+                        schema: tool.parameters,
+                        prompt: [
+                            `The model tried to call the tool "${toolCall.toolName}"` +
+                                ` with the following arguments:`,
+                            JSON.stringify(toolCall.args),
+                            `The tool accepts the following schema:`,
+                            JSON.stringify(parameterSchema(toolCall)),
+                            'Please fix the arguments.',
+                        ].join('\n'),
+                    });
+
+                    return { ...toolCall, args: JSON.stringify(repairedArgs) };
                 },
             });
             const streamParts: TextStreamPart<ToolSet>[] = [];

--- a/apps/studio/electron/main/chat/index.ts
+++ b/apps/studio/electron/main/chat/index.ts
@@ -114,9 +114,7 @@ class LlmManager {
                     const tool = tools[toolCall.toolName as keyof typeof tools];
 
                     console.log(
-                        'Invalid parameter for tool',
-                        toolCall.toolName,
-                        'attempting to fix',
+                        `Invalid parameter for tool ${toolCall.toolName} with args ${JSON.stringify(toolCall.args)}, attempting to fix`,
                     );
 
                     const { object: repairedArgs } = await generateObject({

--- a/apps/studio/electron/main/chat/index.ts
+++ b/apps/studio/electron/main/chat/index.ts
@@ -109,11 +109,12 @@ class LlmManager {
                     error,
                 }) => {
                     if (NoSuchToolError.isInstance(error)) {
+                        console.error('Invalid tool name', toolCall.toolName);
                         return null; // do not attempt to fix invalid tool names
                     }
                     const tool = tools[toolCall.toolName as keyof typeof tools];
 
-                    console.log(
+                    console.warn(
                         `Invalid parameter for tool ${toolCall.toolName} with args ${JSON.stringify(toolCall.args)}, attempting to fix`,
                     );
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds self-healing for invalid tool call parameters in `LlmManager` using `experimental_repairToolCall`.
> 
>   - **Behavior**:
>     - Adds `experimental_repairToolCall` method in `LlmManager` to handle invalid tool call parameters by attempting to repair them using `generateObject`.
>     - Logs an error and returns null for invalid tool names using `NoSuchToolError`.
>   - **Error Handling**:
>     - Enhances error handling in `stream()` method to manage invalid tool call parameters.
>     - Logs warnings for invalid parameters and attempts to fix them.
>   - **Misc**:
>     - Imports `NoSuchToolError` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 5d5e8cad8777ee21ec7d2976794044a61ba24e55. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->