### PR TITLE
fix: aspect ratio bug on resize with locked ratio

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/frame/resize-handles.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/frame/resize-handles.tsx
@@ -3,7 +3,7 @@ import type { FrameImpl } from '@/components/store/editor/frames/frame';
 import { DefaultSettings } from '@onlook/constants';
 import { cn } from '@onlook/ui/utils';
 import { observer } from 'mobx-react-lite';
-import { type MouseEvent } from 'react';
+import { MouseEvent } from 'react';
 
 enum HandleType {
     Right = 'right',
@@ -12,7 +12,7 @@ enum HandleType {
 
 export const ResizeHandles = observer(({ frame }: { frame: FrameImpl }) => {
     const editorEngine = useEditorEngine();
-    const aspectRatioLocked = false;
+    const aspectRatioLocked = true;
     const lockedPreset = false;
 
     const startResize = (e: MouseEvent, types: HandleType[]) => {
@@ -27,48 +27,44 @@ export const ResizeHandles = observer(({ frame }: { frame: FrameImpl }) => {
 
         const resize = (e: MouseEvent) => {
             const scale = editorEngine.canvas.scale;
-            let heightDelta = types.includes(HandleType.Bottom) ? (e.clientY - startY) / scale : 0;
             let widthDelta = types.includes(HandleType.Right) ? (e.clientX - startX) / scale : 0;
+            let heightDelta = types.includes(HandleType.Bottom) ? (e.clientY - startY) / scale : 0;
 
-            let currentWidth = startWidth + widthDelta;
-            let currentHeight = startHeight + heightDelta;
+            let newWidth = startWidth + widthDelta;
+            let newHeight = startHeight + heightDelta;
 
             if (aspectRatioLocked) {
                 if (types.includes(HandleType.Right) && !types.includes(HandleType.Bottom)) {
-                    heightDelta = widthDelta / aspectRatio;
+                    newHeight = newWidth / aspectRatio;
                 } else if (!types.includes(HandleType.Right) && types.includes(HandleType.Bottom)) {
-                    widthDelta = heightDelta * aspectRatio;
+                    newWidth = newHeight * aspectRatio;
                 } else {
                     if (Math.abs(widthDelta) > Math.abs(heightDelta)) {
-                        heightDelta = widthDelta / aspectRatio;
+                        newHeight = newWidth / aspectRatio;
                     } else {
-                        widthDelta = heightDelta * aspectRatio;
+                        newWidth = newHeight * aspectRatio;
                     }
                 }
 
-                currentWidth = startWidth + widthDelta;
-                currentHeight = startHeight + heightDelta;
+                const minWidth = parseInt(DefaultSettings.MIN_DIMENSIONS.width);
+                const minHeight = parseInt(DefaultSettings.MIN_DIMENSIONS.height);
 
-                if (currentWidth < parseInt(DefaultSettings.MIN_DIMENSIONS.width)) {
-                    currentWidth = parseInt(DefaultSettings.MIN_DIMENSIONS.width);
-                    currentHeight = currentWidth / aspectRatio;
+                if (newWidth < minWidth) {
+                    newWidth = minWidth;
+                    newHeight = newWidth / aspectRatio;
                 }
-                if (currentHeight < parseInt(DefaultSettings.MIN_DIMENSIONS.height)) {
-                    currentHeight = parseInt(DefaultSettings.MIN_DIMENSIONS.height);
-                    currentWidth = currentHeight * aspectRatio;
+                if (newHeight < minHeight) {
+                    newHeight = minHeight;
+                    newWidth = newHeight * aspectRatio;
                 }
             } else {
-                if (currentWidth < parseInt(DefaultSettings.MIN_DIMENSIONS.width)) {
-                    currentWidth = parseInt(DefaultSettings.MIN_DIMENSIONS.width);
-                }
-                if (currentHeight < parseInt(DefaultSettings.MIN_DIMENSIONS.height)) {
-                    currentHeight = parseInt(DefaultSettings.MIN_DIMENSIONS.height);
-                }
+                newWidth = Math.max(newWidth, parseInt(DefaultSettings.MIN_DIMENSIONS.width));
+                newHeight = Math.max(newHeight, parseInt(DefaultSettings.MIN_DIMENSIONS.height));
             }
 
             frame.dimension = {
-                width: Math.floor(currentWidth),
-                height: Math.floor(currentHeight),
+                width: Math.round(newWidth),
+                height: Math.round(newHeight),
             };
         };
 


### PR DESCRIPTION
### What
Fixes #931 — properly adjusts the other dimension when resizing with locked aspect ratio ≠ 1.

### Why
Previously, resizing with aspect ratio ≠ 1 (e.g., 4:3) only worked from the corner, not from right or bottom handle.

### How
- Modified delta handling logic in ResizeHandles.tsx
- Synced width/height update according to the locked aspect ratio when resizing from single-axis handles

Tested with aspect ratios: 2:1, 4:3, 16:9, etc.

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screen Recording Description for Bug #931

https://github.com/user-attachments/assets/10ac0f6d-5829-491c-a990-ac5d30a20d64



