### PR TITLE
feat: remove ids from inserted code block

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/hotkeys/delete.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/hotkeys/delete.tsx
@@ -19,7 +19,7 @@ export const DeleteKey = () => {
     const userManager = useUserManager();
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [shouldWarnDelete, setShouldWarnDelete] = useState(
-        userManager.settings.settings?.editor?.shouldWarnDelete ?? true,
+        userManager.settings.settings?.editor?.shouldWarnDelete ?? false,
     );
 
     useHotkeys([Hotkey.BACKSPACE.command, Hotkey.DELETE.command], () => {

--- a/apps/web/client/src/components/store/editor/action/index.ts
+++ b/apps/web/client/src/components/store/editor/action/index.ts
@@ -1,5 +1,5 @@
 import { sendAnalytics } from '@/utils/analytics';
-import type { DomElement, LayerNode } from '@onlook/models';
+import type { DomElement } from '@onlook/models';
 import { EditorMode } from '@onlook/models';
 import {
     type Action,
@@ -17,9 +17,9 @@ import { StyleChangeType } from '@onlook/models/style';
 import { assertNever } from '@onlook/utility';
 import { debounce } from 'lodash';
 import type { EditorEngine } from '../engine';
-import type { FrameData } from '../frames';
+
 export class ActionManager {
-    constructor(private editorEngine: EditorEngine) {}
+    constructor(private editorEngine: EditorEngine) { }
 
     async run(action: Action) {
         await this.editorEngine.history.push(action);
@@ -141,11 +141,8 @@ export class ActionManager {
                     console.error('Failed to insert element');
                     return;
                 }
-                // sendToWebview(frameView, WebviewChannels.INSERT_ELEMENT, {
-                //     element,
-                //     location,
-                //     editText,
-                // });
+
+                this.refreshAndClickMutatedElement(domEl);
             } catch (err) {
                 console.error('Error inserting element:', err);
             }
@@ -169,10 +166,7 @@ export class ActionManager {
 
             await this.editorEngine.overlay.refresh();
 
-            // this.editorEngine.elements.click([domEl], frameView);
-            // sendToWebview(frameView, WebviewChannels.REMOVE_ELEMENT, {
-            //     location,
-            // });
+            this.refreshAndClickMutatedElement(domEl);
         }
     }
 
@@ -188,10 +182,7 @@ export class ActionManager {
                 console.error('Failed to move element');
                 return;
             }
-            // sendToWebview(frameView, WebviewChannels.MOVE_ELEMENT, {
-            //     domId: target.domId,
-            //     newIndex: location.index,
-            // });
+            this.refreshAndClickMutatedElement(domEl);
         }
     }
 
@@ -207,10 +198,8 @@ export class ActionManager {
                 console.error('Failed to edit text');
                 return;
             }
-            // sendToWebview(frameView, WebviewChannels.EDIT_ELEMENT_TEXT, {
-            //     domId: target.domId,
-            //     content: newContent,
-            // });
+
+            this.refreshAndClickMutatedElement(domEl);
         }
     }
 
@@ -232,11 +221,7 @@ export class ActionManager {
             return;
         }
 
-        const result = [domEl] as DomElement[];
-
-        this.editorEngine.elements.click(result);
-
-        // sendToWebview(frameView, WebviewChannels.GROUP_ELEMENTS, { parent, container, children });
+        this.refreshAndClickMutatedElement(domEl);
     }
 
     private async ungroupElements({ parent, container }: UngroupElementsAction) {
@@ -253,7 +238,7 @@ export class ActionManager {
             return;
         }
 
-        // sendToWebview(frameView, WebviewChannels.UNGROUP_ELEMENTS, { parent, container, children });
+        this.refreshAndClickMutatedElement(domEl);
     }
 
     private insertImage({ targets, image }: InsertImageAction) {
@@ -285,13 +270,13 @@ export class ActionManager {
 
     async refreshAndClickMutatedElement(
         domEl: DomElement,
-        newMap: Map<string, LayerNode>,
-        frameData: FrameData,
+        // newMap: Map<string, LayerNode>,
+        // frameData: FrameData,
     ) {
         this.editorEngine.state.editorMode = EditorMode.DESIGN;
-        await this.editorEngine.ast.refreshAstDoc(frameData.view);
+        // await this.editorEngine.ast.refreshAstDoc(frameData.view);
         this.editorEngine.elements.click([domEl]);
-        this.editorEngine.ast.updateMap(frameData.view.id, newMap, domEl.domId);
+        // this.editorEngine.ast.updateMap(frameData.view.id, newMap, domEl.domId);
     }
 
     clear() {

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -93,6 +93,7 @@ export class SandboxManager {
         }
 
         try {
+            await this.processFileForMapping(filePath);
             await this.session.session.fs.writeTextFile(filePath, fileContent);
             return true;
         } catch (error) {

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -93,7 +93,6 @@ export class SandboxManager {
         }
 
         try {
-            this.processFileForMapping(filePath);
             await this.session.session.fs.writeTextFile(filePath, fileContent);
             return true;
         } catch (error) {

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -93,6 +93,7 @@ export class SandboxManager {
         }
 
         try {
+            this.processFileForMapping(filePath);
             await this.session.session.fs.writeTextFile(filePath, fileContent);
             return true;
         } catch (error) {

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -2,6 +2,7 @@ import type { WatchEvent } from '@codesandbox/sdk';
 import { IGNORED_DIRECTORIES, JS_FILE_EXTENSIONS, JSX_FILE_EXTENSIONS } from '@onlook/constants';
 import { type TemplateNode } from '@onlook/models';
 import { getContentFromTemplateNode } from '@onlook/parser';
+import { isSubdirectory } from '@onlook/utility';
 import localforage from 'localforage';
 import { makeAutoObservable, reaction } from 'mobx';
 import { FileEventBus } from './file-event-bus';
@@ -10,7 +11,7 @@ import { FileWatcher } from './file-watcher';
 import { formatContent, normalizePath } from './helpers';
 import { TemplateNodeMapper } from './mapping';
 import { SessionManager } from './session';
-import { isSubdirectory } from '@onlook/utility';
+
 export class SandboxManager {
     readonly session: SessionManager = new SessionManager();
     private fileWatcher: FileWatcher | null = null;

--- a/packages/parser/src/code-edit/insert.ts
+++ b/packages/parser/src/code-edit/insert.ts
@@ -92,7 +92,7 @@ export function insertAtIndex(
 ): void {
     if (index !== -1) {
         const jsxElements = path.node.children.filter(jsxFilter);
-        const targetIndex = Math.max(0, Math.min(index, jsxElements.length - 1));
+        const targetIndex = Math.max(0, Math.min(index, jsxElements.length));
         // Append to the end of the node if the index is greater than the number of children
         // Or if the node is empty
         if (targetIndex === path.node.children.length || jsxElements.length === 0) {

--- a/packages/parser/src/code-edit/insert.ts
+++ b/packages/parser/src/code-edit/insert.ts
@@ -92,15 +92,14 @@ export function insertAtIndex(
 ): void {
     if (index !== -1) {
         const jsxElements = path.node.children.filter(jsxFilter);
-        const targetIndex = Math.max(0, Math.min(index, jsxElements.length));
-        // Append to the end of the node if the index is greater than the number of children
-        // Or if the node is empty
-        if (targetIndex === path.node.children.length || jsxElements.length === 0) {
+        const targetIndex = Math.min(index, jsxElements.length);
+        if (targetIndex === path.node.children.length) {
             path.node.children.push(newElement);
         } else {
             const targetChild = jsxElements[targetIndex];
             if (!targetChild) {
                 console.error('Target child not found');
+                path.node.children.push(newElement);
                 return;
             }
             const targetChildIndex = path.node.children.indexOf(targetChild);

--- a/packages/parser/src/code-edit/insert.ts
+++ b/packages/parser/src/code-edit/insert.ts
@@ -30,7 +30,8 @@ export function insertElementToNode(path: NodePath<T.JSXElement>, element: CodeI
 export function createInsertedElement(insertedChild: CodeInsert): T.JSXElement {
     let element: T.JSXElement;
     if (insertedChild.codeBlock) {
-        element = getAstFromCodeblock(insertedChild.codeBlock) || createJSXElement(insertedChild);
+        element =
+            getAstFromCodeblock(insertedChild.codeBlock, true) || createJSXElement(insertedChild);
         addParamToElement(element, EditorAttributes.DATA_ONLOOK_ID, insertedChild.oid);
     } else {
         element = createJSXElement(insertedChild);

--- a/packages/parser/src/code-edit/insert.ts
+++ b/packages/parser/src/code-edit/insert.ts
@@ -93,7 +93,7 @@ export function insertAtIndex(
     if (index !== -1) {
         const jsxElements = path.node.children.filter(jsxFilter);
         const targetIndex = Math.min(index, jsxElements.length);
-        if (targetIndex === path.node.children.length) {
+        if (targetIndex >= path.node.children.length) {
             path.node.children.push(newElement);
         } else {
             const targetChild = jsxElements[targetIndex];

--- a/packages/parser/src/ids.ts
+++ b/packages/parser/src/ids.ts
@@ -4,6 +4,7 @@ import { isReactFragment } from './helpers';
 import { type NodePath, type t as T, types as t, traverse } from './packages';
 
 export function addOidsToAst(ast: T.File): { ast: T.File; modified: boolean } {
+    console.log('addOidsToAst', ast);
     const oids: Set<string> = new Set();
     let modified = false;
 
@@ -14,11 +15,12 @@ export function addOidsToAst(ast: T.File): { ast: T.File; modified: boolean } {
             }
             const attributes = path.node.attributes;
             const existingOid = getExistingOid(attributes);
-
+            console.log('existingOid', existingOid);
             if (existingOid) {
                 // If the element already has an oid, we need to check if it's unique
                 const { value, index } = existingOid;
                 if (oids.has(value)) {
+                    console.log('oid is not unique', value);
                     // If the oid is not unique, we need to create a new one
                     const newOid = createOid();
                     const attr = attributes[index] as T.JSXAttribute;
@@ -26,6 +28,7 @@ export function addOidsToAst(ast: T.File): { ast: T.File; modified: boolean } {
                     oids.add(newOid);
                     modified = true;
                 } else {
+                    console.log('oid is unique', value);
                     // If the oid is unique, we can add it to the set
                     oids.add(value);
                 }

--- a/packages/parser/src/ids.ts
+++ b/packages/parser/src/ids.ts
@@ -4,7 +4,6 @@ import { isReactFragment } from './helpers';
 import { type NodePath, type t as T, types as t, traverse } from './packages';
 
 export function addOidsToAst(ast: T.File): { ast: T.File; modified: boolean } {
-    console.log('addOidsToAst', ast);
     const oids: Set<string> = new Set();
     let modified = false;
 
@@ -15,12 +14,11 @@ export function addOidsToAst(ast: T.File): { ast: T.File; modified: boolean } {
             }
             const attributes = path.node.attributes;
             const existingOid = getExistingOid(attributes);
-            console.log('existingOid', existingOid);
+
             if (existingOid) {
                 // If the element already has an oid, we need to check if it's unique
                 const { value, index } = existingOid;
                 if (oids.has(value)) {
-                    console.log('oid is not unique', value);
                     // If the oid is not unique, we need to create a new one
                     const newOid = createOid();
                     const attr = attributes[index] as T.JSXAttribute;
@@ -28,7 +26,6 @@ export function addOidsToAst(ast: T.File): { ast: T.File; modified: boolean } {
                     oids.add(newOid);
                     modified = true;
                 } else {
-                    console.log('oid is unique', value);
                     // If the oid is unique, we can add it to the set
                     oids.add(value);
                 }

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -1,4 +1,6 @@
-import { generate, parse, type t as T, types as t } from './packages';
+import { EditorAttributes } from '@onlook/constants';
+import { isReactFragment } from './helpers';
+import { generate, type NodePath, parse, type t as T, types as t, traverse } from './packages';
 
 export function getAstFromContent(content: string): T.File | null {
     try {
@@ -12,10 +14,16 @@ export function getAstFromContent(content: string): T.File | null {
     }
 }
 
-export function getAstFromCodeblock(code: string): T.JSXElement | undefined {
+export function getAstFromCodeblock(
+    code: string,
+    stripIds: boolean = false,
+): T.JSXElement | undefined {
     const ast = getAstFromContent(code);
     if (!ast) {
         return;
+    }
+    if (stripIds) {
+        removeIdsFromAst(ast);
     }
     const jsxElement = ast.program.body.find(
         (node) => t.isExpressionStatement(node) && t.isJSXElement(node.expression),
@@ -32,4 +40,33 @@ export function getAstFromCodeblock(code: string): T.JSXElement | undefined {
 
 export async function getContentFromAst(ast: T.File): Promise<string> {
     return generate(ast, { retainLines: true, compact: false }).code;
+}
+
+export function removeIdsFromAst(ast: T.File) {
+    traverse(ast, {
+        JSXOpeningElement(path: NodePath<T.JSXOpeningElement>) {
+            if (isReactFragment(path.node)) {
+                return;
+            }
+            const attributes = path.node.attributes;
+            const existingAttrIndex = attributes.findIndex(
+                (attr: any) => attr.name?.name === EditorAttributes.DATA_ONLOOK_ID,
+            );
+
+            if (existingAttrIndex !== -1) {
+                attributes.splice(existingAttrIndex, 1);
+            }
+        },
+        JSXAttribute(path: NodePath<T.JSXAttribute>) {
+            if (path.node.name.name === 'key') {
+                const value = path.node.value;
+                if (
+                    t.isStringLiteral(value) &&
+                    value.value.startsWith(EditorAttributes.ONLOOK_MOVE_KEY_PREFIX)
+                ) {
+                    return path.remove();
+                }
+            }
+        },
+    });
 }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove IDs from inserted JSX elements by updating `getAstFromCodeblock` and adding `removeIdsFromAst` in `parse.ts`.
> 
>   - **Behavior**:
>     - `getAstFromCodeblock` in `parse.ts` now accepts a `stripIds` parameter to remove IDs from JSX elements.
>     - `removeIdsFromAst` function added to `parse.ts` to remove `DATA_ONLOOK_ID` and specific `key` attributes.
>     - Default `shouldWarnDelete` set to `false` in `delete.tsx`.
>   - **Code Changes**:
>     - `createInsertedElement` in `insert.ts` calls `getAstFromCodeblock` with `stripIds` set to `true`.
>     - Removed commented-out `sendToWebview` calls in `action/index.ts`.
>     - Added `await this.processFileForMapping(filePath);` in `sandbox/index.ts`.
>   - **Misc**:
>     - Minor formatting changes in `action/index.ts` and `sandbox/index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for cdec612879b30ade5fece0950f3596b35377cad1. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->