### PR TITLE
fix: text hidden when canvas is clicked

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/overlay/elements/text.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/overlay/elements/text.tsx
@@ -74,28 +74,19 @@ export const TextEditor: React.FC<TextEditorProps> = ({
             view.focus();
         }
 
-        return () => {
-            view.destroy();
-        };
-    }, [content, styles, isComponent, isDisabled]);
-
-    // Handle blur events
-    useEffect(() => {
+        // Attach blur handler directly to ProseMirror's contenteditable
         const handleBlur = (event: FocusEvent) => {
-            const editorElement = editorRef.current;
-            if (editorElement && !editorElement.contains(event.relatedTarget as Node)) {
-                onStop?.();
+            if (onStop && !editorRef.current?.contains(event.relatedTarget as Node)) {
+                onStop();
             }
         };
+        view.dom.addEventListener('blur', handleBlur, true);
 
-        const editorElement = editorRef.current;
-        if (editorElement) {
-            editorElement.addEventListener('blur', handleBlur, true);
-            return () => {
-                editorElement.removeEventListener('blur', handleBlur, true);
-            };
-        }
-    }, [onStop]);
+        return () => {
+            view.dom.removeEventListener('blur', handleBlur, true);
+            view.destroy();
+        };
+    }, [content, styles, isComponent, isDisabled, onChange, onStop]);
 
     // Update editor state when disabled state changes
     useEffect(() => {

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "@codemirror/lang-javascript": "^6.2.3",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/lang-markdown": "^6.1.7",
-        "@codesandbox/sdk": "^1.1.6",
+        "@codesandbox/sdk": "^1.1.2",
         "@onlook/constants": "*",
         "@onlook/db": "*",
         "@onlook/email": "*",
@@ -614,7 +614,7 @@
 
     "@codemirror/view": ["@codemirror/view@6.36.8", "", { "dependencies": { "@codemirror/state": "^6.5.0", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-yoRo4f+FdnD01fFt4XpfpMCcCAo9QvZOtbrXExn4SqzH32YC6LgzqxfLZw/r6Ge65xyY03mK/UfUqrVw1gFiFg=="],
 
-    "@codesandbox/sdk": ["@codesandbox/sdk@1.1.6", "", { "dependencies": { "ora": "^8.2.0", "readline": "^1.3.0" }, "bin": { "csb": "dist/bin/codesandbox.cjs" } }, "sha512-65k6TZSr1c0u8xYjBsz32xhMEq1TwHbqRONJ8h6e3re01qylZ5BDtAU6Nnxr9GQmmhOA0wl+3c4h4zY3/HdHHg=="],
+    "@codesandbox/sdk": ["@codesandbox/sdk@1.1.2", "", { "dependencies": { "ora": "^8.2.0", "readline": "^1.3.0" }, "bin": { "csb": "dist/bin/codesandbox.cjs" } }, "sha512-fvXuNyiIHSM3vyxIqaZ0RgtbmzZlSQqKio1VXcoicmg6k3GSeOMBb/boSWfPCn6lUDer6jMPaX15i37DeDayTQ=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 


### PR DESCRIPTION
## Description

Fixes a bug where layers would appear hidden when deselecting by clicking outside the frame. The layer is expected to stay visible even after clicking outside of the frame.

## Related Issues

Fixes #1971 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

When editing and deselect something, it should be applied immediately. If I deselect by clicking inside the frame, it works right away. But if I deselect by clicking outside the frame, that layer gets hidden or appears not to be applied. The layer appears again when I select the frame again.

## Screenshots (if applicable)

### The issue

https://github.com/user-attachments/assets/c18d2797-0a46-4dd3-ab03-f9b68c62d861


### Fixed Reference

https://github.com/user-attachments/assets/0887fc8b-fac4-4033-a26f-4ae81b5fa19a


## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `TextEditor` where text layers were hidden when clicking outside the frame and downgrades `@codesandbox/sdk` version.
> 
>   - **Behavior**:
>     - Fixes bug in `TextEditor` in `text.tsx` where text layers were hidden when clicking outside the frame.
>     - Attaches blur handler directly to ProseMirror's contenteditable to ensure `onStop` is called correctly.
>   - **Dependencies**:
>     - Downgrades `@codesandbox/sdk` from `1.1.6` to `1.1.2` in `bun.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 7ec3af64dd4c201573cba166a0efeed6da5b270c. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->