### PR TITLE
Added panel to select image from images panel to fill images or uploa…

### DIFF
--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ImageSelection.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ImageSelection.tsx
@@ -1,0 +1,58 @@
+import { useEditorEngine } from '@/components/Context';
+import type { ImageContentData } from '@onlook/models';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@onlook/ui/dialog';
+import { Input } from '@onlook/ui/input';
+import React, { useState } from 'react';
+
+interface ImageSelectionModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSelect: (image: ImageContentData) => void;
+}
+
+const ImageSelectionModal: React.FC<ImageSelectionModalProps> = ({ isOpen, onClose, onSelect }) => {
+    const editorEngine = useEditorEngine();
+    const [search, setSearch] = useState('');
+
+    const filteredImages = editorEngine.image.assets.filter(
+        (image) => !search || image.fileName.toLowerCase().includes(search.toLowerCase()),
+    );
+
+    return (
+        <Dialog open={isOpen} onOpenChange={() => onClose()}>
+            <DialogContent className="sm:max-w-[600px]">
+                <DialogHeader>
+                    <DialogTitle>Select Image</DialogTitle>
+                </DialogHeader>
+                <div className="flex flex-col gap-4">
+                    <Input
+                        placeholder="Search images..."
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className="h-8 text-xs"
+                    />
+                    <div className="grid grid-cols-3 gap-3 max-h-[400px] overflow-y-auto p-1">
+                        {filteredImages.map((image) => (
+                            <div
+                                key={image.fileName}
+                                className="aspect-square cursor-pointer hover:opacity-80 transition-opacity border rounded-md overflow-hidden"
+                                onClick={() => {
+                                    onSelect(image);
+                                    onClose();
+                                }}
+                            >
+                                <img
+                                    src={image.content}
+                                    alt={image.fileName}
+                                    className="w-full h-full object-cover"
+                                />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default ImageSelectionModal;


### PR DESCRIPTION
## Description
Added new modal to show the Images from the Image panel. user can either upload new image or select one from the Images panel and applied in the fill color.

## Related Issues

fixes #1550

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Tested by running locally

## Screenshots (if applicable)

[Screencast from 2025-05-03 20-51-45.webm](https://github.com/user-attachments/assets/c9ebe7ea-9a77-4fb4-9fc1-1ed3929c1b68)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added image selection modal to `ImagePicker.tsx` for selecting or uploading images as fill color.
> 
>   - **New Feature**:
>     - Added `ImageSelectionModal` in `ImageSelection.tsx` for selecting images from the image panel.
>     - `ImagePicker.tsx` updated to include `SelectImageButton` to open `ImageSelectionModal`.
>     - Users can upload new images or select existing ones to apply as fill color.
>   - **Functionality**:
>     - `ImageSelectionModal` filters images based on search input and allows selection.
>     - `handleImageSelection` in `ImagePicker.tsx` updates image data and inserts selected image into editor.
>   - **UI Components**:
>     - Added `SelectImageButton` and integrated it into the image picker UI.
>     - `ImageSelectionModal` uses `Dialog`, `DialogContent`, `DialogHeader`, and `DialogTitle` for modal display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 3780e45e67e1d00c2a25ad9c974d0e19065434cb. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->