### PR TITLE
refactor: user specific canvas state

### DIFF
--- a/apps/backend/supabase/migrations/0003_loud_ozymandias.sql
+++ b/apps/backend/supabase/migrations/0003_loud_ozymandias.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "user_canvases" (
+	"user_id" uuid NOT NULL,
+	"canvas_id" uuid NOT NULL,
+	"scale" numeric NOT NULL,
+	"x" numeric NOT NULL,
+	"y" numeric NOT NULL,
+	CONSTRAINT "user_canvases_user_id_canvas_id_pk" PRIMARY KEY("user_id","canvas_id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_canvases" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "user_canvases" ADD CONSTRAINT "user_canvases_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "user_canvases" ADD CONSTRAINT "user_canvases_canvas_id_canvas_id_fk" FOREIGN KEY ("canvas_id") REFERENCES "public"."canvas"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+
+-- Copy over the scale, x, and y values from the canvas table to the user_canvases table
+INSERT INTO "user_canvases" ("user_id", "canvas_id", "scale", "x", "y")
+SELECT 
+    up.user_id,
+    c.id as canvas_id,
+    c.scale,
+    c.x,
+    c.y
+FROM "canvas" c
+INNER JOIN "user_projects" up ON c.project_id = up.project_id
+ON CONFLICT (user_id, canvas_id) DO NOTHING;
+
+ALTER TABLE "canvas" DROP COLUMN "scale";--> statement-breakpoint
+ALTER TABLE "canvas" DROP COLUMN "x";--> statement-breakpoint
+ALTER TABLE "canvas" DROP COLUMN "y";

--- a/apps/backend/supabase/migrations/meta/0003_snapshot.json
+++ b/apps/backend/supabase/migrations/meta/0003_snapshot.json
@@ -1,0 +1,617 @@
+{
+  "id": "518e58bf-052b-4c2c-8095-3fa357233432",
+  "prevId": "cf650e40-2b28-43b0-bfcd-fdd3603f7f88",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.canvas": {
+      "name": "canvas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "canvas_project_id_projects_id_fk": {
+          "name": "canvas_project_id_projects_id_fk",
+          "tableFrom": "canvas",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "frame_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "frames_canvas_id_canvas_id_fk": {
+          "name": "frames_canvas_id_canvas_id_fk",
+          "tableFrom": "frames",
+          "tableTo": "canvas",
+          "columnsFrom": [
+            "canvas_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_project_id_projects_id_fk": {
+          "name": "conversations_project_id_projects_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "snapshots": {
+          "name": "snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_url": {
+          "name": "sandbox_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "preview_img": {
+          "name": "preview_img",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_apply_code": {
+          "name": "auto_apply_code",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expand_code_blocks": {
+          "name": "expand_code_blocks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_suggestions": {
+          "name": "show_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_mini_chat": {
+          "name": "show_mini_chat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_id_users_id_fk": {
+          "name": "users_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_canvases": {
+      "name": "user_canvases",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canvas_id": {
+          "name": "canvas_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scale": {
+          "name": "scale",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "y": {
+          "name": "y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_canvases_user_id_users_id_fk": {
+          "name": "user_canvases_user_id_users_id_fk",
+          "tableFrom": "user_canvases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_canvases_canvas_id_canvas_id_fk": {
+          "name": "user_canvases_canvas_id_canvas_id_fk",
+          "tableFrom": "user_canvases",
+          "tableTo": "canvas",
+          "columnsFrom": [
+            "canvas_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_canvases_user_id_canvas_id_pk": {
+          "name": "user_canvases_user_id_canvas_id_pk",
+          "columns": [
+            "user_id",
+            "canvas_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user_projects": {
+      "name": "user_projects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_projects_user_id_users_id_fk": {
+          "name": "user_projects_user_id_users_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "user_projects_project_id_projects_id_fk": {
+          "name": "user_projects_project_id_projects_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_projects_user_id_project_id_pk": {
+          "name": "user_projects_user_id_project_id_pk",
+          "columns": [
+            "user_id",
+            "project_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "public.frame_type": {
+      "name": "frame_type",
+      "schema": "public",
+      "values": [
+        "web"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/supabase/migrations/meta/_journal.json
+++ b/apps/backend/supabase/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1748028633785,
       "tag": "0002_red_crusher_hogan",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1748335865371,
+      "tag": "0003_loud_ozymandias",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/client/src/app/project/[id]/_components/main.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/main.tsx
@@ -40,7 +40,7 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
         if (!result) {
             return;
         }
-        const { project, canvas, frames, conversation } = result;
+        const { project, canvas, userCanvas, frames, conversation } = result;
         projectManager.project = project;
 
         if (project.sandbox?.id) {
@@ -54,7 +54,7 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
         }
 
         if (canvas) {
-            editorEngine.canvas.applyCanvas(canvas);
+            editorEngine.canvas.applyCanvas(userCanvas);
         } else {
             console.error('No canvas');
         }
@@ -81,22 +81,29 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
         const sandboxConnected = !!editorEngine.sandbox.session.session;
 
         if (shouldCreate && conversationReady && sandboxConnected) {
-            editorEngine.chat.getCreateMessages(creationData.prompt, creationData.images).then((messages) => {
-                if (!messages) {
-                    console.error('Failed to get creation messages');
-                    return;
-                }
-                createManager.pendingCreationData = null;
-                sendMessages(messages, ChatType.CREATE);
-
-            });
+            editorEngine.chat
+                .getCreateMessages(creationData.prompt, creationData.images)
+                .then((messages) => {
+                    if (!messages) {
+                        console.error('Failed to get creation messages');
+                        return;
+                    }
+                    createManager.pendingCreationData = null;
+                    sendMessages(messages, ChatType.CREATE);
+                });
         }
-    }, [editorEngine.chat.conversation.current, createManager.pendingCreationData, editorEngine.sandbox.session.session]);
+    }, [
+        editorEngine.chat.conversation.current,
+        createManager.pendingCreationData,
+        editorEngine.sandbox.session.session,
+    ]);
 
     useEffect(() => {
         function measure() {
             const left = leftPanelRef.current?.getBoundingClientRect().right ?? 0;
-            const right = window.innerWidth - (rightPanelRef.current?.getBoundingClientRect().left ?? window.innerWidth);
+            const right =
+                window.innerWidth -
+                (rightPanelRef.current?.getBoundingClientRect().left ?? window.innerWidth);
             setToolbarLeft(left);
             setToolbarRight(right);
             setEditorBarAvailableWidth(window.innerWidth - left - right);
@@ -108,7 +115,9 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
         let pollInterval: NodeJS.Timeout | null = null;
         pollInterval = setInterval(() => {
             const left = leftPanelRef.current?.getBoundingClientRect().right ?? 0;
-            const right = window.innerWidth - (rightPanelRef.current?.getBoundingClientRect().left ?? window.innerWidth);
+            const right =
+                window.innerWidth -
+                (rightPanelRef.current?.getBoundingClientRect().left ?? window.innerWidth);
             if (left > 0 && right > 0) {
                 measure();
                 if (pollInterval) clearInterval(pollInterval);
@@ -176,7 +185,10 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
                 </div>
 
                 {/* Left Panel */}
-                <div ref={leftPanelRef} className="absolute top-10 left-0 animate-layer-panel-in h-[calc(100%-40px)] z-50">
+                <div
+                    ref={leftPanelRef}
+                    className="absolute top-10 left-0 animate-layer-panel-in h-[calc(100%-40px)] z-50"
+                >
                     <LeftPanel />
                 </div>
 
@@ -200,7 +212,10 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
                 </div>
 
                 {/* Right Panel */}
-                <div ref={rightPanelRef} className="absolute top-10 right-0 animate-edit-panel-in h-[calc(100%-40px)] z-50">
+                <div
+                    ref={rightPanelRef}
+                    className="absolute top-10 right-0 animate-edit-panel-in h-[calc(100%-40px)] z-50"
+                >
                     <RightPanel />
                 </div>
 
@@ -208,6 +223,6 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
                     <BottomBar />
                 </div>
             </div>
-        </TooltipProvider >
+        </TooltipProvider>
     );
 });

--- a/apps/web/client/src/components/store/editor/canvas/index.ts
+++ b/apps/web/client/src/components/store/editor/canvas/index.ts
@@ -64,9 +64,7 @@ export class CanvasManager {
     }
 
     async updateCanvas(canvas: Canvas) {
-        const success = await api.canvas.update.mutate(
-            fromCanvas(this.projects.project?.id ?? '', canvas),
-        );
+        const success = await api.userCanvas.update.mutate(fromCanvas(canvas));
         if (!success) {
             console.error('Failed to update canvas');
         }
@@ -95,13 +93,11 @@ export class CanvasManager {
 
     private undebouncedSaveSettings() {
         if (this.projects.project) {
-            this.updateCanvas(
-                {
-                    id: this.id,
-                    position: this.position,
-                    scale: this.scale,
-                },
-            );
+            this.updateCanvas({
+                id: this.id,
+                position: this.position,
+                scale: this.scale,
+            });
         }
     }
 }

--- a/apps/web/client/src/server/api/root.ts
+++ b/apps/web/client/src/server/api/root.ts
@@ -4,6 +4,7 @@ import { chatRouter } from './routers/chat';
 import { sandboxRouter } from './routers/sandbox';
 import { frameRouter } from './routers/frame';
 import { canvasRouter } from './routers/canvas';
+import { userCanvasRouter } from './routers/user-canvas';
 
 /**
  * This is the primary router for your server.
@@ -17,6 +18,7 @@ export const appRouter = createTRPCRouter({
     chat: chatRouter,
     frame: frameRouter,
     canvas: canvasRouter,
+    userCanvas: userCanvasRouter,
 });
 
 // export type definition of API

--- a/apps/web/client/src/server/api/routers/canvas.ts
+++ b/apps/web/client/src/server/api/routers/canvas.ts
@@ -1,20 +1,24 @@
-import { canvases, canvasUpdateSchema, toCanvas } from "@onlook/db";
-import { eq } from "drizzle-orm";
-import { z } from "zod";
-import { createTRPCRouter, protectedProcedure } from "../trpc";
+import { canvases, canvasUpdateSchema, toCanvas } from '@onlook/db';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { createTRPCRouter, protectedProcedure } from '../trpc';
 
 export const canvasRouter = createTRPCRouter({
-    get: protectedProcedure.input(z.object({
-        projectId: z.string(),
-    })).query(async ({ ctx, input }) => {
-        const dbCanvas = await ctx.db.query.canvases.findFirst({
-            where: eq(canvases.projectId, input.projectId),
-        });
-        if (!dbCanvas) {
-            return null;
-        }
-        return toCanvas(dbCanvas);
-    }),
+    get: protectedProcedure
+        .input(
+            z.object({
+                projectId: z.string(),
+            }),
+        )
+        .query(async ({ ctx, input }) => {
+            const dbCanvas = await ctx.db.query.canvases.findFirst({
+                where: eq(canvases.projectId, input.projectId),
+            });
+            if (!dbCanvas) {
+                return null;
+            }
+            return dbCanvas;
+        }),
     update: protectedProcedure.input(canvasUpdateSchema).mutation(async ({ ctx, input }) => {
         try {
             if (!input.id) {
@@ -27,6 +31,4 @@ export const canvasRouter = createTRPCRouter({
             return false;
         }
     }),
-
-
 });

--- a/apps/web/client/src/server/api/routers/project.ts
+++ b/apps/web/client/src/server/api/routers/project.ts
@@ -7,11 +7,13 @@ import {
     toConversation,
     toFrame,
     toProject,
+    userCanvases,
     userProjects,
-    type Canvas
+    type Canvas,
+    type UserCanvas,
 } from '@onlook/db';
-import { createDefaultCanvas, createDefaultFrame } from '@onlook/utility';
-import { eq } from 'drizzle-orm';
+import { createDefaultCanvas, createDefaultFrame, createDefaultUserCanvas } from '@onlook/utility';
+import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../trpc';
 
@@ -40,11 +42,25 @@ export const projectRouter = createTRPCRouter({
             const canvas: Canvas = project.canvas
                 ? project.canvas
                 : createDefaultCanvas(project.id);
+
+            const dbUserCanvas = await ctx.db.query.userCanvases.findFirst({
+                where: and(
+                    eq(userCanvases.canvasId, canvas.id),
+                    eq(userCanvases.userId, ctx.user.id),
+                ),
+            });
+
+            const userCanvas: UserCanvas =
+                dbUserCanvas ?? createDefaultUserCanvas(ctx.user.id, canvas.id);
+
             return {
                 project: toProject(project),
-                canvas: toCanvas(canvas),
+                canvas,
+                userCanvas: toCanvas(userCanvas),
                 frames: project.canvas?.frames.map(toFrame) ?? [],
-                conversation: project.conversations[0] ? toConversation(project.conversations[0]) : null,
+                conversation: project.conversations[0]
+                    ? toConversation(project.conversations[0])
+                    : null,
             };
         }),
     create: protectedProcedure
@@ -66,6 +82,9 @@ export const projectRouter = createTRPCRouter({
                 // 3. Create the default canvas
                 const newCanvas = createDefaultCanvas(newProject.id);
                 await tx.insert(canvases).values(newCanvas);
+
+                const newUserCanvas = createDefaultUserCanvas(input.userId, newCanvas.id);
+                await tx.insert(userCanvases).values(newUserCanvas);
 
                 // 4. Create the default frame
                 const newFrame = createDefaultFrame(newCanvas.id, input.project.sandboxUrl);
@@ -93,12 +112,10 @@ export const projectRouter = createTRPCRouter({
             });
             return projects.map((project) => toProject(project.project));
         }),
-    update: protectedProcedure
-        .input(projectInsertSchema)
-        .mutation(async ({ ctx, input }) => {
-            if (!input.id) {
-                throw new Error('Project ID is required');
-            }
-            await ctx.db.update(projects).set(input).where(eq(projects.id, input.id));
-        }),
+    update: protectedProcedure.input(projectInsertSchema).mutation(async ({ ctx, input }) => {
+        if (!input.id) {
+            throw new Error('Project ID is required');
+        }
+        await ctx.db.update(projects).set(input).where(eq(projects.id, input.id));
+    }),
 });

--- a/apps/web/client/src/server/api/routers/project.ts
+++ b/apps/web/client/src/server/api/routers/project.ts
@@ -27,6 +27,9 @@ export const projectRouter = createTRPCRouter({
                     canvas: {
                         with: {
                             frames: true,
+                            userCanvases: {
+                                where: eq(userCanvases.userId, ctx.user.id),
+                            },
                         },
                     },
                     conversations: {

--- a/apps/web/client/src/server/api/routers/project.ts
+++ b/apps/web/client/src/server/api/routers/project.ts
@@ -27,9 +27,6 @@ export const projectRouter = createTRPCRouter({
                     canvas: {
                         with: {
                             frames: true,
-                            userCanvases: {
-                                where: eq(userCanvases.userId, ctx.user.id),
-                            },
                         },
                     },
                     conversations: {

--- a/apps/web/client/src/server/api/routers/user-canvas.ts
+++ b/apps/web/client/src/server/api/routers/user-canvas.ts
@@ -17,22 +17,20 @@ export const userCanvasRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
-            const result = await ctx.db
-                .select()
-                .from(canvases)
-                .innerJoin(userCanvases, eq(canvases.id, userCanvases.canvasId))
-                .where(
-                    and(
-                        eq(canvases.projectId, input.projectId),
-                        eq(userCanvases.userId, ctx.user.id),
-                    ),
-                )
-                .limit(1);
+            const userCanvas = await ctx.db.query.userCanvases.findFirst({
+                where: and(
+                    eq(canvases.projectId, input.projectId),
+                    eq(userCanvases.userId, ctx.user.id),
+                ),
+                with: {
+                    canvas: true,
+                },
+            });
 
-            if (!result[0]) {
+            if (!userCanvas) {
                 return null;
             }
-            return toCanvas(result[0].user_canvases);
+            return toCanvas(userCanvas);
         }),
     update: protectedProcedure.input(userCanvasUpdateSchema).mutation(async ({ ctx, input }) => {
         try {

--- a/apps/web/client/src/server/api/routers/user-canvas.ts
+++ b/apps/web/client/src/server/api/routers/user-canvas.ts
@@ -1,9 +1,8 @@
 import {
     canvases,
-    canvasUpdateSchema,
     toCanvas,
     userCanvases,
-    userCanvasUpdateSchema,
+    userCanvasUpdateSchema
 } from '@onlook/db';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
@@ -28,7 +27,7 @@ export const userCanvasRouter = createTRPCRouter({
             });
 
             if (!userCanvas) {
-                return null;
+                throw new Error('User canvas not found');
             }
             return toCanvas(userCanvas);
         }),

--- a/apps/web/client/src/server/api/routers/user-canvas.ts
+++ b/apps/web/client/src/server/api/routers/user-canvas.ts
@@ -1,0 +1,57 @@
+import {
+    canvases,
+    canvasUpdateSchema,
+    toCanvas,
+    userCanvases,
+    userCanvasUpdateSchema,
+} from '@onlook/db';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { createTRPCRouter, protectedProcedure } from '../trpc';
+
+export const userCanvasRouter = createTRPCRouter({
+    get: protectedProcedure
+        .input(
+            z.object({
+                projectId: z.string(),
+            }),
+        )
+        .query(async ({ ctx, input }) => {
+            const result = await ctx.db
+                .select()
+                .from(canvases)
+                .innerJoin(userCanvases, eq(canvases.id, userCanvases.canvasId))
+                .where(
+                    and(
+                        eq(canvases.projectId, input.projectId),
+                        eq(userCanvases.userId, ctx.user.id),
+                    ),
+                )
+                .limit(1);
+
+            if (!result[0]) {
+                return null;
+            }
+            return toCanvas(result[0].user_canvases);
+        }),
+    update: protectedProcedure.input(userCanvasUpdateSchema).mutation(async ({ ctx, input }) => {
+        try {
+            if (!input.canvasId) {
+                throw new Error('Canvas ID is required');
+            }
+            await ctx.db
+                .update(userCanvases)
+                .set(input)
+                .where(
+                    and(
+                        eq(userCanvases.canvasId, input.canvasId),
+                        eq(userCanvases.userId, ctx.user.id),
+                    ),
+                );
+            return true;
+        } catch (error) {
+            console.error('Error updating user canvas', error);
+            return false;
+        }
+    }),
+});

--- a/packages/db/src/dto/canvas.ts
+++ b/packages/db/src/dto/canvas.ts
@@ -1,23 +1,22 @@
-import type { Canvas } from "@onlook/models";
-import type { Canvas as DbCanvas } from "../schema";
+import type { Canvas } from '@onlook/models';
+import type { UserCanvas as DbUserCanvas } from '../schema';
 
-export const toCanvas = (dbCanvas: DbCanvas): Canvas => {
+export const toCanvas = (dbUserCanvas: DbUserCanvas): Canvas => {
     return {
-        id: dbCanvas.id,
-        scale: Number(dbCanvas.scale),
+        id: dbUserCanvas.canvasId,
+        scale: Number(dbUserCanvas.scale),
         position: {
-            x: Number(dbCanvas.x),
-            y: Number(dbCanvas.y),
+            x: Number(dbUserCanvas.x),
+            y: Number(dbUserCanvas.y),
         },
     };
 };
 
-export const fromCanvas = (projectId: string, canvas: Canvas): DbCanvas => {
+export const fromCanvas = (canvas: Canvas): Omit<DbUserCanvas, 'userId'> => {
     return {
-        id: canvas.id,
         scale: canvas.scale.toString(),
         x: canvas.position.x.toString(),
         y: canvas.position.y.toString(),
-        projectId,
+        canvasId: canvas.id,
     };
 };

--- a/packages/db/src/schema/project/canvas/canvas.ts
+++ b/packages/db/src/schema/project/canvas/canvas.ts
@@ -1,17 +1,15 @@
-import { relations } from "drizzle-orm";
-import { numeric, pgTable, uuid } from "drizzle-orm/pg-core";
-import { projects } from "../project";
-import { frames } from "./frame";
-import { createUpdateSchema } from "drizzle-zod";
+import { relations } from 'drizzle-orm';
+import { pgTable, uuid } from 'drizzle-orm/pg-core';
+import { projects } from '../project';
+import { frames } from './frame';
+import { createUpdateSchema } from 'drizzle-zod';
+import { userCanvases } from '../../user';
 
-export const canvases = pgTable("canvas", {
-    id: uuid("id").primaryKey().defaultRandom(),
-    projectId: uuid("project_id")
+export const canvases = pgTable('canvas', {
+    id: uuid('id').primaryKey().defaultRandom(),
+    projectId: uuid('project_id')
         .notNull()
-        .references(() => projects.id, { onDelete: "cascade", onUpdate: "cascade" }),
-    scale: numeric("scale").notNull(),
-    x: numeric("x").notNull(),
-    y: numeric("y").notNull(),
+        .references(() => projects.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
 }).enableRLS();
 
 export const canvasUpdateSchema = createUpdateSchema(canvases);
@@ -21,6 +19,7 @@ export type NewCanvas = typeof canvases.$inferInsert;
 
 export const canvasRelations = relations(canvases, ({ one, many }) => ({
     frames: many(frames),
+    userCanvases: many(userCanvases),
     project: one(projects, {
         fields: [canvases.projectId],
         references: [projects.id],

--- a/packages/db/src/schema/user/index.ts
+++ b/packages/db/src/schema/user/index.ts
@@ -1,3 +1,4 @@
 export * from './settings';
 export * from './user';
+export * from './user-canvas';
 export * from './user-project';

--- a/packages/db/src/schema/user/user-canvas.ts
+++ b/packages/db/src/schema/user/user-canvas.ts
@@ -1,0 +1,38 @@
+import { relations } from 'drizzle-orm';
+import { numeric, pgTable, primaryKey, uuid } from 'drizzle-orm/pg-core';
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod';
+import { canvases } from '../../schema';
+import { users } from './user';
+
+export const userCanvases = pgTable(
+    'user_canvases',
+    {
+        userId: uuid('user_id')
+            .notNull()
+            .references(() => users.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+        canvasId: uuid('canvas_id')
+            .notNull()
+            .references(() => canvases.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+        scale: numeric('scale').notNull(),
+        x: numeric('x').notNull(),
+        y: numeric('y').notNull(),
+    },
+    (table) => [primaryKey({ columns: [table.userId, table.canvasId] })],
+).enableRLS();
+
+export const userCanvasInsertSchema = createInsertSchema(userCanvases);
+export const userCanvasUpdateSchema = createUpdateSchema(userCanvases);
+
+export type UserCanvas = typeof userCanvases.$inferSelect;
+export type NewUserCanvas = typeof userCanvases.$inferInsert;
+
+export const userCanvasesRelations = relations(userCanvases, ({ one }) => ({
+    user: one(users, {
+        fields: [userCanvases.userId],
+        references: [users.id],
+    }),
+    canvas: one(canvases, {
+        fields: [userCanvases.canvasId],
+        references: [canvases.id],
+    }),
+}));

--- a/packages/db/src/schema/user/user.ts
+++ b/packages/db/src/schema/user/user.ts
@@ -3,15 +3,17 @@ import { pgTable, uuid } from 'drizzle-orm/pg-core';
 import { createInsertSchema } from 'drizzle-zod';
 import { authUsers } from '../supabase/user';
 import { userSettings } from './settings';
+import { userCanvases } from './user-canvas';
 import { userProjects } from './user-project';
 
-export const users = pgTable("users", {
-    id: uuid("id")
+export const users = pgTable('users', {
+    id: uuid('id')
         .primaryKey()
-        .references(() => authUsers.id, { onDelete: "cascade", onUpdate: "cascade" }),
+        .references(() => authUsers.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
 }).enableRLS();
 
 export const usersRelations = relations(users, ({ many, one }) => ({
+    userCanvases: many(userCanvases),
     userProjects: many(userProjects),
     userSettings: one(userSettings),
 }));

--- a/packages/db/src/seed/db.ts
+++ b/packages/db/src/seed/db.ts
@@ -1,4 +1,4 @@
-import { canvases, conversations, frames, messages, projects, userProjects, users, type Conversation, type Message, type Project, type User } from '@onlook/db';
+import { canvases, conversations, frames, messages, projects, userProjects, userCanvases, users, type Conversation, type Message, type Project, type User } from '@onlook/db';
 import { db } from '@onlook/db/src/client';
 import { ChatMessageRole, MessageContextType, type ChatMessageContext } from '@onlook/models';
 import { createDefaultCanvas, createDefaultFrame } from '@onlook/utility';

--- a/packages/db/src/seed/db.ts
+++ b/packages/db/src/seed/db.ts
@@ -1,7 +1,7 @@
-import { canvases, conversations, frames, messages, projects, userProjects, userCanvases, users, type Conversation, type Message, type Project, type User } from '@onlook/db';
+import { canvases, conversations, frames, messages, projects, userCanvases, userProjects, users, type Conversation, type Message, type Project, type User } from '@onlook/db';
 import { db } from '@onlook/db/src/client';
 import { ChatMessageRole, MessageContextType, type ChatMessageContext } from '@onlook/models';
-import { createDefaultCanvas, createDefaultFrame } from '@onlook/utility';
+import { createDefaultCanvas, createDefaultFrame, createDefaultUserCanvas } from '@onlook/utility';
 import { v4 as uuidv4 } from 'uuid';
 
 const user0 = {
@@ -34,6 +34,8 @@ const canvas0 = createDefaultCanvas(project0.id);
 const canvas1 = createDefaultCanvas(project1.id);
 const frame0 = createDefaultFrame(canvas0.id, project0.sandboxUrl);
 const frame1 = createDefaultFrame(canvas1.id, project1.sandboxUrl);
+const userCanvas0 = createDefaultUserCanvas(user0.id, canvas0.id);
+const userCanvas1 = createDefaultUserCanvas(user0.id, canvas1.id);
 
 const conversation0 = {
     id: uuidv4(),
@@ -151,6 +153,10 @@ export const seedDb = async () => {
         await tx.insert(canvases).values([
             canvas0,
             canvas1,
+        ]);
+        await tx.insert(userCanvases).values([
+            userCanvas0,
+            userCanvas1,
         ]);
         await tx.insert(frames).values([
             frame0,

--- a/packages/utility/src/canvas.ts
+++ b/packages/utility/src/canvas.ts
@@ -5,9 +5,6 @@ import { v4 as uuidv4 } from 'uuid';
 export const createDefaultCanvas = (projectId: string): DbCanvas => {
     return {
         id: uuidv4(),
-        scale: DefaultSettings.SCALE.toString(),
-        x: DefaultSettings.PAN_POSITION.x.toString(),
-        y: DefaultSettings.PAN_POSITION.y.toString(),
         projectId: projectId,
     };
 };

--- a/packages/utility/src/index.ts
+++ b/packages/utility/src/index.ts
@@ -16,4 +16,5 @@ export * from './tailwind';
 export * from './time';
 export * from './unit';
 export * from './urls';
+export * from './user-canvas';
 export * from './window-metadata';

--- a/packages/utility/src/user-canvas.ts
+++ b/packages/utility/src/user-canvas.ts
@@ -1,0 +1,12 @@
+import { DefaultSettings } from '@onlook/constants';
+import type { UserCanvas as DbUserCanvas } from '@onlook/db';
+
+export const createDefaultUserCanvas = (userId: string, canvasId: string): DbUserCanvas => {
+    return {
+        userId,
+        canvasId,
+        scale: DefaultSettings.SCALE.toString(),
+        x: DefaultSettings.PAN_POSITION.x.toString(),
+        y: DefaultSettings.PAN_POSITION.y.toString(),
+    };
+};


### PR DESCRIPTION
# Implement User-Specific Canvas State Management

## Description

Refactored canvas data storage to be user-specific, allowing multiple users to have independent canvas view states (scale, pan position) for the same project. This enables proper multi-user collaboration where each user maintains their own viewport settings.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [x] Refactor
- [ ] Other (please describe):

## Changes Made

### Database Schema
- **Created `user_canvases` table** with composite primary key (`user_id`, `canvas_id`) to store user-specific canvas viewport data
- **Added foreign key constraints** linking to `users` and `canvas` tables with cascade delete/update
- **Enabled row-level security** on the new table
- **Migrated existing canvas data** from `canvas` table to `user_canvases` via JOIN with `user_projects`
- **Removed viewport columns** (`scale`, `x`, `y`) from `canvas` table as they're now user-specific

### API Layer
- **Added `userCanvasRouter`** with get/update endpoints for user canvas operations
- **Updated project router** to fetch and return both canvas and user canvas data
- **Modified canvas router** to return raw canvas data without viewport information
- **Implemented user canvas utilities** for creating default entries

### Frontend Integration
- **Updated canvas manager** to use user canvas API endpoints instead of general canvas endpoints
- **Modified project data flow** to apply user canvas data to editor engine
- **Added user canvas creation** during project setup to ensure default entries exist

### Utility Functions
- **Created `createDefaultUserCanvas`** helper function for generating default user canvas entries
- **Updated canvas creation** to exclude viewport data (now handled by user canvas)

## Testing

- Verify existing projects maintain their canvas viewport settings after migration
- Test that new users get default canvas settings when accessing projects
- Confirm multiple users can have independent viewport states for the same project
- Validate cascade deletes work properly when users or canvases are removed

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

This change maintains backward compatibility through the migration script that preserves existing canvas viewport data. The refactor enables true multi-user collaboration by isolating each user's canvas view state while maintaining shared project and frame data.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to implement user-specific canvas state management, enabling independent viewport settings per user.
> 
>   - **Database Schema**:
>     - Create `user_canvases` table with composite primary key (`user_id`, `canvas_id`) for user-specific viewport data.
>     - Add foreign key constraints to `users` and `canvas` tables with cascade delete/update.
>     - Enable row-level security on `user_canvases`.
>     - Migrate viewport data from `canvas` to `user_canvases`.
>     - Remove `scale`, `x`, `y` columns from `canvas` table.
>   - **API Layer**:
>     - Add `userCanvasRouter` with get/update endpoints in `user-canvas.ts`.
>     - Update `project.ts` to handle user canvas data.
>     - Modify `canvas.ts` to return raw canvas data without viewport info.
>   - **Frontend Integration**:
>     - Update `main.tsx` to use user canvas data.
>     - Modify `CanvasManager` in `canvas/index.ts` to update user canvas.
>   - **Utility Functions**:
>     - Create `createDefaultUserCanvas` in `user-canvas.ts` for default user canvas entries.
>     - Update `createDefaultCanvas` to exclude viewport data.
>   - **Testing**:
>     - Ensure projects maintain viewport settings post-migration.
>     - Verify new users receive default canvas settings.
>     - Confirm independent viewport states for multiple users.
>     - Validate cascade deletes for users/canvases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 66c79bc81ff210f251c4996a6cc0d6a237a4861e. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->