### PR TITLE
Added recent used colors in the brand panel

### DIFF
--- a/apps/studio/src/lib/editor/engine/theme/index.ts
+++ b/apps/studio/src/lib/editor/engine/theme/index.ts
@@ -1,7 +1,7 @@
 import type { ProjectsManager } from '@/lib/projects';
 import { invokeMainChannel } from '@/lib/utils';
 import type { ColorItem } from '@/routes/editor/LayersPanel/BrandTab/ColorPanel/ColorPalletGroup';
-import { DEFAULT_COLOR_NAME, MainChannels } from '@onlook/models';
+import { DEFAULT_COLOR_NAME, RECENT_COLOR_STORAGE_KEY, MainChannels } from '@onlook/models';
 import type { ConfigResult, ParsedColors, ThemeColors } from '@onlook/models/assets';
 import { Theme } from '@onlook/models/assets';
 import { Color, generateUniqueName } from '@onlook/utility';
@@ -29,7 +29,27 @@ export class ThemeManager {
         private projectsManager: ProjectsManager,
     ) {
         makeAutoObservable(this);
+        this.loadRecentColors();
         this.scanConfig();
+    }
+
+    private loadRecentColors() {
+        try {
+            const storedColors = localStorage.getItem(RECENT_COLOR_STORAGE_KEY);
+            if (storedColors) {
+                this.recentColors = JSON.parse(storedColors);
+            }
+        } catch (error) {
+            console.error('Error loading recent colors:', error);
+        }
+    }
+
+    private saveRecentColors() {
+        try {
+            localStorage.setItem(RECENT_COLOR_STORAGE_KEY, JSON.stringify(this.recentColors));
+        } catch (error) {
+            console.error('Error saving recent colors:', error);
+        }
     }
 
     private reset() {
@@ -551,10 +571,14 @@ export class ThemeManager {
         if (this.recentColors.length > this.MAX_RECENT_COLORS) {
             this.recentColors = this.recentColors.slice(0, this.MAX_RECENT_COLORS);
         }
+
+        this.saveRecentColors();
     }
 
     dispose() {
         this.brandColors = {};
         this.defaultColors = {};
+
+        this.saveRecentColors();
     }
 }

--- a/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
+++ b/apps/studio/src/routes/editor/EditPanel/StylesTab/single/ColorInput/ColorBrandPicker.tsx
@@ -125,6 +125,7 @@ export const BrandPopoverPicker = memo(
 
         const handleColorSelect = (color: ColorItem) => {
             onChangeEnd?.(color);
+            editorEngine.theme.addRecentColors(color.lightColor);
         };
 
         useEffect(() => {

--- a/apps/studio/src/routes/editor/LayersPanel/BrandTab/index.tsx
+++ b/apps/studio/src/routes/editor/LayersPanel/BrandTab/index.tsx
@@ -28,6 +28,7 @@ const FontVariant = ({ name, isActive = false }: FontVariantProps) => (
 
 const BrandTab = observer(() => {
     const editorEngine = useEditorEngine();
+    const recentColors = editorEngine.theme.recentColorList;
 
     // Sample colors for the brand palette
     const brandColors = [
@@ -69,6 +70,16 @@ const BrandTab = observer(() => {
                     <div className="grid grid-cols-6 gap-1">
                         {brandColors.map((color, index) => (
                             <ColorSquare key={`brand-color-${index}`} color={color} />
+                        ))}
+                    </div>
+
+                    <div className="flex justify-between items-center">
+                        <span className="text-base font-normal">Recent Colors</span>
+                    </div>
+
+                    <div className="grid grid-cols-6 gap-1">
+                        {recentColors.map((color, index) => (
+                            <ColorSquare key={`recent-color-${index}`} color={color} />
                         ))}
                     </div>
                 </div>

--- a/packages/models/src/constants/editor.ts
+++ b/packages/models/src/constants/editor.ts
@@ -90,3 +90,5 @@ export const DefaultSettings = {
 };
 
 export const DEFAULT_COLOR_NAME = 'DEFAULT';
+
+export const RECENT_COLOR_STORAGE_KEY = 'recent-colors';


### PR DESCRIPTION
## Description

Added recent colors section to show 12 most recently used colors

## Related Issues

fixes #1697

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Tested by running locally

## Screenshots (if applicable)

![Screenshot from 2025-05-07 20-49-21](https://github.com/user-attachments/assets/0d474638-a7d5-4959-ac8a-e6ee4244e802)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a recent colors section to the brand panel, displaying the 12 most recently used colors.
> 
>   - **Behavior**:
>     - Adds a recent colors section in the brand panel to display the 12 most recently used colors.
>     - Updates `ThemeManager` in `index.ts` to manage recent colors with `addRecentColors()` and `recentColorList`.
>   - **UI Components**:
>     - Updates `BrandPopoverPicker` in `ColorBrandPicker.tsx` to add selected colors to recent colors.
>     - Displays recent colors in `BrandTab` in `index.tsx` using `recentColorList` from `ThemeManager`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 9cf63f2fafe6adb6769347c327de8b5c5a8ab85b. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->