### PR TITLE
Fix invite email grammar

### DIFF
--- a/packages/email/src/templates/invite-user.tsx
+++ b/packages/email/src/templates/invite-user.tsx
@@ -53,7 +53,7 @@ export const InviteUserEmail = ({ invitedByEmail, inviteLink }: InviteUserEmailP
                             >
                                 {invitedByEmail}
                             </Link>
-                            ) has invited you to the their project on <strong>Onlook</strong>.
+                            ) has invited you to their project on <strong>Onlook</strong>.
                         </Text>
                         <Section className="mt-[32px] mb-[32px] text-center">
                             <Button


### PR DESCRIPTION
## Summary
- correct grammar in invite email template

## Testing
- `bun --filter '*' test` *(fails: `deno` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d54791c48323b941c495a719521c