### PR TITLE
Resolve the functionality to duplicate a page that has been already duplicated

### DIFF
--- a/apps/studio/src/routes/editor/LayersPanel/Tree/PageTreeNode.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/Tree/PageTreeNode.tsx
@@ -75,7 +75,13 @@ const PageTreeNode: React.FC<PageTreeNodeProps> = ({ node, style }) => {
 
     const handleDuplicate = async () => {
         try {
-            await editorEngine.pages.duplicatePage(node.data.path, node.data.path);
+            const basePath = node.data.path;
+            const newPath = basePath.replace(/(\/[^/]+)$/, (match) => {
+                const baseName = getBaseName(match);
+                const newName = `${baseName}1`;
+                return `/${newName}`;
+            });
+            await editorEngine.pages.duplicatePage(basePath, newPath);
 
             toast({
                 title: 'Page duplicated',

--- a/apps/studio/src/routes/editor/LayersPanel/Tree/PageTreeNode.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/Tree/PageTreeNode.tsx
@@ -75,13 +75,7 @@ const PageTreeNode: React.FC<PageTreeNodeProps> = ({ node, style }) => {
 
     const handleDuplicate = async () => {
         try {
-            const basePath = node.data.path;
-            const newPath = basePath.replace(/(\/[^/]+)$/, (match) => {
-                const baseName = getBaseName(match);
-                const newName = `${baseName}1`;
-                return `/${newName}`;
-            });
-            await editorEngine.pages.duplicatePage(basePath, newPath);
+            await editorEngine.pages.duplicatePage(node.data.path, node.data.path);
 
             toast({
                 title: 'Page duplicated',


### PR DESCRIPTION

## Description

fixed when a page duplicated for the first time, then again the page can't be duplicated. 

## Related Issues

Solved issue #1770

![Screenshot from 2025-04-13 15-27-36](https://github.com/user-attachments/assets/54f4b70d-4f8c-440d-8297-2dcbf6414581)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes page duplication issue by modifying `handleDuplicate` in `PageTreeNode.tsx` to generate unique paths.
> 
>   - **Behavior**:
>     - Fixes issue where a page could not be duplicated more than once in `PageTreeNode.tsx`.
>     - Modifies `handleDuplicate` to generate a unique path by appending '1' to the base name of the page.
>   - **Functions**:
>     - Updates `handleDuplicate` in `PageTreeNode.tsx` to use `getBaseName` for path generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for ec337334198f9bd3910e808509b5fe37d4abd65c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->