### PR TITLE
Added warning in the chat input that links won't work

### DIFF
--- a/apps/studio/src/locales/en/translation.json
+++ b/apps/studio/src/locales/en/translation.json
@@ -68,7 +68,7 @@
             "title": "What kind of website do you want to make?",
             "description": "Tell us a bit about your project. Be as detailed as possible.",
             "input": {
-                "placeholder": "Paste a reference screenshot, write a novel, get creative...",
+                "placeholder": "Paste a reference screenshot, write a novel, get creative...\nlink (www.*****.com or anything with an https://) won't work.",
                 "imageUpload": "Upload Image Reference",
                 "fileReference": "File Reference",
                 "submit": "Start building your site"

--- a/apps/web/client/messages/en.json
+++ b/apps/web/client/messages/en.json
@@ -68,7 +68,7 @@
             "title": "What kind of website do you want to make?",
             "description": "Tell us a bit about your project. Be as detailed as possible.",
             "input": {
-                "placeholder": "Paste a reference screenshot, write a novel, get creative...",
+                "placeholder": "Paste a reference screenshot, write a novel, get creative...\nlink (www.*****.com or anything with an https://) won't work.",
                 "imageUpload": "Upload Image Reference",
                 "fileReference": "File Reference",
                 "submit": "Start building your site"


### PR DESCRIPTION
## Description

Added warning in the chat input that links with www.*****.com or anything with https:// won't work

## Related Issues

fixes #1649

## Testing

Tested by running locally

## Screenshots (if applicable)
![linkwarning](https://github.com/user-attachments/assets/038dbd4e-c12c-4d6f-98f0-5679ce54ef6c)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds warning to chat input placeholder that links won't work in `translation.json` and `messages/en.json`.
> 
>   - **Behavior**:
>     - Adds warning to chat input placeholder in `translation.json` and `messages/en.json` that links (e.g., `www.*****.com` or `https://`) won't work.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 00588959908c9bf709d9c4c2614b5d3a63a38700. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->