### PR TITLE
fix: ensure user inviter and invitee email exists

### DIFF
--- a/apps/web/client/src/server/api/routers/invitation.ts
+++ b/apps/web/client/src/server/api/routers/invitation.ts
@@ -48,6 +48,13 @@ export const invitationRouter = createTRPCRouter({
                 });
             }
 
+            if (!ctx.user.email) {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: 'You must have an email to invite a user',
+                });
+            }
+
             const invitation = await ctx.db
                 .transaction(async (tx) => {
                     const existingUser = await tx
@@ -116,6 +123,14 @@ export const invitationRouter = createTRPCRouter({
                     message: 'You must be logged in to accept an invitation',
                 });
             }
+
+            if (!ctx.user.email) {
+                throw new TRPCError({
+                    code: 'BAD_REQUEST',
+                    message: 'You must have an email to accept an invitation',
+                });
+            }
+
 
             const invitation = await ctx.db.query.projectInvitations.findFirst({
                 where: and(


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure inviter and invitee have emails before creating or accepting invitations in `invitationRouter`.
> 
>   - **Behavior**:
>     - In `invitationRouter` in `invitation.ts`, added checks to ensure `ctx.user.email` exists before creating or accepting invitations.
>     - Throws `TRPCError` with `BAD_REQUEST` if `ctx.user.email` is missing when inviting or accepting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for c26000c896520a718be7b444a459c38cdf266637. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->