### PR TITLE
chore: enforce user email requirement in protected route

### DIFF
--- a/apps/web/client/package.json
+++ b/apps/web/client/package.json
@@ -107,6 +107,7 @@
         "prettier": "^3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^4.0.15",
+        "type-fest": "^4.41.0",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.27.0"
     },

--- a/apps/web/client/src/server/api/routers/invitation.ts
+++ b/apps/web/client/src/server/api/routers/invitation.ts
@@ -5,7 +5,7 @@ import {
     projectInvitationInsertSchema,
     projectInvitations,
     userCanvases,
-    userProjects
+    userProjects,
 } from '@onlook/db';
 import { sendInvitationEmail } from '@onlook/email';
 import { ProjectRole } from '@onlook/models';
@@ -45,13 +45,6 @@ export const invitationRouter = createTRPCRouter({
                 throw new TRPCError({
                     code: 'UNAUTHORIZED',
                     message: 'You must be logged in to invite a user',
-                });
-            }
-
-            if (!ctx.user.email) {
-                throw new TRPCError({
-                    code: 'BAD_REQUEST',
-                    message: 'You must have an email to invite a user',
                 });
             }
 
@@ -123,14 +116,6 @@ export const invitationRouter = createTRPCRouter({
                     message: 'You must be logged in to accept an invitation',
                 });
             }
-
-            if (!ctx.user.email) {
-                throw new TRPCError({
-                    code: 'BAD_REQUEST',
-                    message: 'You must have an email to accept an invitation',
-                });
-            }
-
 
             const invitation = await ctx.db.query.projectInvitations.findFirst({
                 where: and(

--- a/apps/web/client/src/server/api/trpc.ts
+++ b/apps/web/client/src/server/api/trpc.ts
@@ -10,6 +10,8 @@
 import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
 import { ZodError } from 'zod';
+import type { User } from '@supabase/supabase-js';
+import type { SetRequiredDeep } from 'type-fest';
 
 import { createClient } from '@/utils/supabase/server';
 import { db } from '@onlook/db/src/client';
@@ -130,10 +132,18 @@ export const protectedProcedure = t.procedure.use(timingMiddleware).use(({ ctx, 
     if (!ctx.user) {
         throw new TRPCError({ code: 'UNAUTHORIZED' });
     }
+
+    if (!ctx.user.email) {
+        throw new TRPCError({
+            code: 'UNAUTHORIZED',
+            message: 'User must have an email address to access this resource',
+        });
+    }
+
     return next({
         ctx: {
             // infers the `session` as non-nullable
-            user: ctx.user,
+            user: ctx.user as SetRequiredDeep<User, 'email'>,
             db: ctx.db,
         },
     });

--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "prettier": "^3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^4.0.15",
+        "type-fest": "^4.41.0",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.27.0",
       },
@@ -3341,7 +3342,7 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -3694,6 +3695,8 @@
     "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "glob/minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
+
+    "globals/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
 
     "globby/ignore": ["ignore@7.0.4", "", {}, "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A=="],
 


### PR DESCRIPTION
## Description

- Enforce user has an email in protected routes
- Updated `type-fest` dependency in `bun.lock` and `package.json` to version 4.41.0.
- Added checks in `protectedProcedure` to ensure `ctx.user.email` is present, throwing an error if not.
- Removed redundant email checks from `invitationRouter` to streamline the invitation process.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [x] Refactor
- [ ] Other (please describe):

## Testing

N/A

## Screenshots (if applicable)

N/A

## Additional Notes

N/A

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforce email requirement in `protectedProcedure` and update `type-fest` dependency.
> 
>   - **Behavior**:
>     - Enforce email presence in `protectedProcedure` in `trpc.ts`, throwing an error if `ctx.user.email` is missing.
>     - Remove redundant email checks from `invitationRouter`.
>   - **Dependencies**:
>     - Update `type-fest` to version 4.41.0 in `package.json` and `bun.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for aef82a0f42a56a147f44ab6181d3ef96399f3315. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->