### PR TITLE
Implemented the duplicate/delete web frame feature

### DIFF
--- a/apps/web/client/src/components/store/editor/window/index.ts
+++ b/apps/web/client/src/components/store/editor/window/index.ts
@@ -1,6 +1,9 @@
 import { sendAnalytics } from '@/utils/analytics';
 import { makeAutoObservable } from 'mobx';
 import type { EditorEngine } from '../engine';
+import { nanoid } from 'nanoid/non-secure';
+import type { WebFrame } from '../../../../../../../../packages/models/src/project/frame';
+
 
 export class WindowManager {
     constructor(private editorEngine: EditorEngine) {
@@ -81,69 +84,62 @@ export class WindowManager {
     }
 
     delete(id?: string) {
-        // if (!this.canDeleteWindow()) {
-        //     console.error('Cannot delete the last window');
-        //     return;
-        // }
-        // let settings = null;
-        // if (id) {
-        //     settings = this.editorEngine.frames.get(id);
-        //     if (!settings) {
-        //         console.error('Window not found');
-        //         return;
-        //     }
-        // } else if (this.editorEngine.frames.selected.length === 0) {
-        //     console.error('No window selected');
-        //     return;
-        // } else {
-        //     settings = this.editorEngine.frames.get(this.editorEngine.frames.selected[0].id) || null;
-        // }
-        // if (!settings) {
-        //     console.error('Window not found');
-        //     return;
-        // }
-        // this.ast.mappings.remove(settings.id);
-        // this.canvas.frames = this.canvas.frames.filter((frame) => frame.id !== settings.id);
-        // const frameView = this.webviews.getWebview(settings.id);
-        // if (frameView) {
-        //     this.webviews.deregister(frameView);
-        // }
+        if (this.editorEngine.canvas.frames.length === 1) {
+            console.error('Cannot delete the last window');
+            return;
+        }
+        let settings: WebFrame | null = null;
+        if (id) {
+            settings = this.editorEngine.canvas.getFrame(id) || null;
+        } else if (this.editorEngine.frames.selected.length === 0) {
+            console.error('No window selected');
+            return;
+        } else {
+            settings = this.editorEngine.canvas.getFrame(this.editorEngine.frames.selected[0].id) || null;
+        }
+        if (!settings) {
+            console.error('Window not found');
+            return;
+        }
+        const currentFrame = settings;
+        this.editorEngine.ast.mappings.remove(settings.id);
+        this.editorEngine.canvas.frames = this.editorEngine.canvas.frames.filter((frame) => frame.id !== settings.id);
+        this.editorEngine.frames.deselect(currentFrame);
+        this.editorEngine.frames.disposeFrame(currentFrame.id);
         sendAnalytics('window delete');
     }
 
     duplicate(id?: string) {
-        // let settings: Frames | null = null;
-        // if (id) {
-        //     settings = this.canvas.getFrame(id) || null;
-        // } else if (this.webviews.selected.length === 0) {
-        //     console.error('No window selected');
-        //     return;
-        // } else {
-        //     settings = this.canvas.getFrame(this.webviews.selected[0].id) || null;
-        // }
-        // if (!settings) {
-        //     console.error('Window not found');
-        //     return;
-        // }
-        // const currentFrame = settings;
-        // const newFrame: Frames = {
-        //     id: nanoid(),
-        //     url: currentFrame.url,
-        //     dimension: {
-        //         width: currentFrame.dimension.width,
-        //         height: currentFrame.dimension.height,
-        //     },
-        //     position: {
-        //         x: currentFrame.position.x + currentFrame.dimension.width + 100,
-        //         y: currentFrame.position.y,
-        //     },
-        //     aspectRatioLocked: currentFrame.aspectRatioLocked,
-        //     orientation: currentFrame.orientation,
-        //     device: currentFrame.device,
-        //     theme: currentFrame.theme,
-        // };
+        let settings: WebFrame | null = null;
+        if (id) {
+            settings = this.editorEngine.canvas.getFrame(id) || null;
+        } else if (this.editorEngine.frames.selected.length === 0) {
+            console.error('No window selected');
+            return;
+        } else {
+            settings = this.editorEngine.canvas.getFrame(this.editorEngine.frames.selected[0].id) || null;
+        }
+        if (!settings) {
+            console.error('Window not found');
+            return;
+        }
+        const currentFrame = settings;
+        const newFrame: WebFrame = {
+            id: nanoid(),
+            url: currentFrame.url,
+            dimension: {
+                width: currentFrame.dimension.width,
+                height: currentFrame.dimension.height,
+            },
+            position: {
+                x: currentFrame.position.x + currentFrame.dimension.width + 100,
+                y: currentFrame.position.y,
+            },
+            type: currentFrame.type,
+            windowMetadata : currentFrame.windowMetadata,
+        };
 
-        // this.canvas.frames = [...this.canvas.frames, newFrame];
+        this.editorEngine.canvas.frames = [...this.editorEngine.canvas.frames, newFrame];
         sendAnalytics('window duplicate');
     }
 }

--- a/apps/web/client/src/components/store/editor/window/index.ts
+++ b/apps/web/client/src/components/store/editor/window/index.ts
@@ -84,18 +84,14 @@ export class WindowManager {
     }
 
     delete(id?: string) {
-        if (this.editorEngine.canvas.frames.length === 1) {
-            console.error('Cannot delete the last window');
+        if (!this.canDelete()) {
+            console.error('Cannot delete the last frame');
             return;
         }
         const settings: FrameImpl | null = this.getSelectedFrame(id);
-        if (!settings) {
-            console.error('Window not found');
-            return;
-        }
 
         if (!settings) {
-            console.error('Window not found');
+            console.error('Frame not found');
             return;
         }
         const currentFrame = settings;
@@ -109,7 +105,7 @@ export class WindowManager {
     duplicate(id?: string) {
         const settings: FrameImpl | null = this.getSelectedFrame(id);
         if (!settings) {
-            console.error('Window not found');
+            console.error('Frame not found');
             return;
         }
 


### PR DESCRIPTION
## Description

Implemented the feature to duplicate and delete web frames on canvas.

## Related Issues

None

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

None

## Screenshots (if applicable)

None

## Additional Notes

None

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implemented duplicate and delete functionality for web frames in `WindowManager`, with analytics tracking.
> 
>   - **Behavior**:
>     - Implemented `delete()` in `WindowManager` to remove a frame if more than one exists, deselects and disposes of the frame, and sends analytics.
>     - Implemented `duplicate()` in `WindowManager` to create a new frame with a unique ID and adjusted position, and sends analytics.
>   - **Imports**:
>     - Added `nanoid` for generating unique IDs.
>     - Added `WebFrame` type for frame handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 5a70679ba3082d153a0efd72c33ea9d37e95bf3d. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->