### PR TITLE
use DomElementStyles

### DIFF
--- a/apps/studio/electron/preload/webview/elements/style.ts
+++ b/apps/studio/electron/preload/webview/elements/style.ts
@@ -1,10 +1,8 @@
+import type { DomElementStyles } from '@onlook/models/element';
 import { jsonClone } from '@onlook/utility';
 import { elementFromDomId } from '/common/helpers';
 
-export function getStyles(element: HTMLElement): {
-    defined: Record<string, string>;
-    computed: Record<string, string>;
-} {
+export function getStyles(element: HTMLElement): DomElementStyles {
     const computed = getComputedStyle(element);
     const inline = getInlineStyles(element);
     const stylesheet = getStylesheetStyles(element);

--- a/apps/studio/src/lib/editor/engine/element/index.ts
+++ b/apps/studio/src/lib/editor/engine/element/index.ts
@@ -85,11 +85,7 @@ export class ElementManager {
         for (const domEl of domEls) {
             const adjustedRect = adaptRectToCanvas(domEl.rect, webview);
             const isComponent = !!domEl.instanceId;
-            this.editorEngine.overlay.state.addClickRect(
-                adjustedRect,
-                { ...domEl.styles?.computed, ...domEl.styles?.defined },
-                isComponent,
-            );
+            this.editorEngine.overlay.state.addClickRect(adjustedRect, domEl.styles, isComponent);
             this.addSelectedElement(domEl);
         }
     }

--- a/apps/studio/src/lib/editor/engine/overlay/index.ts
+++ b/apps/studio/src/lib/editor/engine/overlay/index.ts
@@ -1,4 +1,4 @@
-import type { DomElement } from '@onlook/models/element';
+import type { DomElement, DomElementStyles } from '@onlook/models/element';
 import { reaction } from 'mobx';
 import type { EditorEngine } from '..';
 import type { RectDimensions } from './rect';
@@ -27,7 +27,7 @@ export class OverlayManager {
 
     refreshOverlay = async () => {
         this.state.updateHoverRect(null);
-        const newClickRects: { rect: RectDimensions; styles: Record<string, string> }[] = [];
+        const newClickRects: { rect: RectDimensions; styles: DomElementStyles | null }[] = [];
         for (const selectedElement of this.editorEngine.elements.selected) {
             const webview = this.editorEngine.webviews.getWebview(selectedElement.webviewId);
             if (!webview) {
@@ -40,7 +40,7 @@ export class OverlayManager {
                 continue;
             }
             const adaptedRect = adaptRectToCanvas(el.rect, webview);
-            newClickRects.push({ rect: adaptedRect, styles: el.styles?.computed || {} });
+            newClickRects.push({ rect: adaptedRect, styles: el.styles });
         }
         this.state.removeClickRects();
         for (const clickRect of newClickRects) {

--- a/apps/studio/src/lib/editor/engine/overlay/state.ts
+++ b/apps/studio/src/lib/editor/engine/overlay/state.ts
@@ -1,3 +1,4 @@
+import type { DomElementStyles } from '@onlook/models/element';
 import { makeAutoObservable } from 'mobx';
 import { nanoid } from 'nanoid/non-secure';
 import type { RectDimensions } from './rect';
@@ -9,7 +10,7 @@ export interface MeasurementState {
 
 export interface ClickRectState extends RectDimensions {
     isComponent?: boolean;
-    styles?: Record<string, string>;
+    styles: DomElementStyles | null;
     id: string;
 }
 
@@ -48,7 +49,7 @@ export class OverlayState {
 
     addClickRect = (
         rect: RectDimensions,
-        styles: Record<string, string>,
+        styles: DomElementStyles | null,
         isComponent?: boolean,
     ) => {
         this.clickRects = [

--- a/apps/studio/src/routes/editor/Canvas/Overlay/ClickRect.tsx
+++ b/apps/studio/src/routes/editor/Canvas/Overlay/ClickRect.tsx
@@ -1,5 +1,6 @@
 import type { RectDimensions } from '@/lib/editor/engine/overlay/rect';
 import { adaptValueToCanvas } from '@/lib/editor/engine/overlay/utils';
+import type { DomElementStyles } from '@onlook/models/element';
 import { colors } from '@onlook/ui/tokens';
 import { nanoid } from 'nanoid';
 import { BaseRect } from './BaseRect';
@@ -90,7 +91,7 @@ const parseCssBoxValues = (
 
 interface ClickRectProps extends RectDimensions {
     isComponent?: boolean;
-    styles: Record<string, string>;
+    styles: DomElementStyles | null;
     shouldShowResizeHandles: boolean;
 }
 
@@ -104,10 +105,10 @@ export const ClickRect = ({
     shouldShowResizeHandles,
 }: ClickRectProps) => {
     const renderMarginLabels = () => {
-        if (!styles?.margin) {
+        if (!styles?.computed.margin) {
             return null;
         }
-        const { adjusted, original } = parseCssBoxValues(styles.margin);
+        const { adjusted, original } = parseCssBoxValues(styles.computed.margin);
 
         const patternId = `margin-pattern-${nanoid()}`;
         const maskId = `margin-mask-${nanoid()}`;
@@ -201,10 +202,10 @@ export const ClickRect = ({
     };
 
     const renderPaddingLabels = () => {
-        if (!styles?.padding) {
+        if (!styles?.computed.padding) {
             return null;
         }
-        const { adjusted, original } = parseCssBoxValues(styles.padding);
+        const { adjusted, original } = parseCssBoxValues(styles.computed.padding);
 
         const patternId = `padding-pattern-${nanoid()}`;
         const maskId = `padding-mask-${nanoid()}`;
@@ -301,8 +302,8 @@ export const ClickRect = ({
 
     const renderDimensionLabels = () => {
         const rectColor = isComponent ? colors.purple[500] : colors.red[500];
-        const displayWidth = parseFloat(styles?.width || '0').toFixed(0);
-        const displayHeight = parseFloat(styles?.height || '0').toFixed(0);
+        const displayWidth = parseFloat(styles?.defined.width || '0').toFixed(0);
+        const displayHeight = parseFloat(styles?.defined.height || '0').toFixed(0);
         const text = `${displayWidth} × ${displayHeight}`;
 
         // Constants from showDimensions
@@ -355,9 +356,9 @@ export const ClickRect = ({
                     height={height}
                     left={left}
                     top={top}
-                    borderRadius={parseInt(styles?.['borderRadius'] || '0')}
+                    borderRadius={parseInt(styles?.computed['borderRadius'] || '0')}
                     isComponent={isComponent}
-                    styles={styles}
+                    styles={styles?.computed ?? {}}
                 />
             )}
         </BaseRect>

--- a/apps/studio/src/routes/editor/Canvas/Overlay/index.tsx
+++ b/apps/studio/src/routes/editor/Canvas/Overlay/index.tsx
@@ -51,7 +51,7 @@ export const Overlay = observer(({ children }: { children: React.ReactNode }) =>
                     top={rectState.top}
                     left={rectState.left}
                     isComponent={rectState.isComponent}
-                    styles={rectState.styles ?? {}}
+                    styles={rectState.styles}
                     shouldShowResizeHandles={isSingleSelection}
                 />
             )),

--- a/apps/web/preload/script/api/elements/style.ts
+++ b/apps/web/preload/script/api/elements/style.ts
@@ -1,10 +1,8 @@
+import type { DomElementStyles } from '@onlook/models/element';
 import { jsonClone } from '@onlook/utility';
 import { elementFromDomId } from '../../helpers';
 
-export function getStyles(element: HTMLElement): {
-    defined: Record<string, string>;
-    computed: Record<string, string>;
-} {
+export function getStyles(element: HTMLElement): DomElementStyles {
     const computed = getElComputedStyle(element);
     const inline = getInlineStyles(element);
     const stylesheet = getStylesheetStyles(element);

--- a/packages/models/src/element/element.ts
+++ b/packages/models/src/element/element.ts
@@ -10,11 +10,13 @@ export interface ParentDomElement extends BaseDomElement {}
 
 export interface DomElement extends BaseDomElement {
     tagName: string;
-    styles: {
-        defined: Record<string, string>; // Styles from stylesheets or inline
-        computed: Record<string, string>; // Browser computed styles
-    } | null;
+    styles: DomElementStyles | null;
     parent: ParentDomElement | null;
+}
+
+export interface DomElementStyles {
+    defined: Record<string, string>; // Styles from stylesheets or inline
+    computed: Record<string, string>; // Browser computed styles
 }
 
 export interface ElementPosition {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor style handling by introducing `DomElementStyles` type and updating related code to use this new type.
> 
>   - **Refactor**:
>     - Introduce `DomElementStyles` type in `element.ts` to encapsulate `defined` and `computed` styles.
>     - Update `getStyles()` in `style.ts` (both `apps/studio/electron/preload/webview/elements` and `apps/web/preload/script/api/elements`) to return `DomElementStyles`.
>   - **Code Updates**:
>     - Modify `ElementManager` in `index.ts` to use `DomElementStyles` for style handling.
>     - Update `OverlayManager` and `OverlayState` in `overlay/index.ts` and `overlay/state.ts` to handle `DomElementStyles`.
>     - Adjust `ClickRect` component in `ClickRect.tsx` to utilize `DomElementStyles` for rendering styles.
>   - **Misc**:
>     - Remove redundant merging of `computed` and `defined` styles in `ElementManager` and `OverlayManager`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 580ae4eed6fc4cf9d8688986c4cfc4e1e82dde5d. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->