### PR TITLE
Added tool for the brand config files

### DIFF
--- a/packages/ai/src/tools/helpers.ts
+++ b/packages/ai/src/tools/helpers.ts
@@ -30,6 +30,15 @@ export async function getAllFiles(
     },
 ): Promise<{ success: boolean; files?: string[]; error?: string }> {
     try {
+        const exists = await access(dirPath)
+            .then(() => true)
+            .catch(() => false);
+        if (!exists) {
+            return {
+                success: false,
+                error: `Directory does not exist: ${dirPath}`,
+            };
+        }
         const files = await fg(options.patterns, {
             cwd: dirPath,
             ignore: options.ignore,
@@ -49,27 +58,5 @@ export async function getBrandConfigFiles(
         maxDepth: 5,
     },
 ): Promise<{ success: boolean; files?: string[]; error?: string }> {
-    try {
-        const exists = await access(dirPath)
-            .then(() => true)
-            .catch(() => false);
-        if (!exists) {
-            return {
-                success: false,
-                error: `Directory does not exist: ${dirPath}`,
-            };
-        }
-        const files = await fg(options.patterns, {
-            cwd: dirPath,
-            ignore: options.ignore,
-            deep: options.maxDepth,
-        });
-        return { success: true, files };
-    } catch (error) {
-        console.error(error);
-        return {
-            success: false,
-            error: error instanceof Error ? error.message : 'Unknown error',
-        };
-    }
+    return getAllFiles(dirPath, options);
 }

--- a/packages/ai/src/tools/helpers.ts
+++ b/packages/ai/src/tools/helpers.ts
@@ -1,4 +1,5 @@
 import fg from 'fast-glob';
+import { access } from 'fs/promises';
 
 export const IGNORE_PATHS = [
     'node_modules/**',
@@ -38,5 +39,37 @@ export async function getAllFiles(
     } catch (error) {
         console.error(error);
         return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+}
+export async function getbrandConfigFiles(
+    dirPath: string,
+    options: FileFilterOptions = {
+        patterns: ['**/globals.css', '**/tailwind.config.{js,ts,mjs}'],
+        ignore: IGNORE_PATHS,
+        maxDepth: 5,
+    },
+): Promise<{ success: boolean; files?: string[]; error?: string }> {
+    try {
+        const exists = await access(dirPath)
+            .then(() => true)
+            .catch(() => false);
+        if (!exists) {
+            return {
+                success: false,
+                error: `Directory does not exist: ${dirPath}`,
+            };
+        }
+        const files = await fg(options.patterns, {
+            cwd: dirPath,
+            ignore: options.ignore,
+            deep: options.maxDepth,
+        });
+        return { success: true, files };
+    } catch (error) {
+        console.error(error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Unknown error',
+        };
     }
 }

--- a/packages/ai/src/tools/helpers.ts
+++ b/packages/ai/src/tools/helpers.ts
@@ -41,7 +41,7 @@ export async function getAllFiles(
         return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
     }
 }
-export async function getbrandConfigFiles(
+export async function getBrandConfigFiles(
     dirPath: string,
     options: FileFilterOptions = {
         patterns: ['**/globals.css', '**/tailwind.config.{js,ts,mjs}'],

--- a/packages/ai/src/tools/index.ts
+++ b/packages/ai/src/tools/index.ts
@@ -3,7 +3,7 @@ import { tool, type ToolSet } from 'ai';
 import { readFile } from 'fs/promises';
 import { z } from 'zod';
 import { ONLOOK_PROMPT } from '../prompt/onlook';
-import { getAllFiles, getbrandConfigFiles } from './helpers';
+import { getAllFiles, getBrandConfigFiles } from './helpers';
 
 export const listFilesTool = tool({
     description: 'List all files in the current directory, including subdirectories',
@@ -140,7 +140,7 @@ export const getBrandConfigTool = tool({
             ),
     }),
     execute: async ({ path }) => {
-        const res = await getbrandConfigFiles(path);
+        const res = await getBrandConfigFiles(path);
         if (!res.success) {
             return { error: res.error };
         }

--- a/packages/ai/src/tools/index.ts
+++ b/packages/ai/src/tools/index.ts
@@ -3,7 +3,7 @@ import { tool, type ToolSet } from 'ai';
 import { readFile } from 'fs/promises';
 import { z } from 'zod';
 import { ONLOOK_PROMPT } from '../prompt/onlook';
-import { getAllFiles } from './helpers';
+import { getAllFiles, getbrandConfigFiles } from './helpers';
 
 export const listFilesTool = tool({
     description: 'List all files in the current directory, including subdirectories',
@@ -130,8 +130,27 @@ export const getStrReplaceEditorTool = (handlers: FileOperationHandlers) => {
     return strReplaceEditorTool;
 };
 
+export const getBrandConfigTool = tool({
+    description: 'Get the brand config of the current project',
+    parameters: z.object({
+        path: z
+            .string()
+            .describe(
+                'The absolute path to the directory to get files from. This should be the root directory of the project.',
+            ),
+    }),
+    execute: async ({ path }) => {
+        const res = await getbrandConfigFiles(path);
+        if (!res.success) {
+            return { error: res.error };
+        }
+        return res.files;
+    },
+});
+
 export const chatToolSet: ToolSet = {
     list_files: listFilesTool,
     read_files: readFilesTool,
     onlook_instructions: onlookInstructionsTool,
+    get_brand_config: getBrandConfigTool,
 };

--- a/packages/ai/test/tools/brand-config-file.test.ts
+++ b/packages/ai/test/tools/brand-config-file.test.ts
@@ -1,9 +1,9 @@
-import { getbrandConfigFiles } from '@onlook/ai/src/tools/helpers';
+import { getBrandConfigFiles } from '@onlook/ai/src/tools/helpers';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
-describe('getbrandConfigFiles', () => {
+describe('getBrandConfigFiles', () => {
     const testDir = join(__dirname, 'test-files');
 
     beforeEach(() => {
@@ -26,7 +26,7 @@ describe('getbrandConfigFiles', () => {
     });
 
     test('should find all brand config files', async () => {
-        const { files } = await getbrandConfigFiles(testDir, {
+        const { files } = await getBrandConfigFiles(testDir, {
             patterns: ['**/globals.css', '**/tailwind.config.{js,ts,mjs}'],
             ignore: ['node_modules/**'],
         });
@@ -37,7 +37,7 @@ describe('getbrandConfigFiles', () => {
     });
 
     test('should exclude node_modules', async () => {
-        const { files } = await getbrandConfigFiles(testDir, {
+        const { files } = await getBrandConfigFiles(testDir, {
             patterns: ['**/globals.css', '**/tailwind.config.{js,ts,mjs}'],
             ignore: ['node_modules/**'],
         });
@@ -46,7 +46,7 @@ describe('getbrandConfigFiles', () => {
     });
 
     test('should find only tailwind config files', async () => {
-        const { files } = await getbrandConfigFiles(testDir, {
+        const { files } = await getBrandConfigFiles(testDir, {
             patterns: ['**/tailwind.config.{js,ts,mjs}'],
             ignore: [],
         });
@@ -55,11 +55,18 @@ describe('getbrandConfigFiles', () => {
     });
 
     test('should find only globals.css files', async () => {
-        const { files } = await getbrandConfigFiles(testDir, {
+        const { files } = await getBrandConfigFiles(testDir, {
             patterns: ['**/globals.css'],
             ignore: ['node_modules/**'],
         });
         expect(files?.length).toBe(1);
         expect(files?.every((f) => f.endsWith('globals.css'))).toBe(true);
+    });
+
+    test('should handle non-existent directory', async () => {
+        const nonExistentDir = join(testDir, 'does-not-exist');
+        const result = await getBrandConfigFiles(nonExistentDir);
+        expect(result.success).toBe(false);
+        expect(result.error).toBe(`Directory does not exist: ${nonExistentDir}`);
     });
 });

--- a/packages/ai/test/tools/brand-config-file.test.ts
+++ b/packages/ai/test/tools/brand-config-file.test.ts
@@ -1,0 +1,65 @@
+import { getbrandConfigFiles } from '@onlook/ai/src/tools/helpers';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+describe('getbrandConfigFiles', () => {
+    const testDir = join(__dirname, 'test-files');
+
+    beforeEach(() => {
+        // Create test directory structure
+        mkdirSync(testDir);
+        mkdirSync(join(testDir, 'src'));
+        mkdirSync(join(testDir, 'styles'));
+        mkdirSync(join(testDir, 'node_modules'));
+
+        // Create test files
+        writeFileSync(join(testDir, 'tailwind.config.js'), 'content');
+        writeFileSync(join(testDir, 'styles/globals.css'), 'content');
+        writeFileSync(join(testDir, 'src/tailwind.config.ts'), 'content');
+        writeFileSync(join(testDir, 'node_modules/globals.css'), 'content');
+    });
+
+    afterEach(() => {
+        // Cleanup test directory
+        rmSync(testDir, { recursive: true, force: true });
+    });
+
+    test('should find all brand config files', async () => {
+        const { files } = await getbrandConfigFiles(testDir, {
+            patterns: ['**/globals.css', '**/tailwind.config.{js,ts,mjs}'],
+            ignore: ['node_modules/**'],
+        });
+        expect(files?.length).toBe(3);
+        expect(files?.some((f) => f.endsWith('tailwind.config.js'))).toBe(true);
+        expect(files?.some((f) => f.endsWith('tailwind.config.ts'))).toBe(true);
+        expect(files?.some((f) => f.endsWith('globals.css'))).toBe(true);
+    });
+
+    test('should exclude node_modules', async () => {
+        const { files } = await getbrandConfigFiles(testDir, {
+            patterns: ['**/globals.css', '**/tailwind.config.{js,ts,mjs}'],
+            ignore: ['node_modules/**'],
+        });
+        expect(files?.length).toBe(3);
+        expect(files?.every((f) => !f.includes('node_modules'))).toBe(true);
+    });
+
+    test('should find only tailwind config files', async () => {
+        const { files } = await getbrandConfigFiles(testDir, {
+            patterns: ['**/tailwind.config.{js,ts,mjs}'],
+            ignore: [],
+        });
+        expect(files?.length).toBe(2);
+        expect(files?.every((f) => f.includes('tailwind.config'))).toBe(true);
+    });
+
+    test('should find only globals.css files', async () => {
+        const { files } = await getbrandConfigFiles(testDir, {
+            patterns: ['**/globals.css'],
+            ignore: ['node_modules/**'],
+        });
+        expect(files?.length).toBe(1);
+        expect(files?.every((f) => f.endsWith('globals.css'))).toBe(true);
+    });
+});


### PR DESCRIPTION
## Description

Added a tool to the Agent to find the brand config files and return globals.css and tailwind.config.js|ts|mjs

## Related Issues

related #1696

## Type of Change


- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Tested by writing test scripts

## Screenshots (if applicable)

![Screenshot from 2025-05-08 01-10-30](https://github.com/user-attachments/assets/a118cb74-c81e-44af-a7f3-6285cec0f475)


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Added a tool to locate brand config files (`globals.css` and `tailwind.config`) in a project directory, with tests to verify functionality.
> 
>   - **New Feature**:
>     - Added `getBrandConfigFiles` function in `helpers.ts` to locate `globals.css` and `tailwind.config` files in a directory.
>     - Introduced `getBrandConfigTool` in `index.ts` to expose the functionality as a tool.
>   - **Testing**:
>     - Added `brand-config-file.test.ts` to test `getBrandConfigFiles` for various scenarios, including file discovery and exclusion of `node_modules`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 0041a9992451634e9ec7f6465701e4126c3f2379. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->