### PR TITLE
Added the warning in the input chat that links wouldn't work

### DIFF
--- a/apps/studio/src/locales/en/translation.json
+++ b/apps/studio/src/locales/en/translation.json
@@ -68,7 +68,7 @@
             "title": "What kind of website do you want to make?",
             "description": "Tell us a bit about your project. Be as detailed as possible.",
             "input": {
-                "placeholder": "Paste a reference screenshot, write a novel, get creative...",
+                "placeholder": "Paste a reference screenshot, write a novel, get creative...\nlink (www.*****.com or anything with an https:://) won't work.",
                 "imageUpload": "Upload Image Reference",
                 "fileReference": "File Reference",
                 "submit": "Start building your site"

--- a/apps/studio/src/locales/en/translation.json
+++ b/apps/studio/src/locales/en/translation.json
@@ -68,7 +68,7 @@
             "title": "What kind of website do you want to make?",
             "description": "Tell us a bit about your project. Be as detailed as possible.",
             "input": {
-                "placeholder": "Paste a reference screenshot, write a novel, get creative...\nlink (www.*****.com or anything with an https:://) won't work.",
+                "placeholder": "Paste a reference screenshot, write a novel, get creative...\nlink (www.*****.com or anything with an https://) won't work.",
                 "imageUpload": "Upload Image Reference",
                 "fileReference": "File Reference",
                 "submit": "Start building your site"

--- a/apps/studio/src/routes/editor/LayersPanel/Tree/PageTreeNode.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/Tree/PageTreeNode.tsx
@@ -75,7 +75,13 @@ const PageTreeNode: React.FC<PageTreeNodeProps> = ({ node, style }) => {
 
     const handleDuplicate = async () => {
         try {
-            await editorEngine.pages.duplicatePage(node.data.path, node.data.path);
+            const basePath = node.data.path;
+            const newPath = basePath.replace(/(\/[^/]+)$/, (match) => {
+                const baseName = getBaseName(match);
+                const newName = `${baseName}1`;
+                return `/${newName}`;
+            });
+            await editorEngine.pages.duplicatePage(basePath, newPath);
 
             toast({
                 title: 'Page duplicated',

--- a/apps/web/client/messages/en.json
+++ b/apps/web/client/messages/en.json
@@ -68,7 +68,7 @@
             "title": "What kind of website do you want to make?",
             "description": "Tell us a bit about your project. Be as detailed as possible.",
             "input": {
-                "placeholder": "Paste a reference screenshot, write a novel, get creative...",
+                "placeholder": "Paste a reference screenshot, write a novel, get creative...\nlink (www.*****.com or anything with an https:://) won't work.",
                 "imageUpload": "Upload Image Reference",
                 "fileReference": "File Reference",
                 "submit": "Start building your site"


### PR DESCRIPTION
## Description
Provide a warning on the chat that link wouldn't work

## Related Issues

fixes #1649

## Screenshots 
![Screenshot from 2025-04-13 23-46-36](https://github.com/user-attachments/assets/f3de74cd-fe2d-431d-bc23-bc313cfced4e)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a warning in chat input about non-functional links and updates page duplication naming in `PageTreeNode.tsx`.
> 
>   - **Behavior**:
>     - Adds a warning in the chat input placeholder that links (e.g., `www.*****.com` or `https://`) won't work in `translation.json` and `messages/en.json`.
>     - Modifies `handleDuplicate` in `PageTreeNode.tsx` to append '1' to the base name when duplicating a page.
>   - **Localization**:
>     - Updates `translation.json` and `messages/en.json` to include the new placeholder text for chat input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for e0edcb6bce0209b603ebe18fdba4fa86767d6683. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->