### PR TITLE
fix can not set max width

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-dimension-control.ts
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-dimension-control.ts
@@ -49,6 +49,7 @@ export const useDimensionControl = <T extends DimensionType>(dimension: T) => {
     const editorEngine = useEditorEngine();
 
     const getInitialState = useCallback((): DimensionStateMap<T> => {
+        // Use defined styles because computed styles always return px
         const definedStyles = editorEngine.style.selectedStyle?.styles.defined;
         if (!definedStyles) {
             return createDefaultState(dimension);
@@ -57,11 +58,12 @@ export const useDimensionControl = <T extends DimensionType>(dimension: T) => {
         const dimensionValue = definedStyles[dimension]?.toString() ?? '--';
         const { num, unit } = stringToParsedValue(dimensionValue);
 
-        const maxDimensionKey = `max${dimension.charAt(0).toUpperCase() + dimension.slice(1)}` as keyof CSSProperties;
+        const maxDimensionKey = `max-${dimension}` as keyof CSSProperties;
         const maxDimensionValue = definedStyles[maxDimensionKey]?.toString() ?? '--';
+
         const { num: maxNum, unit: maxUnit } = stringToParsedValue(maxDimensionValue);
 
-        const minDimensionKey = `min${dimension.charAt(0).toUpperCase() + dimension.slice(1)}` as keyof CSSProperties;
+        const minDimensionKey = `min-${dimension}` as keyof CSSProperties;
         const minDimensionValue = definedStyles[minDimensionKey]?.toString() ?? '--';
         const { num: minNum, unit: minUnit } = stringToParsedValue(minDimensionValue);
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
(Should merge after #2080 )
- Fixed a bug that prevented users from setting min/max values for dimension inputs.
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
- Close #2054 
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `use-dimension-control.ts` by correcting key format for min/max dimension values to enable setting them.
> 
>   - **Bug Fix**:
>     - Corrects key format for accessing min/max dimension values in `use-dimension-control.ts`.
>     - Changes `maxDimensionKey` and `minDimensionKey` to use kebab-case (`max-width`, `min-width`) instead of camelCase (`maxWidth`, `minWidth`).
>   - **Behavior**:
>     - Fixes issue preventing setting of min/max values for dimension inputs.
>     - Ensures correct style properties are accessed and updated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for c480f5dcb1a4ce4f73961bb72196a71bca98a70e. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->