### PR TITLE
[wip] not able to listen to iframe errors

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/frame/web-frame.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/frame/web-frame.tsx
@@ -212,7 +212,10 @@ export const WebFrameComponent = observer(
                 allow="geolocation; microphone; camera; midi; encrypted-media"
                 style={{ width: frame.dimension.width, height: frame.dimension.height }}
                 onLoad={setupPenpalConnection}
-                onError={debouncedReloadIframe}
+                onError={(e) => {
+                    console.error('error inside iframe', e);
+                    debouncedReloadIframe();
+                }}
                 {...props}
             />
         );

--- a/apps/web/preload/dist/index.js
+++ b/apps/web/preload/dist/index.js
@@ -17155,6 +17155,21 @@ var preloadMethods = {
   handleBodyReady
 };
 
+// script/listeners/index.ts
+"use client";
+var listenForEvents2 = () => {
+  console.log("listening for events");
+  window.addEventListener("error", (event) => {
+    console.error("xxxiframe inside iframe", event);
+  });
+  window.addEventListener("error", (e) => {
+    console.error("xxxiframe inside iframe", e);
+  });
+  window.addEventListener("unhandledrejection", (e) => {
+    console.error("xxxiframe rejection inside iframe", e);
+  });
+};
+
 // script/index.ts
 var penpalParent = null;
 var isConnecting = false;
@@ -17198,9 +17213,10 @@ var reconnect = import_debounce2.default(() => {
   createMessageConnection();
 }, 1000);
 createMessageConnection();
+listenForEvents2();
 export {
   penpalParent
 };
 
-//# debugId=BBDD2620C8642F0564756E2164756E21
+//# debugId=4BBA540F7070152C64756E2164756E21
 //# sourceMappingURL=index.js.map

--- a/apps/web/preload/script/index.ts
+++ b/apps/web/preload/script/index.ts
@@ -2,6 +2,7 @@ import { PENPAL_CHILD_CHANNEL, type PromisifiedPenpalParentMethods } from '@onlo
 import debounce from 'lodash/debounce';
 import { WindowMessenger, connect } from 'penpal';
 import { preloadMethods } from './api';
+import { listenForEvents } from './listeners';
 
 export let penpalParent: PromisifiedPenpalParentMethods | null = null;
 let isConnecting = false;
@@ -56,3 +57,4 @@ const reconnect = debounce(() => {
 }, 1000);
 
 createMessageConnection();
+listenForEvents();

--- a/apps/web/preload/script/listeners/index.ts
+++ b/apps/web/preload/script/listeners/index.ts
@@ -1,0 +1,17 @@
+"use client";
+
+export const listenForEvents = () => {
+    console.log('listening for events');
+    window.addEventListener('error', (event) => {
+        console.error('xxxiframe inside iframe', event);
+    });
+
+    // In iframe code
+    window.addEventListener('error', e => {
+        console.error('xxxiframe inside iframe', e);
+    });
+
+    window.addEventListener('unhandledrejection', e => {
+        console.error('xxxiframe rejection inside iframe', e);
+    });
+};

--- a/apps/web/template/app/layout.tsx
+++ b/apps/web/template/app/layout.tsx
@@ -29,6 +29,19 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
                         strategy="beforeInteractive"
                     />
                 )}
+                <Script
+                    id="error-handler"
+                    dangerouslySetInnerHTML={{
+                        __html: `
+                                    window.addEventListener('error', (event) => {
+                                        console.error('error inside xxxiframe', event);
+                                    });
+                                    window.addEventListener('unhandledrejection', (event) => {
+                                        console.error('xxxiframe', event.reason);
+                                    });
+                                `,
+                    }}
+                />
             </head>
             <body className={inter.className} data-oid="mwz9mme">
                 {children}


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add error and unhandled rejection listeners to handle iframe errors in `web-frame.tsx`, `listeners/index.ts`, and `layout.tsx`.
> 
>   - **Error Handling**:
>     - Add `onError` handler in `web-frame.tsx` to log iframe errors and call `debouncedReloadIframe()`.
>     - Add `listenForEvents` function in `listeners/index.ts` to log errors and unhandled rejections inside iframes.
>     - Inject error handling script in `layout.tsx` to log errors and unhandled rejections globally.
>   - **Misc**:
>     - Call `listenForEvents()` in `index.ts` to initialize event listeners.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 28374fd2d55c51d8b14c11e6d02e2ad7aa25663b. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->