### PR TITLE
fix: sandbox keep-alive and auto reconnect over time

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/main.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/main.tsx
@@ -93,7 +93,7 @@ export const Main = observer(({ projectId }: { projectId: string }) => {
 
     useEffect(() => {
         if (tabState === 'reactivated') {
-            editorEngine.sandbox.session.reconnect();
+            editorEngine.sandbox.session.reconnect(projectId, userManager.user?.id);
         }
     }, [tabState]);
 

--- a/apps/web/client/src/components/store/editor/sandbox/session.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/session.ts
@@ -23,6 +23,14 @@ export class SessionManager {
                 return await api.sandbox.start.mutate({ sandboxId: id, userId });
             },
         });
+        this.session.keepActiveWhileConnected(true);
+        this.session.onStateChange((state) => {
+            if (state.state === 'DISCONNECTED' || state.state === 'HIBERNATED') {
+                this.session?.reconnect().catch((err) => {
+                    console.error('Failed to reconnect session:', err);
+                });
+            }
+        });
         this.isConnecting = false;
         await this.createTerminalSessions(this.session);
     }

--- a/apps/web/client/src/components/store/editor/sandbox/session.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/session.ts
@@ -24,13 +24,6 @@ export class SessionManager {
             },
         });
         this.session.keepActiveWhileConnected(true);
-        this.session.onStateChange((state) => {
-            if (state.state === 'DISCONNECTED' || state.state === 'HIBERNATED') {
-                this.session?.reconnect().catch((err) => {
-                    console.error('Failed to reconnect session:', err);
-                });
-            }
-        });
         this.isConnecting = false;
         await this.createTerminalSessions(this.session);
     }
@@ -63,8 +56,22 @@ export class SessionManager {
         await api.sandbox.hibernate.mutate({ sandboxId });
     }
 
-    async reconnect() {
-        await this.session?.reconnect();
+    async reconnect(sandboxId: string, userId: string | undefined) {
+        if (!this.session) {
+            console.error('No session found');
+            return;
+        }
+        this.isConnecting = true;
+        await this.session.reconnect().catch(async (err) => {
+            console.error('Failed to reconnect session:', err);
+            if (!userId) {
+                console.error('No user id found');
+                return;
+            }
+            await this.start(sandboxId, userId);
+        }).finally(() => {
+            this.isConnecting = false;
+        });
     }
 
     async disconnect() {


### PR DESCRIPTION
## Description
- keep CodeSandbox sessions alive with `keepActiveWhileConnected`
- auto reconnect when the session gets disconnected

## Related Issues

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing
- `bun format`
- `bun lint` *(fails: Key "@typescript-eslint/no-misused-promises" should be boolean)*
- `bun test` *(fails: 11 failing tests)*

## Screenshots (if applicable)

## Additional Notes


------
https://chatgpt.com/codex/tasks/task_e_6849fb243ce88323b0be06c541edc0a6
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `SessionManager` in `session.ts` to keep CodeSandbox sessions alive and auto-reconnect on disconnection.
> 
>   - **Behavior**:
>     - In `SessionManager` in `session.ts`, added `keepActiveWhileConnected(true)` to keep CodeSandbox sessions alive.
>     - Implemented auto-reconnect in `SessionManager` for states `DISCONNECTED` and `HIBERNATED` using `onStateChange` and `reconnect()`.
>   - **Error Handling**:
>     - Logs error to console if reconnection fails in `SessionManager`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 216e1294374171a84f488472dfa214935f585164. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->