### PR TITLE
fix: add filter web version when run local

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "dev:studio": "bun --filter @onlook/studio dev",
         "build": "bun --filter '!@onlook/web' build",
         "ci:build": "bun run build:foundation && bun --filter '!@onlook/web' build",
-        "dev": "bun --elide-lines=0  --filter '!@onlook/web' dev",
+        "dev": "bun --elide-lines=0  --filter '!**/web*' dev",
         "dev:web": "bun --filter @onlook/web dev",
         "test": "bun --filter '*' test",
         "format": "bun --filter '*' format",


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `dev` script in `package.json` to exclude all paths containing 'web' during local development.
> 
>   - **Scripts**:
>     - Update `dev` script in `package.json` to use `--filter '!**/web*'` instead of `--filter '!@onlook/web'` to exclude all paths containing 'web' during local development.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 6c41ab90a0bf314f64ad4aa33a88a6dcc3a6d71f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->