### PR TITLE
Fix DevTab rerenders on file tree

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
@@ -1,5 +1,5 @@
 import { type FileNode } from '@onlook/models';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Tree, type TreeApi } from 'react-arborist';
 import { FileTreeNode } from './file-tree-node';
 import { FileTreeRow } from './file-tree-row';
@@ -20,7 +20,7 @@ interface FileTreeProps {
     activeFilePath?: string | null;
 }
 
-export const FileTree = ({ onFileSelect, files, isLoading = false, onRefresh, activeFilePath }: FileTreeProps) => {
+export const FileTree = memo(function FileTree({ onFileSelect, files, isLoading = false, onRefresh, activeFilePath }: FileTreeProps) {
     const editorEngine = useEditorEngine();
     const [searchQuery, setSearchQuery] = useState('');
     const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
@@ -318,4 +318,4 @@ export const FileTree = ({ onFileSelect, files, isLoading = false, onRefresh, ac
             </div>
         </div>
     );
-}; 
+});

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -17,7 +17,7 @@ import { getMimeType } from '@onlook/utility';
 import CodeMirror, { EditorSelection } from '@uiw/react-codemirror';
 import { observer } from 'mobx-react-lite';
 import { useTheme } from 'next-themes';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getBasicSetup, getExtensions } from './code-mirror-config';
 import { FileModal } from './file-modal';
 import { FileTab } from './file-tab';
@@ -38,9 +38,9 @@ export const DevTab = observer(() => {
     const editorViewsRef = useRef<Map<string, EditorView>>(new Map());
 
     // Helper function to check if sandbox is connected and ready
-    const isSandboxReady = (): boolean => {
+    const isSandboxReady = useCallback((): boolean => {
         return !!(editorEngine.sandbox.session.session && !editorEngine.sandbox.session.isConnecting);
-    };
+    }, [editorEngine.sandbox.session.session, editorEngine.sandbox.session.isConnecting]);
 
     // Helper function to handle sandbox not ready scenarios
     const handleSandboxNotReady = (operation: string): void => {
@@ -242,7 +242,7 @@ export const DevTab = observer(() => {
         }
     }, [editorEngine.sandbox.session.session, editorEngine.sandbox.session.isConnecting]);
 
-    const handleRefreshFiles = async () => {
+    const handleRefreshFiles = useCallback(async () => {
         if (!isSandboxReady()) {
             handleSandboxNotReady('refresh files');
             return;
@@ -255,7 +255,7 @@ export const DevTab = observer(() => {
         } catch (error) {
             console.error('Error refreshing files:', error);
         }
-    };
+    }, [isSandboxReady]);
 
     async function loadNewContent(filePath: string) {
         if (!isSandboxReady()) {
@@ -270,7 +270,7 @@ export const DevTab = observer(() => {
         }
     }
 
-    async function loadFile(filePath: string): Promise<EditorFile | null> {
+    const loadFile = useCallback(async (filePath: string): Promise<EditorFile | null> => {
         if (!isSandboxReady()) {
             handleSandboxNotReady('load file');
             return null;
@@ -282,7 +282,7 @@ export const DevTab = observer(() => {
             console.error('Error loading file:', error);
             return null;
         }
-    }
+    }, [isSandboxReady]);
 
     function handleFileSelect(file: EditorFile) {
         ide.setHighlightRange(null);


### PR DESCRIPTION
## Description
- memoize `FileTree` component
- memoize sandbox helpers in DevTab
- avoid creating new callbacks when refreshing or loading files

## Related Issues

- fixes rerender issues seen in file tree

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing
- `bun format`
- `bun lint` *(fails: script exited with code 127)*
- `bun test` *(fails: missing dependencies)*

## Screenshots (if applicable)

## Additional Notes

- Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847341ae0288323b5248d822c8e1caa