### PR TITLE
fix: Improve sandbox indexing logic

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
@@ -208,7 +208,7 @@ function UnmemoizedFileTree({ onFileSelect, files, isLoading = false, onRefresh,
             await onRefresh();
         } else {
             try {
-                await editorEngine.sandbox.index();
+                await editorEngine.sandbox.index(true);
                 await editorEngine.sandbox.listAllFiles();
             } catch (error) {
                 console.error('Error refreshing files:', error);

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -249,7 +249,7 @@ export const DevTab = observer(() => {
 
         ide.isFilesLoading = true;
         try {
-            await editorEngine.sandbox.index();
+            await editorEngine.sandbox.index(true);
             await ide.refreshFiles();
         } catch (error) {
             console.error('Error refreshing files:', error);

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -422,7 +422,7 @@ export const DevTab = observer(() => {
             <div className="flex items-center justify-between h-11 pl-4 pr-2 border-b-[0.5px]">
                 <div className="flex gap-1 items-center h-full">
                     <Tooltip>
-                        <TooltipTrigger>
+                        <TooltipTrigger asChild>
                             <Button variant="ghost" size="icon" onClick={() => setIsFilesVisible(!isFilesVisible)}>
                                 <Icons.CollapseSidebar />
                             </Button>


### PR DESCRIPTION
## Description

Adds safeguards to the sandbox manager to avoid re-indexing project files unnecessarily. Indexing is now skipped unless it has not yet run or a force flag is provided. The dev panel refresh actions were updated to request a forced re-index.

## Related Issues


## Type of Change
- [x] Bug fix

## Testing
- `bun format`
- `bun lint` *(fails: next not found)*
- `bun test` *(fails: missing packages)*



------
https://chatgpt.com/codex/tasks/task_e_6849caea8400832397534bbfca812641
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves sandbox indexing logic by adding safeguards to prevent unnecessary re-indexing and updating components to use forced re-indexing when refreshing files.
> 
>   - **Behavior**:
>     - Adds `isIndexed` and `isIndexing` flags to `SandboxManager` in `index.ts` to prevent unnecessary re-indexing.
>     - Updates `index()` in `SandboxManager` to accept a `force` parameter, skipping indexing if already indexed unless forced.
>     - Modifies `handleRefresh` in `file-tree.tsx` and `handleRefreshFiles` in `index.tsx` to call `index(true)` for forced re-indexing.
>   - **Components**:
>     - Updates `DevTab` in `index.tsx` to use forced re-indexing when refreshing files.
>     - Updates `UnmemoizedFileTree` in `file-tree.tsx` to use forced re-indexing when refreshing files.
>   - **Misc**:
>     - Minor change to `TooltipTrigger` in `index.tsx` to use `asChild` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for c058ce5b816fd469bfbc7e0eaa6d7041b50e0442. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->