### PR TITLE
Fix: Text editor uses current styles

### DIFF
--- a/apps/web/client/src/components/store/editor/text/index.ts
+++ b/apps/web/client/src/components/store/editor/text/index.ts
@@ -62,7 +62,9 @@ export class TextEditingManager {
             this.editorEngine.overlay.state.addTextEditor(
                 adjustedRect,
                 this.originalContent,
-                el.styles?.computed ?? {},
+                this.editorEngine.style.domIdToStyle.get(el.domId)?.computed ??
+                    computedStyles ??
+                    {},
                 (content: string) => {
                     this.edit(content);
                 },


### PR DESCRIPTION
Previously, when a text element was clicked for editing, it could revert to default styling. This was because the text editor was not always initialized with the most up-to-date styles of the element.

This commit modifies the `TextEditingManager.start()` method to prioritize styles from `StyleManager` for the element being edited. If styles are not found in `StyleManager`, it falls back to the `computedStyles` fetched from the element directly. This ensures the text editor consistently uses the correct and current styles, preventing the style reversion issue.

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `TextEditingManager.start()` to prioritize `StyleManager` styles, ensuring text editor uses current styles and prevents reversion to defaults.
> 
>   - **Behavior**:
>     - Updates `TextEditingManager.start()` to prioritize styles from `StyleManager` over `computedStyles` for text elements.
>     - Ensures text editor uses current styles, preventing reversion to default styles.
>   - **Error Handling**:
>     - Logs error if `computedStyles` cannot be fetched in `TextEditingManager.start()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 875cf532946fd08c445ed269e81ab14852063605. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->