### PR TITLE
fix: migration failure when column does not exist during project setup

### DIFF
--- a/apps/backend/supabase/migrations/0009_project_img_path.sql
+++ b/apps/backend/supabase/migrations/0009_project_img_path.sql
@@ -1,6 +1,6 @@
-ALTER TABLE "projects" DROP COLUMN "preview_img_url";--> statement-breakpoint
-ALTER TABLE "projects" DROP COLUMN "preview_img_path";--> statement-breakpoint
-ALTER TABLE "projects" DROP COLUMN "preview_img_bucket";--> statement-breakpoint
+ALTER TABLE "projects" DROP COLUMN IF EXISTS "preview_img_url";--> statement-breakpoint
+ALTER TABLE "projects" DROP COLUMN IF EXISTS "preview_img_path";--> statement-breakpoint
+ALTER TABLE "projects" DROP COLUMN IF EXISTS "preview_img_bucket";--> statement-breakpoint
 
 ALTER TABLE "projects" ADD COLUMN "preview_img_url" varchar;--> statement-breakpoint
 ALTER TABLE "projects" ADD COLUMN "preview_img_path" varchar;--> statement-breakpoint

--- a/apps/backend/supabase/migrations/0010_bent_edwin_jarvis.sql
+++ b/apps/backend/supabase/migrations/0010_bent_edwin_jarvis.sql
@@ -45,4 +45,4 @@ ALTER TABLE "published_domains" ADD CONSTRAINT "published_domains_domain_id_cust
 ALTER TABLE "published_domains" ADD CONSTRAINT "published_domains_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ADD CONSTRAINT "custom_domain_verification_domain_id_custom_domains_id_fk" FOREIGN KEY ("domain_id") REFERENCES "public"."custom_domains"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ADD CONSTRAINT "custom_domain_verification_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "projects" DROP COLUMN "preview_img";
+ALTER TABLE "projects" DROP COLUMN IF EXISTS "preview_img";


### PR DESCRIPTION
## Description

Added IF EXISTS to the ALTER TABLE "projects" DROP COLUMN "preview_img_url" statement in the migration file to prevent errors when the column doesn't exist on fresh database setups.

## Related Issues

closes #2145

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes
This prevents the `bun backend:start` command from failing during initial project setup when the database schema doesn't have the `preview_img_url` column that the migration is trying to drop.

cc : @Kitenite 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added `IF EXISTS` to `DROP COLUMN` statements in migration files to prevent errors during initial setup when columns do not exist.
> 
>   - **Migration Fix**:
>     - Added `IF EXISTS` to `DROP COLUMN` statements in `0009_project_img_path.sql` and `0010_bent_edwin_jarvis.sql` to prevent errors if columns do not exist.
>     - Affects columns `preview_img_url`, `preview_img_path`, `preview_img_bucket`, and `preview_img` in `projects` table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for bd1bcbead92c2e20a77e09f4ab712ac0dc49ee85. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->