### PR TITLE
Fix pointer stroke cleanup and unique directory search

### DIFF
--- a/apps/web/client/src/components/store/editor/pages/helper.ts
+++ b/apps/web/client/src/components/store/editor/pages/helper.ts
@@ -529,13 +529,18 @@ const cleanupEmptyFolders = async (session: any, folderPath: string): Promise<vo
     }
 };
 
-const getUniqueDir = async (session: any, basePath: string, dirName: string): Promise<string> => {
+const getUniqueDir = async (
+    session: any,
+    basePath: string,
+    dirName: string,
+    maxAttempts = 100,
+): Promise<string> => {
     let uniquePath = dirName;
     let counter = 1;
 
     const baseName = dirName.replace(/-copy(-\d+)?$/, '');
 
-    while (true) {
+    while (counter <= maxAttempts) {
         const fullPath = joinPath(basePath, uniquePath);
         if (!(await pathExists(session, fullPath))) {
             return uniquePath;
@@ -543,6 +548,8 @@ const getUniqueDir = async (session: any, basePath: string, dirName: string): Pr
         uniquePath = `${baseName}-copy-${counter}`;
         counter++;
     }
+
+    throw new Error(`Unable to find available directory name for ${dirName}`);
 };
 
 const createDirectory = async (session: any, dirPath: string): Promise<void> => {

--- a/packages/ui/src/hooks/use-pointer-stroke.tsx
+++ b/packages/ui/src/hooks/use-pointer-stroke.tsx
@@ -71,7 +71,19 @@ export function usePointerStroke<T extends Element = Element, InitData = void>(
         const { initX, initY, lastX, lastY } = stateRef.current;
 
         if (e.buttons === 0) {
-            // TODO: Looks like onPointerUp is not called accidentally
+            // In some cases `onPointerUp` will not fire. Finish the stroke here
+            // and forward the last movement so state remains consistent.
+            const deltaX = x - lastX;
+            const deltaY = y - lastY;
+            stateRef.current.lastX = x;
+            stateRef.current.lastY = y;
+            onMove(e, {
+                totalDeltaX: x - initX,
+                totalDeltaY: y - initY,
+                deltaX,
+                deltaY,
+                initData: stateRef.current.initData,
+            });
             e.currentTarget.releasePointerCapture(e.pointerId);
             onEnd?.(e, {
                 totalDeltaX: x - initX,


### PR DESCRIPTION
## Summary
- handle missing `pointerup` events in `usePointerStroke`
- prevent `getUniqueDir` from infinite looping when path collisions persist

## Testing
- `bun lint` *(fails: script exited with code 127)*
- `bun test` *(fails: 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840fb90622c8323a1e1c3f37385a3f2
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `pointerup` event handling in `usePointerStroke` and prevents infinite loops in `getUniqueDir` by limiting attempts.
> 
>   - **Behavior**:
>     - In `use-pointer-stroke.tsx`, handle missing `pointerup` events by completing the stroke in `onPointerMove` when `e.buttons === 0`.
>     - In `helper.ts`, prevent infinite loops in `getUniqueDir` by limiting attempts to `maxAttempts` and throwing an error if no unique directory is found.
>   - **Error Handling**:
>     - Add error throwing in `getUniqueDir` when unable to find a unique directory name after `maxAttempts`.
>   - **Misc**:
>     - Update comments in `use-pointer-stroke.tsx` to reflect changes in event handling logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 1df4fb4386a34af34061cd798a79297f4f02a789. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->