### PR TITLE
fix: orientation calculation

### DIFF
--- a/packages/utility/src/window-metadata.ts
+++ b/packages/utility/src/window-metadata.ts
@@ -1,18 +1,27 @@
 import { DEVICE_OPTIONS, Orientation, Theme } from '@onlook/constants';
 import type { WindowMetadata } from '@onlook/models';
 
-export const computeWindowMetadata = (width: string, height: string): WindowMetadata => {
+export const computeWindowMetadata = (
+    width: string,
+    height: string,
+): WindowMetadata => {
+    const numericWidth = Number(width);
+    const numericHeight = Number(height);
+
     return {
-        orientation: width > height ? Orientation.Landscape : Orientation.Portrait,
+        orientation:
+            numericWidth > numericHeight
+                ? Orientation.Landscape
+                : Orientation.Portrait,
         aspectRatioLocked: true,
-        device: computeDevice(width, height),
+        device: computeDevice(numericWidth, numericHeight),
         theme: Theme.System,
-        width: Number(width),
-        height: Number(height),
+        width: numericWidth,
+        height: numericHeight,
     };
 };
 
-const computeDevice = (width: string, height: string): string => {
+const computeDevice = (width: number, height: number): string => {
     let matchedDevice = 'Custom';
 
     for (const category in DEVICE_OPTIONS) {
@@ -22,7 +31,7 @@ const computeDevice = (width: string, height: string): string => {
             const resolution = devices[deviceName];
             if (typeof resolution === 'string') {
                 const [w, h] = resolution.split('x').map(Number);
-                if (w === Number(width) && h === Number(height)) {
+                if (w === width && h === height) {
                     matchedDevice = deviceName;
                     break;
                 }


### PR DESCRIPTION
## Summary
- fix lexicographic comparison of width/height in window metadata computation

## Testing
- `npm test` *(fails: deno not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2d0c5f4832383b73c690fff8241
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes orientation calculation by converting width and height to numbers in `computeWindowMetadata` and `computeDevice`.
> 
>   - **Behavior**:
>     - Fixes orientation calculation in `computeWindowMetadata` by converting `width` and `height` to numbers before comparison.
>     - Updates `computeDevice` to accept numeric `width` and `height` for device matching.
>   - **Functions**:
>     - `computeWindowMetadata`: Converts `width` and `height` to numbers for orientation and device computation.
>     - `computeDevice`: Now takes numeric parameters for accurate device resolution matching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 07f6885b4735e0bbfc6c0a733a55cdedad2f69e4. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->