### PR TITLE
Add test for transparent color

### DIFF
--- a/packages/utility/test/colors.test.ts
+++ b/packages/utility/test/colors.test.ts
@@ -57,4 +57,11 @@ describe('ColorUtil', () => {
             expect(palette).toEqual(expectPalette);
         });
     });
+
+    describe('Unknown Colors', () => {
+        it('should return transparent color for invalid input', () => {
+            expect(Color.from('not-a-color')).toEqual(Color.transparent);
+            expect(Color.from('not-a-color').toHex8()).toEqual('#00000000');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- ensure `Color.from()` falls back to transparent for invalid input

## Testing
- `bun test packages/utility`

------
https://chatgpt.com/codex/tasks/task_e_6840d56dbecc8323a7962913fc2ea4c4
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add test in `colors.test.ts` to ensure `Color.from()` returns transparent color for invalid input.
> 
>   - **Testing**:
>     - Adds test in `colors.test.ts` to ensure `Color.from('not-a-color')` returns `Color.transparent`.
>     - Verifies `Color.from('not-a-color').toHex8()` equals `'#00000000'`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for a0191176a57f55d03ef15a19263841cfef73f2a8. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->