### PR TITLE
Fix/font search bug

### DIFF
--- a/apps/web/client/src/components/store/editor/font/index.ts
+++ b/apps/web/client/src/components/store/editor/font/index.ts
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import type { ProjectManager } from '@/components/store/project/manager';
 import type { ParseResult } from '@babel/parser';
@@ -118,7 +118,9 @@ export class FontManager {
 
         // React to sandbox connection status
         const sandboxDisposer = reaction(
-            () => this.editorEngine.state.brandTab === BrandTabValue.FONTS && this.editorEngine.sandbox?.session.session,
+            () =>
+                this.editorEngine.state.brandTab === BrandTabValue.FONTS &&
+                this.editorEngine.sandbox?.session.session,
             (session) => {
                 if (session) {
                     this.loadInitialFonts();
@@ -128,7 +130,9 @@ export class FontManager {
         );
 
         const fontConfigDisposer = reaction(
-            () => this.editorEngine.state.brandTab === BrandTabValue.FONTS && this.editorEngine.sandbox?.readFile(this.fontConfigPath),
+            () =>
+                this.editorEngine.state.brandTab === BrandTabValue.FONTS &&
+                this.editorEngine.sandbox?.readFile(this.fontConfigPath),
             async (contentPromise) => {
                 if (contentPromise) {
                     const content = await contentPromise;
@@ -621,7 +625,8 @@ export class FontManager {
                                     isValidLocalFontDeclaration(declarator, fontName)
                                 ) {
                                     // @ts-ignore
-                                    const configObject = declarator.init?.arguments[0] as t.ObjectExpression;
+                                    const configObject = declarator.init
+                                        ?.arguments[0] as t.ObjectExpression;
                                     const srcProp = configObject.properties.find((prop) =>
                                         isPropertyWithName(prop, 'src'),
                                     );
@@ -744,11 +749,17 @@ export class FontManager {
                 enrich: true,
             });
 
-            const fonts = Object.values(searchResults)
+            let fonts = Object.values(searchResults)
                 .flatMap((result) => result.result)
                 // @ts-ignore
                 .map((font) => this.convertFont(font.doc))
                 .filter((font) => !this._fonts.some((f) => f.family === font.family));
+
+            // If the query is more than one word, filter for exact (case-insensitive) match
+            if (query.trim().split(/\s+/).length > 1) {
+                const normalizedQuery = query.trim().toLowerCase();
+                fonts = fonts.filter((font) => font.family.toLowerCase() === normalizedQuery);
+            }
 
             if (fonts.length === 0) {
                 this._searchResults = [];


### PR DESCRIPTION
## Description

Fixes the font search logic to properly match full query strings. Previously, searching for a font like "Adlam Display" would return results that only partially matched the term (e.g., fonts that contained just "Display"), instead of requiring a more complete match.

The updated logic uses FlexSearch with suggest and enrich options, maps and filters results, and applies a stricter condition for multi-word queries to ensure full, case-insensitive matching.

## Related Issues

Fixes #2058 Font search doesn't work as expected .

## Type of Change

 Bug fix

## Testing

Verified the font search returns exact match results for multi-word queries like "Adlam Display".

Ensured partial matches still work for single-word queries like "Roboto".

Confirmed that no fonts are returned when no match is found.

Manually validated that _searchResults is updated only with valid results.

Checked that loadFontBatch() is only triggered when valid fonts are found.

No console errors were encountered during searches.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes font search logic for full query matches and updates UI with animations and style changes.
> 
>   - **Font Search Logic**:
>     - Fixes font search logic in `FontManager` to ensure full query string matches for multi-word queries using FlexSearch.
>     - Filters results for exact case-insensitive matches when query has multiple words.
>   - **UI Enhancements**:
>     - Updates `not-found.tsx` to include animations using `framer-motion` and changes text and button styles.
>   - **Code Refactoring**:
>     - Locks aspect ratio in `resize-handles.tsx` by setting `aspectRatioLocked` to `true`.
>     - Refactors variable names in `resize-handles.tsx` for clarity (e.g., `currentWidth` to `newWidth`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 9f2affbb79c595bde58af6088bcb9aa27af1d5a6. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->