### PR TITLE
Codesandbox reconnect logic improvement

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/main.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/main.tsx
@@ -103,7 +103,11 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
     }, [editorEngine.chat.conversation.current, createManager.pendingCreationData, editorEngine.sandbox.session.session]);
 
     useEffect(() => {
-        if (tabState === 'reactivated' && editorEngine.sandbox.session.session) {
+        if (
+            tabState === 'reactivated' &&
+            editorEngine.sandbox.session.session &&
+            !editorEngine.sandbox.session.connected()
+        ) {
             editorEngine.sandbox.session.reconnect();
         }
     }, [tabState]);

--- a/apps/web/client/src/components/store/editor/sandbox/session.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/session.ts
@@ -22,16 +22,17 @@ export class SessionManager {
         await api.sandbox.hibernate.mutate({ sandboxId });
     }
 
-    async connected(){
+    async connected() {
         if (!this.session) return false;
         try {
             await this.session.shells.run('echo "ping"');
             return true;
         } catch (error) {
+            console.error('Failed to connect to sandbox', error);
             return false;
         }
     }
-    
+
 
     async reconnect() {
         if (!this.session) {

--- a/apps/web/client/src/components/store/editor/sandbox/session.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/session.ts
@@ -22,6 +22,17 @@ export class SessionManager {
         await api.sandbox.hibernate.mutate({ sandboxId });
     }
 
+    async connected(){
+        if (!this.session) return false;
+        try {
+            await this.session.shells.run('echo "ping"');
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+    
+
     async reconnect() {
         if (!this.session) {
             console.error('No session found');

--- a/apps/web/client/src/components/store/editor/sandbox/session.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/session.ts
@@ -33,7 +33,6 @@ export class SessionManager {
         }
     }
 
-
     async reconnect() {
         if (!this.session) {
             console.error('No session found');


### PR DESCRIPTION
## Description

When the user was switching tabs, even though there was a connection to csb the connection was getting re-established. As the official docs for csb did not have any method to check the connection persisted or not, I have added a simple api call in a try/catch block which will check the connection is to be re-established or not

## Related Issues

None

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

None

## Screenshots (if applicable)

None

## Additional Notes

None

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve CodeSandbox reconnection logic by checking session connection status before reconnecting in `main.tsx`.
> 
>   - **Behavior**:
>     - In `main.tsx`, added a check using `connected()` before calling `reconnect()` when tab is reactivated.
>   - **Session Management**:
>     - Added `connected()` method in `SessionManager` in `session.ts` to verify session connection by running a shell command.
>   - **Misc**:
>     - No changes to documentation or tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 54f60528695306f4c02c36efd368a271dda8ff53. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->