### PR TITLE
Skip apply test when env vars missing

### DIFF
--- a/packages/ai/test/apply.test.ts
+++ b/packages/ai/test/apply.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'bun:test';
 import { applyCodeChange } from '../src/apply';
 
+const hasFastApplyEnv =
+    Boolean(process.env.MORPH_API_KEY) || Boolean(process.env.RELACE_API_KEY);
+
 describe('applyCodeChange', () => {
-    it('should apply code change', async () => {
+    const run = hasFastApplyEnv ? it : it.skip;
+
+    run('should apply code change', async () => {
         const originalCode = `interface User {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- revert the `applyCodeChange` environment variable checks
- skip the apply test when API keys are absent

## Testing
- `bun test` *(fails: Cannot find package 'openai' from packages/ai/src/apply/client.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6840da2578f88323861e5806f77350fb
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip `applyCodeChange` test in `apply.test.ts` if required API keys are missing.
> 
>   - **Behavior**:
>     - In `apply.test.ts`, skips `applyCodeChange` test if `MORPH_API_KEY` or `RELACE_API_KEY` are not set.
>   - **Testing**:
>     - `bun test` fails due to missing 'openai' package in `client.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for f099c4127e54996c5333e9621957231f944a0946. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->