### PR TITLE
fix: tooltip ui changes

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -428,7 +428,7 @@ export const DevTab = observer(() => {
                                 <Icons.CollapseSidebar />
                             </Button>
                         </TooltipTrigger>
-                        <TooltipContent>
+                        <TooltipContent side="bottom" hideArrow>
                             {isFilesVisible ? 'Collapse sidebar' : 'Expand sidebar'}
                         </TooltipContent>
                     </Tooltip>
@@ -438,7 +438,7 @@ export const DevTab = observer(() => {
                                 <Icons.FilePlus />
                             </Button>
                         </TooltipTrigger>
-                        <TooltipContent>
+                        <TooltipContent side="bottom" hideArrow>
                             New File
                         </TooltipContent>
                     </Tooltip>
@@ -448,7 +448,7 @@ export const DevTab = observer(() => {
                                 <Icons.DirectoryPlus />
                             </Button>
                         </TooltipTrigger>
-                        <TooltipContent>
+                        <TooltipContent side="bottom" hideArrow>
                             New Folder
                         </TooltipContent>
                     </Tooltip>
@@ -458,7 +458,7 @@ export const DevTab = observer(() => {
                                 <Icons.FloppyDisk />
                             </Button>
                         </TooltipTrigger>
-                        <TooltipContent>
+                        <TooltipContent side="bottom" hideArrow>
                             Save changes
                         </TooltipContent>
                     </Tooltip>

--- a/apps/web/client/src/app/project/[id]/_components/top-bar/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/top-bar/index.tsx
@@ -71,7 +71,7 @@ export const TopBar = observer(({ projectId }: { projectId: string }) => {
                                     </Button>
                                 </span>
                             </TooltipTrigger>
-                            <TooltipContent side="bottom">
+                            <TooltipContent side="bottom" hideArrow>
                                 <HotkeyLabel hotkey={hotkey} />
                             </TooltipContent>
                         </Tooltip>


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Tooltip ui fix
Removed double arrows from tooltip on undo redo
removed arrows from the second tooltip and made it underneath the icons instead of above

## Related Issues
fixes #2133 
<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->


https://github.com/user-attachments/assets/4034b893-9efa-431d-b8eb-d4698f478928





## Additional Notes

<!-- Add any other context about the PR here -->
