### PR TITLE
Fix chat message persistence

### DIFF
--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
@@ -25,10 +25,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         api: '/api/chat',
         maxSteps: 10,
         onToolCall: (toolCall) => handleToolCall(toolCall.toolCall, editorEngine),
-        onFinish: (message, config) => {
-            if (config.finishReason === 'stop') {
-                editorEngine.chat.conversation.addAssistantMessage(message);
-            }
+        onFinish: (message) => {
+            editorEngine.chat.conversation.addAssistantMessage(message);
         },
         onError: (error) => {
             console.error('Error in chat', error);


### PR DESCRIPTION
## Summary
- ensure assistant messages are saved regardless of finish reason

## Testing
- `bun lint` *(fails: createEnv error)*
- `bun test` *(fails: localForage and git tests due to missing environment)*

------
https://chatgpt.com/codex/tasks/task_e_684620965fdc832390a555d803d16307
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `onFinish` in `use-chat.tsx` to save assistant messages regardless of `finishReason`.
> 
>   - **Behavior**:
>     - Modify `onFinish` in `use-chat.tsx` to save assistant messages regardless of `finishReason`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 8d36122ce5fc0739e7b3a14895ce10c9bf780ab9. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->