### PR TITLE
feat: add hasBorderWidth utility function to use-box-control hook

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border-color.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border-color.tsx
@@ -4,13 +4,13 @@ import { useEditorEngine } from '@/components/store/editor';
 import { Button } from '@onlook/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@onlook/ui/dropdown-menu';
 import { Icons } from '@onlook/ui/icons';
+import { observer } from 'mobx-react-lite';
 import { useMemo } from 'react';
-import { ColorPickerContent } from '../inputs/color-picker';
+import { hasBorderWidth, useBoxControl } from '../hooks/use-box-control';
 import { useColorUpdate } from '../hooks/use-color-update';
 import { useDropdownControl } from '../hooks/use-dropdown-manager';
 import { HoverOnlyTooltip } from '../hover-tooltip';
-import { observer } from 'mobx-react-lite';
-import { useBoxControl, hasBorderWidth } from '../hooks/use-box-control';
+import { ColorPickerContent } from '../inputs/color-picker';
 
 export const BorderColor = observer(() => {
     const editorEngine = useEditorEngine();

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border-color.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border-color.tsx
@@ -10,9 +10,11 @@ import { useColorUpdate } from '../hooks/use-color-update';
 import { useDropdownControl } from '../hooks/use-dropdown-manager';
 import { HoverOnlyTooltip } from '../hover-tooltip';
 import { observer } from 'mobx-react-lite';
+import { useBoxControl, hasBorderWidth } from '../hooks/use-box-control';
 
 export const BorderColor = observer(() => {
     const editorEngine = useEditorEngine();
+    const { boxState } = useBoxControl('border');
     const initialColor = editorEngine.style.selectedStyle?.styles.computed.borderColor;
 
     const { isOpen, onOpenChange } = useDropdownControl({
@@ -25,6 +27,11 @@ export const BorderColor = observer(() => {
     });
 
     const colorHex = useMemo(() => tempColor?.toHex(), [tempColor]);
+
+    // Don't render if no border is defined
+    if (!hasBorderWidth(boxState.borderWidth)) {
+        return null;
+    }
 
     return (
         <DropdownMenu open={isOpen} onOpenChange={onOpenChange}>

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border-color.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border-color.tsx
@@ -6,7 +6,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@onlook/
 import { Icons } from '@onlook/ui/icons';
 import { observer } from 'mobx-react-lite';
 import { useMemo } from 'react';
-import { hasBorderWidth, useBoxControl } from '../hooks/use-box-control';
+import { useBoxControl } from '../hooks/use-box-control';
 import { useColorUpdate } from '../hooks/use-color-update';
 import { useDropdownControl } from '../hooks/use-dropdown-manager';
 import { HoverOnlyTooltip } from '../hover-tooltip';
@@ -14,7 +14,7 @@ import { ColorPickerContent } from '../inputs/color-picker';
 
 export const BorderColor = observer(() => {
     const editorEngine = useEditorEngine();
-    const { boxState } = useBoxControl('border');
+    const { borderExists } = useBoxControl('border');
     const initialColor = editorEngine.style.selectedStyle?.styles.computed.borderColor;
 
     const { isOpen, onOpenChange } = useDropdownControl({
@@ -28,8 +28,7 @@ export const BorderColor = observer(() => {
 
     const colorHex = useMemo(() => tempColor?.toHex(), [tempColor]);
 
-    // Don't render if no border is defined
-    if (!hasBorderWidth(boxState.borderWidth)) {
+    if (!borderExists) {
         return null;
     }
 

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border.tsx
@@ -4,7 +4,7 @@ import { Button } from '@onlook/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@onlook/ui/dropdown-menu';
 import { Icons } from '@onlook/ui/icons';
 import { useState } from 'react';
-import { useBoxControl } from '../hooks/use-box-control';
+import { useBoxControl, hasBorderWidth } from '../hooks/use-box-control';
 import { useDropdownControl } from '../hooks/use-dropdown-manager';
 import { HoverOnlyTooltip } from '../hover-tooltip';
 import { InputRange } from '../inputs/input-range';
@@ -19,6 +19,8 @@ export const Border = observer(() => {
     const { isOpen, onOpenChange } = useDropdownControl({
         id: 'border-dropdown',
     });
+
+    const borderExists = hasBorderWidth(boxState.borderWidth);
 
     return (
         <DropdownMenu open={isOpen} onOpenChange={onOpenChange}>
@@ -36,7 +38,13 @@ export const Border = observer(() => {
                         className="flex items-center gap-1 text-muted-foreground hover:text-foreground border border-border/0 cursor-pointer rounded-lg hover:bg-background-tertiary/20 hover:text-white hover:border hover:border-border data-[state=open]:bg-background-tertiary/20 data-[state=open]:text-white data-[state=open]:border data-[state=open]:border-border focus-visible:ring-0 focus-visible:ring-offset-0 focus:outline-none focus-visible:outline-none active:border-0 data-[state=open]:border data-[state=open]:text-white"
                     >
                         <Icons.BorderEdit className="h-4 w-4 min-h-4 min-w-4" />
-                        <p className="text-xs">{boxState.borderWidth.num ?? 0}</p>
+                        {borderExists && (
+                            <span className="text-xs">
+                                {boxState.borderWidth.unit === 'px' 
+                                    ? boxState.borderWidth.num 
+                                    : boxState.borderWidth.value}
+                            </span>
+                        )}
                     </Button>
                 </DropdownMenuTrigger>
             </HoverOnlyTooltip>

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/border.tsx
@@ -3,24 +3,22 @@
 import { Button } from '@onlook/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@onlook/ui/dropdown-menu';
 import { Icons } from '@onlook/ui/icons';
+import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
-import { useBoxControl, hasBorderWidth } from '../hooks/use-box-control';
+import { useBoxControl } from '../hooks/use-box-control';
 import { useDropdownControl } from '../hooks/use-dropdown-manager';
 import { HoverOnlyTooltip } from '../hover-tooltip';
 import { InputRange } from '../inputs/input-range';
 import { SpacingInputs } from '../inputs/spacing-inputs';
-import { observer } from 'mobx-react-lite';
 
 export const Border = observer(() => {
     const [activeTab, setActiveTab] = useState('all');
-    const { boxState, handleBoxChange, handleUnitChange, handleIndividualChange } =
+    const { boxState, handleBoxChange, handleUnitChange, handleIndividualChange, borderExists } =
         useBoxControl('border');
 
     const { isOpen, onOpenChange } = useDropdownControl({
         id: 'border-dropdown',
     });
-
-    const borderExists = hasBorderWidth(boxState.borderWidth);
 
     return (
         <DropdownMenu open={isOpen} onOpenChange={onOpenChange}>
@@ -40,8 +38,8 @@ export const Border = observer(() => {
                         <Icons.BorderEdit className="h-4 w-4 min-h-4 min-w-4" />
                         {borderExists && (
                             <span className="text-xs">
-                                {boxState.borderWidth.unit === 'px' 
-                                    ? boxState.borderWidth.num 
+                                {boxState.borderWidth.unit === 'px'
+                                    ? boxState.borderWidth.num
                                     : boxState.borderWidth.value}
                             </span>
                         )}
@@ -56,21 +54,19 @@ export const Border = observer(() => {
                 <div className="flex items-center gap-2 mb-3">
                     <button
                         onClick={() => setActiveTab('all')}
-                        className={`flex-1 text-sm px-4 py-1.5 rounded-md transition-colors cursor-pointer ${
-                            activeTab === 'all'
-                                ? 'text-white bg-background-tertiary/20'
-                                : 'text-muted-foreground hover:bg-background-tertiary/10'
-                        }`}
+                        className={`flex-1 text-sm px-4 py-1.5 rounded-md transition-colors cursor-pointer ${activeTab === 'all'
+                            ? 'text-white bg-background-tertiary/20'
+                            : 'text-muted-foreground hover:bg-background-tertiary/10'
+                            }`}
                     >
                         All sides
                     </button>
                     <button
                         onClick={() => setActiveTab('individual')}
-                        className={`flex-1 text-sm px-4 py-1.5 rounded-md transition-colors cursor-pointer ${
-                            activeTab === 'individual'
-                                ? 'text-white bg-background-tertiary/20'
-                                : 'text-muted-foreground hover:bg-background-tertiary/10'
-                        }`}
+                        className={`flex-1 text-sm px-4 py-1.5 rounded-md transition-colors cursor-pointer ${activeTab === 'individual'
+                            ? 'text-white bg-background-tertiary/20'
+                            : 'text-muted-foreground hover:bg-background-tertiary/10'
+                            }`}
                     >
                         Individual
                     </button>

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-box-control.ts
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-box-control.ts
@@ -94,6 +94,14 @@ const createDefaultState = (type: BoxType): BoxStateMap => {
     return state;
 };
 
+//Checks for border
+export const hasBorderWidth = (borderState: BoxState): boolean => {
+    if (borderState.unit === 'px') {
+        return typeof borderState.num === 'number' && borderState.num > 0;
+    }
+    return borderState.value !== '--' && borderState.value !== '' && borderState.value !== '0px';
+};
+
 export const useBoxControl = (type: BoxType) => {
     const editorEngine = useEditorEngine();
 

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-box-control.ts
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-box-control.ts
@@ -1,14 +1,14 @@
 import { useEditorEngine } from '@/components/store/editor';
 import { capitalizeFirstLetter, stringToParsedValue } from '@onlook/utility';
 import type { CSSProperties } from 'react';
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export type BoxType = 'margin' | 'padding' | 'border' | 'radius';
 export type BoxSide = 'Top' | 'Right' | 'Bottom' | 'Left';
 export type RadiusCorner = `${BoxSide}${BoxSide}Radius`;
-export type BoxProperty = 
-    | BoxType 
-    | `${BoxType}${BoxSide}` 
+export type BoxProperty =
+    | BoxType
+    | `${BoxType}${BoxSide}`
     | `border${RadiusCorner}`
     | `border${BoxSide}Width`
     | 'borderColor'
@@ -94,8 +94,9 @@ const createDefaultState = (type: BoxType): BoxStateMap => {
     return state;
 };
 
-//Checks for border
-export const hasBorderWidth = (borderState: BoxState): boolean => {
+const hasBorderWidth = (borderState: BoxState | undefined): boolean => {
+    if (!borderState) return false;
+
     if (borderState.unit === 'px') {
         return typeof borderState.num === 'number' && borderState.num > 0;
     }
@@ -161,6 +162,11 @@ export const useBoxControl = (type: BoxType) => {
     }, [editorEngine.style.selectedStyle, type]);
 
     const [boxState, setBoxState] = useState<BoxStateMap>(getInitialState);
+    const [borderExists, setBorderExists] = useState(false);
+
+    useEffect(() => {
+        setBorderExists(hasBorderWidth(boxState.borderWidth));
+    }, [boxState.borderWidth]);
 
     useEffect(() => {
         setBoxState(getInitialState);
@@ -176,7 +182,7 @@ export const useBoxControl = (type: BoxType) => {
         const updates = new Map<CSSBoxProperty, string>();
 
         updates.set(property, cssValue);
-    
+
         if (type === 'radius' && property === 'borderRadius') {
             CORNERS_RADIUS.forEach((corner) => {
                 updates.set(`border${corner}` as CSSBoxProperty, cssValue);
@@ -192,7 +198,6 @@ export const useBoxControl = (type: BoxType) => {
         }
 
         editorEngine.style.updateMultiple(Object.fromEntries(updates));
-        
     }, [boxState, editorEngine.style, type]);
 
     const handleUnitChange = useCallback((property: CSSBoxProperty, unit: string) => {
@@ -209,21 +214,22 @@ export const useBoxControl = (type: BoxType) => {
         const property = type === 'radius'
             ? (`border${capitalizeFirstLetter(side)}Radius` as CSSBoxProperty)
             : type === 'border'
-            ? (`border${capitalizeFirstLetter(side)}Width` as CSSBoxProperty)
-            : (`${type}${capitalizeFirstLetter(side)}` as CSSBoxProperty);
+                ? (`border${capitalizeFirstLetter(side)}Width` as CSSBoxProperty)
+                : (`${type}${capitalizeFirstLetter(side)}` as CSSBoxProperty);
 
         const currentState = boxState[property];
         if (!currentState) return;
 
         const newValue = `${value}${currentState.unit}`;
-        
+
         // Update CSS
         editorEngine.style.update(property, newValue);
-        
+
     }, [boxState, editorEngine.style, type]);
 
     return {
         boxState,
+        borderExists,
         handleBoxChange,
         handleUnitChange,
         handleIndividualChange,

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-color-update.ts
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-color-update.ts
@@ -2,7 +2,7 @@ import { useEditorEngine } from '@/components/store/editor';
 import { DEFAULT_COLOR_NAME } from '@onlook/constants';
 import type { TailwindColor } from '@onlook/models/style';
 import { Color } from '@onlook/utility';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 interface ColorUpdateOptions {
     elementStyleKey: string;
@@ -17,6 +17,10 @@ export const useColorUpdate = ({
 }: ColorUpdateOptions) => {
     const editorEngine = useEditorEngine();
     const [tempColor, setTempColor] = useState<Color>(Color.from(initialColor ?? '#000000'));
+
+    useEffect(() => {
+        setTempColor(Color.from(initialColor ?? '#000000'));
+    }, [initialColor]);
 
     const handleColorUpdateEnd = useCallback(
         (newValue: Color | TailwindColor) => {

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-measure-group.ts
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/hooks/use-measure-group.ts
@@ -35,7 +35,7 @@ export const useMeasureGroup = ({ availableWidth = 0, count = 0 }: { availableWi
 
         for (let i = 0; i < groupKeys.length; i++) {
             const width = GROUP_WIDTHS[groupKeys[i] as keyof typeof GROUP_WIDTHS];
-            
+
             // Add separator width if this isn't the first group
             const totalWidth = width + (count > 0 ? SEPARATOR_WIDTH : 0);
 


### PR DESCRIPTION
## Description

This PR fixes the border controls visibility issue where border width and color controls were always displayed even when no border was defined. The solution implements conditional rendering for border-related controls, making them behave consistently with padding and margin controls.

**Changes made:**
- Added `hasBorderWidth` utility function to `use-box-control.ts` hook to check if a border width is defined and greater than 0
- Updated `border.tsx` to conditionally display border width value only when a border exists
- Updated `border-color.tsx` to conditionally render the color picker (pencil icon) only when a border is defined
- Implemented clean conditional logic that handles both px and non-px units properly

The UI now only shows border controls when they are relevant, eliminating the confusing "0" display and unnecessary color picker when no border is set.

## Related Issues

Closes #2106

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

**Steps to verify the changes:**

1. Open the Onlook editor
2. Select an element with no border defined
3. **Before**: Border width showed "0" and color picker (pencil) was visible
4. **After**: Border width and color picker are now hidden
5. Set a border width > 0 on the element
6. **Verify**: Border width value and color picker now appear
7. Set border width back to 0
8. **Verify**: Controls disappear again

**Test different scenarios:**
- Elements with no border-width CSS property
- Elements with `border-width: 0px`
- Elements with `border-width: --` (undefined)
- Elements with various unit types (px, em, rem, etc.)

## Screenshots (if applicable)

**Behaviour after fix:**

https://github.com/user-attachments/assets/1e702b94-cc30-489d-8b71-37ab1d71652c


## Additional Notes

- This change aligns border control behavior with existing padding and margin control patterns
- The `hasBorderWidth` utility function is reusable and exported from the existing `use-box-control` hook
- The solution handles edge cases like empty strings, '--' values, and different CSS units
- Maintains backward compatibility and doesn't affect existing functionality
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `hasBorderWidth` utility to conditionally render border controls based on border presence, improving UI consistency.
> 
>   - **Behavior**:
>     - Adds `hasBorderWidth` function in `use-box-control.ts` to check if border width is defined and > 0.
>     - Updates `border.tsx` to show border width only when a border exists.
>     - Updates `border-color.tsx` to render color picker only when a border is defined.
>   - **Logic**:
>     - Handles both px and non-px units in `hasBorderWidth`.
>     - Ensures border controls align with padding and margin control behavior.
>   - **Misc**:
>     - No new files; changes utilize existing infrastructure.
>     - Handles edge cases like empty strings, '--' values, and different CSS units.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 6419c598a35322cd67a6bfbe829658729ce7369a. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->