### PR TITLE
fix: made codepanel theme dark with custom colors

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/code-change-display/code-block.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/code-change-display/code-block.tsx
@@ -33,7 +33,7 @@ export const CodeBlock = ({
                     'flex-1 w-full h-full min-h-full max-h-full overflow-auto',
                     className,
                 )}
-                theme={theme === SystemTheme.DARK ? SystemTheme.DARK : SystemTheme.LIGHT}
+                theme={SystemTheme.DARK}
                 extensions={extensions}
             />
         </div>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-mirror-config.ts
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-mirror-config.ts
@@ -1,18 +1,13 @@
-import { javascript } from '@codemirror/lang-javascript';
+import { autocompletion } from '@codemirror/autocomplete';
 import { css } from '@codemirror/lang-css';
 import { html } from '@codemirror/lang-html';
+import { javascript } from '@codemirror/lang-javascript';
 import { json } from '@codemirror/lang-json';
 import { markdown } from '@codemirror/lang-markdown';
-import { EditorView } from '@codemirror/view';
-import { highlightActiveLine, highlightActiveLineGutter } from '@codemirror/view';
-import { highlightSpecialChars, drawSelection } from '@codemirror/view';
-import { bracketMatching } from '@codemirror/language';
-import { autocompletion } from '@codemirror/autocomplete';
-import { highlightSelectionMatches } from '@codemirror/search';
+import { bracketMatching, HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { lintGutter } from '@codemirror/lint';
-import { lineNumbers } from '@codemirror/view';
-import { keymap } from '@codemirror/view';
-import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { highlightSelectionMatches } from '@codemirror/search';
+import { drawSelection, EditorView, highlightActiveLine, highlightActiveLineGutter, highlightSpecialChars, keymap, lineNumbers } from '@codemirror/view';
 import { tags } from '@lezer/highlight';
 
 // Custom colors for CodeMirror
@@ -59,16 +54,16 @@ export const customDarkTheme = EditorView.theme({
         borderLeftWidth: '2px'
     },
     '&.cm-focused .cm-selectionBackground, ::selection': {
-        backgroundColor: 'rgba(63, 164, 255, 0.2)', 
+        backgroundColor: 'rgba(63, 164, 255, 0.2)',
     },
     '.cm-selectionBackground': {
         backgroundColor: 'rgba(63, 164, 255, 0.2)',
     },
     '.cm-gutters': {
-        backgroundColor: '#0a0a0a', 
-        color: '#6b7280',
-        border: 'none',
-        borderRight: '1px solid #1f2937'
+        backgroundColor: '#0a0a0a !important',
+        color: '#6b7280 !important',
+        border: 'none !important',
+        borderRight: '1px solid #1f2937 !important'
     },
     '.cm-gutterElement': {
         color: '#6b7280'
@@ -78,7 +73,7 @@ export const customDarkTheme = EditorView.theme({
         fontSize: '12px'
     },
     '.cm-activeLine': {
-        backgroundColor: 'rgba(255, 255, 255, 0.02)' 
+        backgroundColor: 'rgba(255, 255, 255, 0.02)'
     },
     '.cm-activeLineGutter': {
         backgroundColor: 'rgba(255, 255, 255, 0.05)'
@@ -111,50 +106,50 @@ export const customDarkHighlightStyle = HighlightStyle.define([
     { tag: tags.keyword, color: customColors.pink, fontWeight: 'bold' },
     { tag: tags.controlKeyword, color: customColors.pink, fontWeight: 'bold' },
     { tag: tags.operatorKeyword, color: customColors.pink },
-    
+
     // Strings - Blue
     { tag: tags.string, color: customColors.blue },
     { tag: tags.regexp, color: customColors.blue },
-    
+
     // Numbers - Pink, bool purple, null pink
     { tag: tags.number, color: customColors.pink },
     { tag: tags.bool, color: customColors.purple },
     { tag: tags.null, color: customColors.pink },
-    
+
     // Functions - purple and methods - pink
     { tag: tags.function(tags.variableName), color: customColors.purple },
-    { tag: tags.function(tags.propertyName), color: customColors.pink},
-    
-    
+    { tag: tags.function(tags.propertyName), color: customColors.pink },
+
+
     // Variables-purple and properties - Green
     { tag: tags.variableName, color: customColors.purple },
     { tag: tags.propertyName, color: customColors.green },
     { tag: tags.attributeName, color: customColors.green },
-    
+
     // Types and classes - Purple (lighter shade)
     { tag: tags.typeName, color: '#E879F9' },
     { tag: tags.className, color: '#E879F9' },
     { tag: tags.namespace, color: '#E879F9' },
-    
+
     // Comments - Gray
     { tag: tags.comment, color: '#6b7280', fontStyle: 'italic' },
     { tag: tags.lineComment, color: '#6b7280', fontStyle: 'italic' },
     { tag: tags.blockComment, color: '#6b7280', fontStyle: 'italic' },
-    
+
     // Operators - White/Light Gray
     { tag: tags.operator, color: '#d1d5db' },
     { tag: tags.punctuation, color: '#d1d5db' },
     { tag: tags.bracket, color: '#d1d5db' },
-    
+
     // Tags (HTML/JSX) - Pink
     { tag: tags.tagName, color: customColors.pink },
     { tag: tags.angleBracket, color: '#d1d5db' },
-    
+
     // Special tokens
     { tag: tags.atom, color: customColors.pink },
     { tag: tags.literal, color: customColors.orange },
     { tag: tags.unit, color: customColors.pink },
-    
+
     // Invalid/Error
     { tag: tags.invalid, color: '#ef4444', textDecoration: 'underline' }
 ]);
@@ -180,7 +175,7 @@ export const getBasicSetup = (saveFile: () => void) => {
                 },
             },
         ]),
-      
+
         customDarkTheme,
         syntaxHighlighting(customDarkHighlightStyle)
     ];

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -2,7 +2,6 @@ import { useEditorEngine } from '@/components/store/editor';
 import type { CodeRange, EditorFile } from '@/components/store/editor/dev';
 import type { FileEvent } from '@/components/store/editor/sandbox/file-event-bus';
 import { EditorView } from '@codemirror/view';
-import { SystemTheme } from '@onlook/models';
 import { Button } from '@onlook/ui/button';
 import {
     DropdownMenu,
@@ -562,9 +561,9 @@ export const DevTab = observer(() => {
                                                 key={file.id}
                                                 value={file.content}
                                                 height="100%"
-                                                theme={theme === SystemTheme.DARK ? 'dark' : 'light'}
+                                                theme="dark"
                                                 extensions={[
-                                                    ...getBasicSetup(theme === SystemTheme.DARK, saveFile),
+                                                    ...getBasicSetup(saveFile),
                                                     ...getExtensions(file.language),
                                                 ]}
                                                 onChange={(value) => {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Before Code panel was in white light mode . I made this code panel in dark mode with custom highlighted colors as mentione d in the issue #2124 

FFAC60
C478FF
3FA4FF
1AC69C
FF32C6


## Related Issues
fixes #2124 
<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
Here is a screenshot of how it's looking now

<img width="1469" alt="Screenshot 2025-06-10 at 2 41 04 PM" src="https://github.com/user-attachments/assets/a9d2d042-63f2-4fbc-a5e2-588158fa20ce" />

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a dark theme with custom syntax highlighting colors for the CodeMirror code panel in `code-mirror-config.ts`.
> 
>   - **Theme**:
>     - Adds `customDarkTheme` to `code-mirror-config.ts` for dark mode with custom colors.
>     - Sets background to black and text to white, with specific styles for gutters, active lines, and scrollbars.
>   - **Syntax Highlighting**:
>     - Introduces `customDarkHighlightStyle` for syntax highlighting with custom colors for keywords, strings, numbers, functions, variables, types, comments, operators, tags, and special tokens.
>   - **Setup**:
>     - Updates `getBasicSetup()` to include `customDarkTheme` and `customDarkHighlightStyle`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 668ceb75e96e7984b40fa9114f3873c82218b6cc. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->