### PR TITLE
fix: add prompt to save changes when closing an edited file

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -3,6 +3,7 @@ import type { CodeRange, EditorFile } from '@/components/store/editor/dev';
 import type { FileEvent } from '@/components/store/editor/sandbox/file-event-bus';
 import { EditorView } from '@codemirror/view';
 import { SystemTheme } from '@onlook/models';
+import { Button } from '@onlook/ui/button';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -18,7 +19,6 @@ import { useEffect, useRef, useState } from 'react';
 import { getBasicSetup, getExtensions } from './code-mirror-config';
 import { FileTab } from './file-tab';
 import { FileTree } from './file-tree';
-import { Button } from '@onlook/ui/button';
 
 export const DevTab = observer(() => {
     const editorEngine = useEditorEngine();
@@ -300,7 +300,6 @@ export const DevTab = observer(() => {
         return ide.getFilePathFromOid(oid);
     }
 
-    // Add saving functionality
     async function saveFile() {
         if (!ide.activeFile) {
             return;
@@ -319,13 +318,14 @@ export const DevTab = observer(() => {
             }
 
             const remainingDirty = ide.openedFiles.filter((f) => f.isDirty);
-            if (remainingDirty.length === 0) {
-                ide.closeAllFiles();
-                setPendingCloseAll(false);
-                setShowUnsavedDialog(false);
-            } else {
+            if (remainingDirty.length !== 0) {
                 setShowUnsavedDialog(true);
+                return;
             }
+
+            ide.closeAllFiles();
+            setPendingCloseAll(false);
+            setShowUnsavedDialog(false);
 
             return;
         }
@@ -611,7 +611,10 @@ export const DevTab = observer(() => {
                                                     </Button>
                                                     <Button
                                                         variant="ghost"
-                                                        onClick={() => setShowUnsavedDialog(false)}
+                                                        onClick={() => {
+                                                            setShowUnsavedDialog(false);
+                                                            setPendingCloseAll(false);
+                                                        }}
                                                     >
                                                         Cancel
                                                     </Button>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -348,7 +348,7 @@ export const DevTab = observer(() => {
     };
 
     function closeFile(fileId: string) {
-        if (ide.activeFile?.isDirty) {
+        if (ide.openedFiles.find(f => f.id === fileId)?.isDirty) {
             setShowUnsavedDialog(true);
             return;
         }

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -18,12 +18,15 @@ import { useEffect, useRef, useState } from 'react';
 import { getBasicSetup, getExtensions } from './code-mirror-config';
 import { FileTab } from './file-tab';
 import { FileTree } from './file-tree';
+import { Button } from '@onlook/ui/button';
 
 export const DevTab = observer(() => {
     const editorEngine = useEditorEngine();
     const { theme } = useTheme();
     const ide = editorEngine.ide;
     const [isFilesVisible, setIsFilesVisible] = useState(true);
+    const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
+    const [pendingCloseAll, setPendingCloseAll] = useState(false);
     const isDirty = ide.activeFile?.isDirty ?? false;
     const editorContainer = useRef<HTMLDivElement | null>(null);
     const editorViewsRef = useRef<Map<string, EditorView>>(new Map());
@@ -308,7 +311,32 @@ export const DevTab = observer(() => {
             return;
         }
 
+        if (pendingCloseAll) {
+            const file = ide.openedFiles.find((f) => f.id === ide.activeFile?.id);
+            if (file) {
+                await ide.saveActiveFile();
+                closeFile(file.id);
+            }
+
+            const remainingDirty = ide.openedFiles.filter((f) => f.isDirty);
+            if (remainingDirty.length === 0) {
+                ide.closeAllFiles();
+                setPendingCloseAll(false);
+                setShowUnsavedDialog(false);
+            } else {
+                setShowUnsavedDialog(true);
+            }
+
+            return;
+        }
+
         await ide.saveActiveFile();
+
+        if (showUnsavedDialog) {
+            setShowUnsavedDialog(false);
+            closeFile(ide.activeFile.id);
+        }
+
         toast('File saved!');
     }
 
@@ -320,6 +348,11 @@ export const DevTab = observer(() => {
     };
 
     function closeFile(fileId: string) {
+        if (ide.activeFile?.isDirty) {
+            setShowUnsavedDialog(true);
+            return;
+        }
+
         const editorView = editorViewsRef.current.get(fileId);
         if (editorView) {
             editorView.destroy();
@@ -329,6 +362,13 @@ export const DevTab = observer(() => {
     }
 
     function closeAllFiles() {
+        const dirtyFiles = ide.openedFiles.filter((file) => file.isDirty);
+        if (dirtyFiles.length > 0) {
+            setShowUnsavedDialog(true);
+            setPendingCloseAll(true);
+            return;
+        }
+
         editorViewsRef.current.forEach((view) => view.destroy());
         editorViewsRef.current.clear();
         ide.closeAllFiles();
@@ -337,6 +377,35 @@ export const DevTab = observer(() => {
     const updateFileContent = (fileId: string, content: string) => {
         ide.updateFileContent(fileId, content);
     };
+
+    async function discardChanges(fileId: string) {
+        if (pendingCloseAll) {
+            const file = ide.openedFiles.find((e) => e.id === fileId);
+            if (file) {
+                await ide.discardFileChanges(file.id);
+                closeFile(fileId);
+                setShowUnsavedDialog(true);
+                const isDirty = ide.openedFiles.filter((val) => val.isDirty);
+                if (isDirty.length === 0) {
+                    ide.closeAllFiles();
+                    setPendingCloseAll(false);
+                    setShowUnsavedDialog(false);
+                }
+                return;
+            }
+
+            setPendingCloseAll(false);
+            return;
+        }
+
+        if (!ide.activeFile) {
+            return;
+        }
+
+        await ide.discardFileChanges(fileId);
+        closeFile(fileId);
+        setShowUnsavedDialog(false);
+    }
 
     // Cleanup editor instances when component unmounts
     useEffect(() => {
@@ -515,6 +584,40 @@ export const DevTab = observer(() => {
                                                 }
                                             }}
                                         />
+                                        {ide.activeFile?.isDirty && showUnsavedDialog && (
+                                            <div className="absolute top-4 left-1/2 z-50 -translate-x-1/2 bg-white dark:bg-zinc-800 border dark:border-zinc-700 shadow-lg rounded-lg p-4 w-[320px]">
+                                                <div className="text-sm text-gray-800 dark:text-gray-100 mb-4">
+                                                    You have unsaved changes. Are you sure you want
+                                                    to close this file?
+                                                </div>
+                                                <div className="flex justify-end gap-1">
+                                                    <Button
+                                                        onClick={async () => {
+                                                            await discardChanges(file.id);
+                                                        }}
+                                                        variant="ghost"
+                                                        className="text-red hover:text-red"
+                                                    >
+                                                        Discard
+                                                    </Button>
+                                                    <Button
+                                                        onClick={async () => {
+                                                            await saveFile();
+                                                        }}
+                                                        variant="ghost"
+                                                        className="text-sm text-blue-500 hover:text-blue-500"
+                                                    >
+                                                        Save
+                                                    </Button>
+                                                    <Button
+                                                        variant="ghost"
+                                                        onClick={() => setShowUnsavedDialog(false)}
+                                                    >
+                                                        Cancel
+                                                    </Button>
+                                                </div>
+                                            </div>
+                                        )}
                                     </div>
                                 ))}
                             </div>

--- a/apps/web/client/src/components/store/editor/dev/index.ts
+++ b/apps/web/client/src/components/store/editor/dev/index.ts
@@ -216,6 +216,25 @@ export class IDEManager {
         return null;
     }
 
+    async discardFileChanges(id: string) {
+        if (!this.activeFile) {
+            console.error('No active file');
+            return;
+        }
+        try {
+            const originalContent = await this.editorEngine.sandbox.readFile(this.activeFile.path);
+            const file = this.openedFiles.find((f) => f.id === id);
+            if (file) file.isDirty = false;
+            this.activeFile = {
+                ...this.activeFile,
+                isDirty: false,
+                content: originalContent || '',
+            };
+        } catch (error) {
+            console.error('Error discarding file:', error);
+        }
+    }
+
     setHighlightRange(range: CodeRange | null) {
         this.highlightRange = range;
     }

--- a/apps/web/client/src/components/store/editor/dev/index.ts
+++ b/apps/web/client/src/components/store/editor/dev/index.ts
@@ -222,7 +222,7 @@ export class IDEManager {
             return;
         }
         try {
-            const originalContent = await this.editorEngine.sandbox.readFile(this.activeFile.path);
+            const originalContent = await this.editorEngine.sandbox.readFile((this.openedFiles.find((f) => f.id === id))?.path);
             const file = this.openedFiles.find((f) => f.id === id);
             if (file) file.isDirty = false;
             this.activeFile = {


### PR DESCRIPTION
## Description

## Related Issues

Closes: #2070

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds prompt to save or discard changes when closing an edited file, with state management and function updates in `index.tsx` and `IDEManager`.
> 
>   - **Behavior**:
>     - Adds prompt to save or discard changes when closing an edited file in `index.tsx`.
>     - Handles unsaved changes when closing all files.
>   - **State Management**:
>     - Introduces `showUnsavedDialog` and `pendingCloseAll` state variables in `index.tsx`.
>   - **Functions**:
>     - Adds `discardChanges()` in `index.tsx` to discard unsaved changes.
>     - Updates `closeFile()` and `closeAllFiles()` in `index.tsx` to handle unsaved changes.
>     - Adds `discardFileChanges()` in `IDEManager` in `index.ts` to reset file content and dirty state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 45cb182b2dc3b081e54c0d7c3d4a25e44c952b80. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->