### PR TITLE
fix: revert dev tab style highlighting

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-mirror-config.ts
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-mirror-config.ts
@@ -176,7 +176,7 @@ export const getBasicSetup = (saveFile: () => void) => {
             },
         ]),
 
-        customDarkTheme,
+        EditorView.theme(basicTheme, { dark: true }),
         syntaxHighlighting(customDarkHighlightStyle)
     ];
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `customDarkTheme` to `EditorView.theme(basicTheme, { dark: true })` in `code-mirror-config.ts` affecting dark theme styling.
> 
>   - **Behavior**:
>     - Reverts `customDarkTheme` to `EditorView.theme(basicTheme, { dark: true })` in `code-mirror-config.ts`.
>   - **Misc**:
>     - Affects dark theme styling in the dev tab of the project right panel.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 9b406079c2f3b3690297d9eb58a83fddd0941250. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->