### PR TITLE
fix: border thickness hidden when setting border color from color picker

### DIFF
--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/index.tsx
@@ -129,7 +129,7 @@ const ColorInput = observer(
                         colorValue = colorValue.split(`-${DEFAULT_COLOR_NAME}`)[0];
                     }
                     editorEngine.style.updateCustom(elementStyle.key, colorValue);
-                    onValueChange?.(elementStyle.key, colorValue);
+                    onValueChange?.(elementStyle.key, newValue.lightColor);
                 }
             },
             [editorEngine.style, elementStyle.key, onValueChange],


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

This PR fixes the issue where selecting a border color from the color picker causes the border thickness to be hidden. Now, the border thickness remains visible and correctly applied after choosing a color

## Related Issues
#1804

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue in `ColorInput` where selecting a border color hid the border thickness by adjusting `onValueChange` callback.
> 
>   - **Bug Fix**:
>     - Fixes issue in `ColorInput` component where selecting a border color from the color picker hid the border thickness.
>     - Changes `onValueChange` callback to use `newValue.lightColor` instead of `colorValue` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 2dae37b7cc37cc12d194f8f112dedc606e48177a. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->