### PR TITLE
Add next-intl TypeScript config

### DIFF
--- a/apps/web/client/messages/en.ts
+++ b/apps/web/client/messages/en.ts
@@ -1,4 +1,4 @@
-{
+export const messages = {
     "projects": {
         "create": {
             "settings": {
@@ -313,4 +313,8 @@
             "shortcuts": "Shortcuts"
         }
     }
-}
+} as const;
+
+export type Messages = typeof messages;
+
+export default messages;

--- a/apps/web/client/messages/es.ts
+++ b/apps/web/client/messages/es.ts
@@ -1,4 +1,6 @@
-{
+import type { Messages } from './en';
+
+const messages: Messages = {
   "projects": {
     "create": {
       "settings": {
@@ -313,4 +315,6 @@
       "shortcuts": "Atajos"
     }
   }
-}
+} as const;
+
+export default messages;

--- a/apps/web/client/messages/ja.ts
+++ b/apps/web/client/messages/ja.ts
@@ -1,4 +1,6 @@
-{
+import type { Messages } from './en';
+
+const messages: Messages = {
     "pricing": {
         "plans": {
             "basic": {
@@ -313,4 +315,6 @@
             "shortcuts": "ショートカット"
         }
     }
-}
+} as const;
+
+export default messages;

--- a/apps/web/client/messages/ko.ts
+++ b/apps/web/client/messages/ko.ts
@@ -1,4 +1,6 @@
-{
+import type { Messages } from './en';
+
+const messages: Messages = {
     "projects": {
         "create": {
             "settings": {
@@ -313,4 +315,6 @@
             "shortcuts": "단축키"
         }
     }
-}
+} as const;
+
+export default messages;

--- a/apps/web/client/messages/zh.ts
+++ b/apps/web/client/messages/zh.ts
@@ -1,4 +1,6 @@
-{
+import type { Messages } from './en';
+
+const messages: Messages = {
     "projects": {
         "create": {
             "settings": {
@@ -313,4 +315,6 @@
             "shortcuts": "快捷键"
         }
     }
-}
+} as const;
+
+export default messages;

--- a/apps/web/client/src/app/projects/_components/top-bar.tsx
+++ b/apps/web/client/src/app/projects/_components/top-bar.tsx
@@ -3,6 +3,7 @@ import { Routes } from '@/utils/constants';
 import { Button } from '@onlook/ui/button';
 import { Icons } from '@onlook/ui/icons';
 import { useTranslations } from 'next-intl';
+import { keys } from '@/i18n/keys';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
@@ -24,7 +25,7 @@ export const TopBar = () => {
                     }}
                 >
                     <Icons.Plus className="w-5 h-5 mr-2" />
-                    {t('projects.actions.newProject')}
+                    {t(keys.projects.actions.newProject)}
                 </Button>
                 <CurrentUserAvatar className="w-8 h-8" />
             </div>

--- a/apps/web/client/src/i18n/global.ts
+++ b/apps/web/client/src/i18n/global.ts
@@ -1,0 +1,9 @@
+import { Language } from '@onlook/constants';
+import messages from '../../messages/en';
+
+declare module 'next-intl' {
+  interface AppConfig {
+    Locale: `${Language}`;
+    Messages: typeof messages;
+  }
+}

--- a/apps/web/client/src/i18n/keys.ts
+++ b/apps/web/client/src/i18n/keys.ts
@@ -1,0 +1,27 @@
+import en, { type Messages } from '../../messages/en';
+
+export type MessageKeyPaths = MessagePaths<Messages>;
+
+export const keys = buildPaths(en) as MessageKeyPaths;
+
+function buildPaths(obj: Record<string, any>, prefix = ''): any {
+  const result: Record<string, any> = {};
+  for (const key of Object.keys(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const value = (obj as Record<string, any>)[key];
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      result[key] = buildPaths(value, path);
+    } else {
+      result[key] = path;
+    }
+  }
+  return result;
+}
+
+export type MessagePaths<T, Prefix extends string = ''> = {
+  [K in keyof T]: T[K] extends string
+    ? `${Prefix}${Extract<K, string>}`
+    : T[K] extends Record<string, any>
+    ? MessagePaths<T[K], `${Prefix}${Extract<K, string>}.`>
+    : never;
+};

--- a/apps/web/client/src/i18n/request.ts
+++ b/apps/web/client/src/i18n/request.ts
@@ -6,7 +6,7 @@ export default getRequestConfig(async () => {
     const locale = await getLanguage();
     return {
         locale,
-        messages: (await import(`../../messages/${locale}.json`)).default,
+        messages: (await import(`../../messages/${locale}`)).default,
     };
 });
 

--- a/apps/web/client/tsconfig.json
+++ b/apps/web/client/tsconfig.json
@@ -17,6 +17,7 @@
     "include": [
         "src",
         "tests",
+        "messages",
         ".next/types/**/*.ts"
     ],
     "exclude": [


### PR DESCRIPTION
## Description
- replace JSON locale files with typed `.ts` modules
- update i18n utilities to import TypeScript locales
- add helper that generates typed key paths
- show example usage of typed `t()` keys

## Related Issues

## Type of Change
- [x] New feature

## Testing
- `bun lint` *(fails: next not installed)*
- `bun test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6840f900a82883239fb31d6201c042cf
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add TypeScript configuration for locale files, updating i18n utilities and components to use typed translation keys.
> 
>   - **Locale Files**:
>     - Convert JSON locale files to typed `.ts` modules in `en.ts`, `es.ts`, `ja.ts`, `ko.ts`, and `zh.ts`.
>     - Add type `Messages` and export default `messages` in each locale file.
>   - **i18n Utilities**:
>     - Update `request.ts` to import TypeScript locale files.
>     - Add `keys.ts` to generate typed key paths using `buildPaths()` function.
>     - Modify `global.ts` to declare `AppConfig` with typed `Messages`.
>   - **Component Update**:
>     - Update `TopBar` component in `top-bar.tsx` to use typed `t()` keys with `keys.projects.actions.newProject`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 37e59658523b0346996d42c157789700da7204fa. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->