### PR TITLE
fix text color changes inconsistently when entering edit mode

### DIFF
--- a/apps/studio/src/components/Modals/Settings/Site/Image.tsx
+++ b/apps/studio/src/components/Modals/Settings/Site/Image.tsx
@@ -29,6 +29,8 @@ const ImagePicker = forwardRef<
             if (image) {
                 setSelectedImage(image.content);
             }
+        } else {
+            setSelectedImage(null);
         }
     }, [url]);
 

--- a/apps/studio/src/lib/editor/engine/text/index.ts
+++ b/apps/studio/src/lib/editor/engine/text/index.ts
@@ -145,7 +145,7 @@ export class TextEditingManager {
         }
 
         const domEl = await webview.executeJavaScript(
-            `window.api?.getDomElementByDomId('${selectedEl.domId}')`,
+            `window.api?.getDomElementByDomId('${selectedEl.domId}', true)`,
         );
         if (!domEl) {
             return;


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Fix text color changes inconsistently when entering edit mode
Root cause:
- The `DOUBLE_CLICK` action uses the `getElementAtLoc` function, which already passes `true` to include the `styles` object.  
- The `ENTER` action uses `getDomElementByDomId`, but it still needs to pass `true` to retrieve the `styles` object as well.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
- fixes #1725 
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

https://github.com/user-attachments/assets/821c020e-90e8-4ddd-ade9-27da9c1b1380


## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix inconsistent text color change in edit mode by updating `getDomElementByDomId` call and handling null URLs in `Image.tsx`.
> 
>   - **Behavior**:
>     - Fix inconsistent text color change when entering edit mode by modifying `getDomElementByDomId` call in `index.ts` to include an additional parameter.
>     - Ensure `setSelectedImage(null)` is called in `Image.tsx` when no URL is provided.
>   - **Files**:
>     - `index.ts`: Update `getDomElementByDomId` call to include `true` parameter.
>     - `Image.tsx`: Add `else` block to set `selectedImage` to `null` when `url` is not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for c4e1f3ee943dd957572233c4fa021914a833cfe1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->