### PR TITLE
Code Tab UI polish

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-controls.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-controls.tsx
@@ -65,7 +65,7 @@ export const CodeControls = observer(() => {
                             disabled={!isDirty}
                             className="p-2 w-fit h-fit hover:bg-background-onlook cursor-pointer"
                         >
-                            <Icons.FloppyDisk className="h-4 w-4" />
+                            <Icons.Save className="h-4 w-4" />
                         </Button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom" hideArrow>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-controls.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-controls.tsx
@@ -1,0 +1,91 @@
+import { useEditorEngine } from '@/components/store/editor';
+import { Button } from '@onlook/ui/button';
+import { Icons } from '@onlook/ui/icons';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@onlook/ui/tooltip';
+import { TooltipArrow } from '@radix-ui/react-tooltip';
+import { observer } from 'mobx-react-lite';
+import { useState } from 'react';
+import { FileModal } from './file-modal';
+import { FolderModal } from './folder-modal';
+
+export const CodeControls = observer(() => {
+    const editorEngine = useEditorEngine();
+    const [fileModalOpen, setFileModalOpen] = useState(false);
+    const [folderModalOpen, setFolderModalOpen] = useState(false);
+    const isDirty = editorEngine.ide.activeFile?.isDirty ?? false;
+
+    const saveFile = () => {
+        editorEngine.ide.saveActiveFile();
+    };
+
+    const basePath = editorEngine.ide.activeFile?.path ?? '';
+    const files = editorEngine.ide.files;
+
+    return (
+        <>
+            <div className="flex flex-row opacity-50 transition-opacity duration-200 group-hover/panel:opacity-100">
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setFileModalOpen(true)}
+                            className="p-2 w-fit h-fit hover:bg-background-onlook cursor-pointer"
+                        >
+                            <Icons.FilePlus className="h-4 w-4" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" hideArrow>
+                        <p>New File</p>
+                        <TooltipArrow className="fill-foreground" />
+                    </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => setFolderModalOpen(true)}
+                            className="p-2 w-fit h-fit hover:bg-background-onlook cursor-pointer"
+                        >
+                            <Icons.DirectoryPlus className="h-4 w-4" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" hideArrow>
+                        <p>New Folder</p>
+                        <TooltipArrow className="fill-foreground" />
+                    </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={saveFile}
+                            disabled={!isDirty}
+                            className="p-2 w-fit h-fit hover:bg-background-onlook cursor-pointer"
+                        >
+                            <Icons.FloppyDisk className="h-4 w-4" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" hideArrow>
+                        <p>Save changes</p>
+                        <TooltipArrow className="fill-foreground" />
+                    </TooltipContent>
+                </Tooltip>
+            </div>
+            <FileModal 
+                open={fileModalOpen} 
+                onOpenChange={setFileModalOpen} 
+                basePath={basePath}
+                files={files}
+            />
+            <FolderModal 
+                open={folderModalOpen} 
+                onOpenChange={setFolderModalOpen} 
+                basePath={basePath}
+                files={files}
+            />
+        </>
+    );
+}); 

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-controls.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/code-controls.tsx
@@ -7,6 +7,7 @@ import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 import { FileModal } from './file-modal';
 import { FolderModal } from './folder-modal';
+import { cn } from '@onlook/ui/utils';
 
 export const CodeControls = observer(() => {
     const editorEngine = useEditorEngine();
@@ -63,9 +64,17 @@ export const CodeControls = observer(() => {
                             size="icon"
                             onClick={saveFile}
                             disabled={!isDirty}
-                            className="p-2 w-fit h-fit hover:bg-background-onlook cursor-pointer"
+                            className={cn(
+                                "p-2 w-fit h-fit cursor-pointer",
+                                isDirty 
+                                    ? "text-teal-200 hover:text-teal-100 hover:bg-teal-500" 
+                                    : "hover:bg-background-onlook hover:text-teal-200"
+                            )}
                         >
-                            <Icons.Save className="h-4 w-4" />
+                            <Icons.Save className={cn(
+                                "h-4 w-4",
+                                isDirty && "text-teal-200 group-hover:text-teal-100"
+                            )} />
                         </Button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom" hideArrow>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tab.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tab.tsx
@@ -18,15 +18,15 @@ export const FileTab: React.FC<FileTabProps> = ({
     onClose,
 }) => {
     return (
-        <div className="h-full pl-3 pr-2 relative group">
+        <div className="h-full pl-3 pr-3 relative group">
             <div className="absolute right-0 h-[50%] w-[0.5px] bg-foreground/10 top-1/2 -translate-y-1/2"></div>
-            <div className="flex items-center h-full">
+            <div className="flex items-center h-full relative">
                 <button
                     className={cn(
                         'text-sm h-full flex items-center focus:outline-none max-w-[150px]',
                         isActive
-                            ? 'text-foreground-hover'
-                            : 'text-foreground/60 hover:text-foreground-hover',
+                            ? 'text-foreground'
+                            : 'text-foreground-secondary/50 hover:text-foreground-hover',
                     )}
                     onClick={onClick}
                 >
@@ -40,15 +40,20 @@ export const FileTab: React.FC<FileTabProps> = ({
                         <div className="absolute bottom-0 left-0 w-full h-[2px] bg-foreground-hover"></div>
                     )}
                 </button>
-                <button
-                    className="ml-2 cursor-pointer text-foreground/30 p-1.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity hover:text-foreground-hover hover:bg-secondary hover:rounded-md"
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        onClose?.();
-                    }}
-                >
-                    <Icons.CrossS className="h-3 w-3" />
-                </button>
+                <div className="absolute right-[-3px] top-1/2 -translate-y-1/2 z-10 opacity-0 group-hover:opacity-100 transition-opacity group-hover:bg-background-primary rounded-md">
+                    <button
+                        className={cn(
+                            "cursor-pointer p-1.5 flex-shrink-0 hover:text-foreground-hover hover:bg-secondary hover:rounded-md",
+                            isActive ? "text-foreground" : "text-foreground"
+                        )}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onClose?.();
+                        }}
+                    >
+                        <Icons.CrossS className="h-3 w-3" />
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tab.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tab.tsx
@@ -18,7 +18,7 @@ export const FileTab: React.FC<FileTabProps> = ({
     onClose,
 }) => {
     return (
-        <div className="h-full px-4 relative group">
+        <div className="h-full pl-3 pr-2 relative group">
             <div className="absolute right-0 h-[50%] w-[0.5px] bg-foreground/10 top-1/2 -translate-y-1/2"></div>
             <div className="flex items-center h-full">
                 <button
@@ -26,7 +26,7 @@ export const FileTab: React.FC<FileTabProps> = ({
                         'text-sm h-full flex items-center focus:outline-none max-w-[150px]',
                         isActive
                             ? 'text-foreground-hover'
-                            : 'text-foreground hover:text-foreground-hover',
+                            : 'text-foreground/60 hover:text-foreground-hover',
                     )}
                     onClick={onClick}
                 >
@@ -41,7 +41,7 @@ export const FileTab: React.FC<FileTabProps> = ({
                     )}
                 </button>
                 <button
-                    className="ml-2 cursor-pointer text-foreground flex-shrink-0"
+                    className="ml-2 cursor-pointer text-foreground/30 p-1.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity hover:text-foreground-hover hover:bg-secondary hover:rounded-md"
                     onClick={(e) => {
                         e.stopPropagation();
                         onClose?.();

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tab.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tab.tsx
@@ -8,6 +8,7 @@ export interface FileTabProps {
     isDirty?: boolean;
     onClick?: () => void;
     onClose?: () => void;
+    'data-active'?: boolean;
 }
 
 export const FileTab: React.FC<FileTabProps> = ({
@@ -16,35 +17,49 @@ export const FileTab: React.FC<FileTabProps> = ({
     isDirty = false,
     onClick,
     onClose,
+    'data-active': dataActive,
 }) => {
     return (
-        <div className="h-full pl-3 pr-3 relative group">
+        <div className="h-full pl-3 pr-3 relative group" data-active={dataActive}>
             <div className="absolute right-0 h-[50%] w-[0.5px] bg-foreground/10 top-1/2 -translate-y-1/2"></div>
             <div className="flex items-center h-full relative">
                 <button
                     className={cn(
                         'text-sm h-full flex items-center focus:outline-none max-w-[150px]',
                         isActive
-                            ? 'text-foreground'
-                            : 'text-foreground-secondary/50 hover:text-foreground-hover',
+                            ? isDirty 
+                                ? 'text-teal-300'
+                                : 'text-foreground'
+                            : isDirty
+                                ? 'text-teal-500'
+                                : 'text-foreground-secondary/50',
                     )}
                     onClick={onClick}
                 >
                     <span className="truncate">{filename}</span>
                     {isDirty && (
-                        <span className="ml-1 flex-shrink-0 text-foreground-hover text-white">
+                        <span className={cn(
+                            "ml-1 flex-shrink-0",
+                            isActive ? "text-teal-300" : "text-teal-500"
+                        )}>
                             ●
                         </span>
                     )}
                     {isActive && (
-                        <div className="absolute bottom-0 left-0 w-full h-[2px] bg-foreground-hover"></div>
+                        <div className={cn(
+                            "absolute bottom-0 left-0 w-full h-[2px]",
+                            isDirty ? "bg-teal-300" : "bg-foreground-hover"
+                        )}></div>
+                    )}
+                    {!isActive && (
+                        <div className="absolute bottom-0 left-0 w-full h-[2px] bg-foreground-tertiary/50 opacity-0 group-hover:opacity-100"></div>
                     )}
                 </button>
                 <div className="absolute right-[-3px] top-1/2 -translate-y-1/2 z-10 opacity-0 group-hover:opacity-100 transition-opacity group-hover:bg-background-primary rounded-md">
                     <button
                         className={cn(
                             "cursor-pointer p-1.5 flex-shrink-0 hover:text-foreground-hover hover:bg-secondary hover:rounded-md",
-                            isActive ? "text-foreground" : "text-foreground"
+                            isActive ? "text-foreground-secondary" : "text-foreground-primary"
                         )}
                         onClick={(e) => {
                             e.stopPropagation();

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree-row.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree-row.tsx
@@ -12,7 +12,7 @@ export const FileTreeRow = forwardRef<
             ref={ref}
             {...attrs}
             className={cn(
-                'outline-none h-6 cursor-pointer w-full rounded',
+                'outline-none h-6 cursor-pointer min-w-0 w-auto rounded',
                 'text-foreground-onlook/70',
                 !attrs['aria-selected'] && [
                     isHighlighted && 'bg-background-onlook text-foreground-primary',

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
@@ -219,15 +219,15 @@ function UnmemoizedFileTree({ onFileSelect, files, isLoading = false, onRefresh,
     return (
         <div
             ref={containerRef}
-            className="w-64 h-full border-r-[0.5px] flex-shrink-0 overflow-hidden flex flex-col"
+            className="w-56 h-full border-r-[0.5px] flex-shrink-0 overflow-hidden flex flex-col"
         >
             <div className="flex flex-col h-full overflow-hidden">
-                <div className="p-3 flex-shrink-0">
-                    <div className="flex flex-row justify-between items-center gap-2 mb-2">
+                <div className="p-1.5 flex-shrink-0">
+                    <div className="flex flex-row justify-between items-center gap-1 mb-2 pb-1.5 border-b-[0.5px] border-border-primary">
                         <div className="relative flex-grow">
                             <Input
                                 ref={inputRef}
-                                className="h-8 text-xs pr-8"
+                                className="h-8 text-small pr-8 focus-visible:ring-1 focus-visible:ring-border-secondary/50 focus-visible:ring-offset-0"
                                 placeholder="Search files"
                                 value={searchQuery}
                                 disabled={isLoading}
@@ -248,7 +248,7 @@ function UnmemoizedFileTree({ onFileSelect, files, isLoading = false, onRefresh,
                                 <Button
                                     variant={'default'}
                                     size={'icon'}
-                                    className="p-2 w-fit h-fit text-foreground-primary border-border-primary hover:border-border-onlook bg-background-secondary hover:bg-background-onlook border"
+                                    className="p-2 w-fit h-8 text-foreground-tertiary hover:text-foreground-hover hover:border-border-onlook bg-background-none hover:bg-background-onlook"
                                     disabled={isLoading}
                                     onClick={handleRefresh}
                                 >
@@ -268,51 +268,55 @@ function UnmemoizedFileTree({ onFileSelect, files, isLoading = false, onRefresh,
                     </div>
                 </div>
 
+                <div className="px-2">
                 <div
-                    className="flex-1 overflow-auto px-3 text-xs"
+                    className="flex-1 overflow-x-auto text-xs w-full"
                     style={{ height: 'calc(100% - 56px)' }}
                 >
-                    {isLoading ? (
-                        <div className="flex flex-col justify-center items-center h-full text-sm text-foreground/50">
-                            <div className="animate-spin h-6 w-6 border-2 border-foreground-hover rounded-full border-t-transparent mb-2"></div>
-                            <span>Loading files...</span>
+                    <div className="min-w-full h-full">
+                        {isLoading ? (
+                            <div className="flex flex-col justify-center items-center h-full text-sm text-foreground/50">
+                                <div className="animate-spin h-6 w-6 border-2 border-foreground-hover rounded-full border-t-transparent mb-2"></div>
+                                <span>Loading files...</span>
+                            </div>
+                        ) : filteredFiles.length === 0 ? (
+                            <div className="flex justify-center items-center h-full text-sm text-foreground/50">
+                                {files.length === 0 ? 'No files found' : 'No files match your search'}
+                            </div>
+                        ) : (
+                            <div className="h-full">
+                                <Tree
+                                    ref={treeRef}
+                                    data={filteredFiles}
+                                    idAccessor={(node: FileNode) => node.id}
+                                    childrenAccessor={(node: FileNode) =>
+                                        node.children && node.children.length > 0
+                                            ? node.children
+                                            : null
+                                    }
+                                    onSelect={handleFileTreeSelect}
+                                    height={filesTreeDimensions.height}
+                                    width={filesTreeDimensions.width}
+                                    indent={8}
+                                    rowHeight={24}
+                                    openByDefault={false}
+                                    renderRow={(props: any) => (
+                                        <FileTreeRow
+                                            {...props}
+                                            isHighlighted={
+                                                highlightedIndex !== null &&
+                                                treeRef.current?.visibleNodes[highlightedIndex]?.id ===
+                                                props.node.id
+                                            }
+                                        />
+                                    )}
+                                >
+                                    {(props) => <FileTreeNode {...props} files={files} />}
+                                </Tree>
+                            </div>
+                        )}
                         </div>
-                    ) : filteredFiles.length === 0 ? (
-                        <div className="flex justify-center items-center h-full text-sm text-foreground/50">
-                            {files.length === 0 ? 'No files found' : 'No files match your search'}
-                        </div>
-                    ) : (
-                        <div className="h-full">
-                            <Tree
-                                ref={treeRef}
-                                data={filteredFiles}
-                                idAccessor={(node: FileNode) => node.id}
-                                childrenAccessor={(node: FileNode) =>
-                                    node.children && node.children.length > 0
-                                        ? node.children
-                                        : null
-                                }
-                                onSelect={handleFileTreeSelect}
-                                height={filesTreeDimensions.height}
-                                width={filesTreeDimensions.width}
-                                indent={8}
-                                rowHeight={24}
-                                openByDefault={false}
-                                renderRow={(props: any) => (
-                                    <FileTreeRow
-                                        {...props}
-                                        isHighlighted={
-                                            highlightedIndex !== null &&
-                                            treeRef.current?.visibleNodes[highlightedIndex]?.id ===
-                                            props.node.id
-                                        }
-                                    />
-                                )}
-                            >
-                                {(props) => <FileTreeNode {...props} files={files} />}
-                            </Tree>
-                        </div>
-                    )}
+                    </div>
                 </div>
             </div>
         </div>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -464,7 +464,7 @@ export const DevTab = observer(() => {
                                             onClick={() => setIsFilesVisible(!isFilesVisible)}
                                             className="text-muted-foreground hover:text-foreground"
                                         >
-                                            <Icons.CollapseSidebar />
+                                            {isFilesVisible ? <Icons.SidebarLeftCollapse /> : <Icons.SidebarLeftExpand />}
                                         </Button>
                                     </TooltipTrigger>
                                     <TooltipContent side="bottom" className="mt-1" hideArrow>
@@ -472,7 +472,7 @@ export const DevTab = observer(() => {
                                     </TooltipContent>
                                 </Tooltip>
                             </div>
-                            <div className="absolute right-0 top-0 bottom-0 z-20 flex items-center h-full border-l-[0.5px] p-1 bg-background w-12">
+                            <div className="absolute right-0 top-0 bottom-0 z-20 flex items-center h-full border-l-[0.5px] p-1 bg-background w-11">
                                 <DropdownMenu>
                                     <DropdownMenuTrigger className="text-muted-foreground hover:text-foreground hover:bg-foreground/5 p-1 rounded h-full w-full flex items-center justify-center px-2.5">
                                         <Icons.DotsHorizontal className="h-4 w-4" />
@@ -481,12 +481,14 @@ export const DevTab = observer(() => {
                                         <DropdownMenuItem
                                             onClick={() => ide.activeFile && closeFile(ide.activeFile.id)}
                                             disabled={!ide.activeFile}
+                                            className="cursor-pointer"
                                         >
                                             Close file
                                         </DropdownMenuItem>
                                         <DropdownMenuItem
                                             onClick={() => closeAllFiles()}
                                             disabled={ide.openedFiles.length === 0}
+                                            className="cursor-pointer"
                                         >
                                             Close all
                                         </DropdownMenuItem>
@@ -518,101 +520,110 @@ export const DevTab = observer(() => {
                                 </div>
                             )}
                             <div ref={editorContainer} className="h-full">
-                                {ide.openedFiles.map((file) => (
-                                    <div
-                                        key={file.id}
-                                        className="h-full"
-                                        style={{
-                                            display: ide.activeFile?.id === file.id ? 'block' : 'none',
-                                        }}
-                                    >
-                                        {file.isBinary ? (
-                                            <img
-                                                src={getFileUrl(file)}
-                                                alt={file.filename}
-                                                className="w-full h-full object-contain p-5"
-                                            />
-                                        ) : (
-                                            <CodeMirror
-                                                key={file.id}
-                                                value={file.content}
-                                                height="100%"
-                                                theme="dark"
-                                                extensions={[
-                                                    ...getBasicSetup(saveFile),
-                                                    ...getExtensions(file.language),
-                                                ]}
-                                                onChange={(value) => {
-                                                    if (ide.highlightRange) {
-                                                        ide.setHighlightRange(null);
-                                                    }
-                                                    updateFileContent(file.id, value);
-                                                }}
-                                                className="h-full overflow-hidden"
-                                                onCreateEditor={(editor) => {
-                                                    editorViewsRef.current.set(file.id, editor);
-
-                                                    editor.dom.addEventListener('mousedown', () => {
+                                {/* Empty state when no file is selected */}
+                                {ide.openedFiles.length === 0 || !ide.activeFile ? (
+                                    <div className="absolute inset-0 flex items-center justify-center z-10">
+                                        <div className="text-center text-muted-foreground text-base">
+                                            Open a file or select an element on the page.
+                                        </div>
+                                    </div>
+                                ) : (
+                                    ide.openedFiles.map((file) => (
+                                        <div
+                                            key={file.id}
+                                            className="h-full"
+                                            style={{
+                                                display: ide.activeFile?.id === file.id ? 'block' : 'none',
+                                            }}
+                                        >
+                                            {file.isBinary ? (
+                                                <img
+                                                    src={getFileUrl(file)}
+                                                    alt={file.filename}
+                                                    className="w-full h-full object-contain p-5"
+                                                />
+                                            ) : (
+                                                <CodeMirror
+                                                    key={file.id}
+                                                    value={file.content}
+                                                    height="100%"
+                                                    theme="dark"
+                                                    extensions={[
+                                                        ...getBasicSetup(saveFile),
+                                                        ...getExtensions(file.language),
+                                                    ]}
+                                                    onChange={(value) => {
                                                         if (ide.highlightRange) {
                                                             ide.setHighlightRange(null);
                                                         }
-                                                    });
+                                                        updateFileContent(file.id, value);
+                                                    }}
+                                                    className="h-full overflow-hidden"
+                                                    onCreateEditor={(editor) => {
+                                                        editorViewsRef.current.set(file.id, editor);
 
-                                                    // If this file is the active file and we have a highlight range,
-                                                    // trigger the highlight effect again
-                                                    if (
-                                                        ide.activeFile &&
-                                                        ide.activeFile.id === file.id &&
-                                                        ide.highlightRange
-                                                    ) {
-                                                        setTimeout(() => {
+                                                        editor.dom.addEventListener('mousedown', () => {
                                                             if (ide.highlightRange) {
-                                                                ide.setHighlightRange(ide.highlightRange);
+                                                                ide.setHighlightRange(null);
                                                             }
-                                                        }, 300);
-                                                    }
-                                                }}
-                                            />
-                                        )}
-                                        {ide.activeFile?.isDirty && showUnsavedDialog && (
-                                            <div className="absolute top-4 left-1/2 z-50 -translate-x-1/2 bg-white dark:bg-zinc-800 border dark:border-zinc-700 shadow-lg rounded-lg p-4 w-[320px]">
-                                                <div className="text-sm text-gray-800 dark:text-gray-100 mb-4">
-                                                    You have unsaved changes. Are you sure you want
-                                                    to close this file?
+                                                        });
+
+                                                        // If this file is the active file and we have a highlight range,
+                                                        // trigger the highlight effect again
+                                                        if (
+                                                            ide.activeFile &&
+                                                            ide.activeFile.id === file.id &&
+                                                            ide.highlightRange
+                                                        ) {
+                                                            setTimeout(() => {
+                                                                if (ide.highlightRange) {
+                                                                    ide.setHighlightRange(ide.highlightRange);
+                                                                }
+                                                            }, 300);
+                                                        }
+                                                    }}
+                                                />
+                                            )}
+                                            {ide.activeFile?.isDirty && showUnsavedDialog && (
+                                                <div className="absolute top-4 left-1/2 z-50 -translate-x-1/2 bg-white dark:bg-zinc-800 border dark:border-zinc-700 shadow-lg rounded-lg p-4 w-[320px]">
+                                                    <div className="text-sm text-gray-800 dark:text-gray-100 mb-4">
+                                                        You have unsaved changes. Are you sure you want
+                                                        to close this file?
+                                                    </div>
+                                                    <div className="flex justify-end gap-1">
+                                                        <Button
+                                                            onClick={async () => {
+                                                                await discardChanges(file.id);
+                                                            }}
+                                                            variant="ghost"
+                                                            className="text-red hover:text-red"
+                                                        >
+                                                            Discard
+                                                        </Button>
+                                                        <Button
+                                                            onClick={async () => {
+                                                                await saveFile();
+                                                            }}
+                                                            variant="ghost"
+                                                            className="text-sm text-blue-500 hover:text-blue-500"
+                                                        >
+                                                            Save
+                                                        </Button>
+                                                        <Button
+                                                            variant="ghost"
+                                                            onClick={() => {
+                                                                setShowUnsavedDialog(false);
+                                                                setPendingCloseAll(false);
+                                                            }}
+                                                        >
+                                                            Cancel
+                                                        </Button>
+                                                    </div>
                                                 </div>
-                                                <div className="flex justify-end gap-1">
-                                                    <Button
-                                                        onClick={async () => {
-                                                            await discardChanges(file.id);
-                                                        }}
-                                                        variant="ghost"
-                                                        className="text-red hover:text-red"
-                                                    >
-                                                        Discard
-                                                    </Button>
-                                                    <Button
-                                                        onClick={async () => {
-                                                            await saveFile();
-                                                        }}
-                                                        variant="ghost"
-                                                        className="text-sm text-blue-500 hover:text-blue-500"
-                                                    >
-                                                        Save
-                                                    </Button>
-                                                    <Button
-                                                        variant="ghost"
-                                                        onClick={() => {
-                                                            setShowUnsavedDialog(false);
-                                                            setPendingCloseAll(false);
-                                                        }}
-                                                    >
-                                                        Cancel
-                                                    </Button>
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
-                                ))}
+                                            )}
+                                        </div>
+                                    ))
+                                )}
                             </div>
                         </div>
                     </div>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -35,6 +35,7 @@ export const DevTab = observer(() => {
     const isDirty = ide.activeFile?.isDirty ?? false;
     const editorContainer = useRef<HTMLDivElement | null>(null);
     const editorViewsRef = useRef<Map<string, EditorView>>(new Map());
+    const fileTabsContainerRef = useRef<HTMLDivElement>(null);
 
     // Helper function to check if sandbox is connected and ready
     const isSandboxReady = useCallback((): boolean => {
@@ -421,6 +422,32 @@ export const DevTab = observer(() => {
         };
     }, []);
 
+    const scrollToActiveTab = useCallback(() => {
+        if (!fileTabsContainerRef.current || !ide.activeFile) return;
+        
+        const container = fileTabsContainerRef.current;
+        const activeTab = container.querySelector('[data-active="true"]');
+        
+        if (activeTab) {
+            const containerRect = container.getBoundingClientRect();
+            const tabRect = activeTab.getBoundingClientRect();
+            
+            // Calculate if the tab is outside the visible area
+            if (tabRect.left < containerRect.left) {
+                // Tab is to the left of the visible area
+                container.scrollLeft += tabRect.left - containerRect.left;
+            } else if (tabRect.right > containerRect.right) {
+                // Tab is to the right of the visible area
+                container.scrollLeft += tabRect.right - containerRect.right;
+            }
+        }
+    }, [ide.activeFile]);
+
+    // Scroll to active tab when it changes
+    useEffect(() => {
+        scrollToActiveTab();
+    }, [ide.activeFile, scrollToActiveTab]);
+
     return (
         <div className="size-full flex flex-col">
 
@@ -495,7 +522,7 @@ export const DevTab = observer(() => {
                                     </DropdownMenuContent>
                                 </DropdownMenu>
                             </div>
-                            <div className="flex items-center h-full overflow-x-auto w-full pl-11 pr-12">
+                            <div className="flex items-center h-full overflow-x-auto w-full ml-11 mr-10.5" ref={fileTabsContainerRef}>
                                 {ide.openedFiles.map((file) => (
                                     <FileTab
                                         key={file.id}
@@ -504,6 +531,7 @@ export const DevTab = observer(() => {
                                         isDirty={file.isDirty}
                                         onClick={() => handleFileSelect(file)}
                                         onClose={() => closeFile(file.id)}
+                                        data-active={ide.activeFile?.id === file.id}
                                     />
                                 ))}
                             </div>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/index.tsx
@@ -423,50 +423,6 @@ export const DevTab = observer(() => {
 
     return (
         <div className="size-full flex flex-col">
-            <div className="flex items-center justify-between h-11 pl-4 pr-2 border-b-[0.5px]">
-                <div className="flex gap-1 items-center h-full">
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Button variant="ghost" size="icon" onClick={() => setIsFilesVisible(!isFilesVisible)}>
-                                <Icons.CollapseSidebar />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" hideArrow>
-                            {isFilesVisible ? 'Collapse sidebar' : 'Expand sidebar'}
-                        </TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                        <TooltipTrigger>
-                            <Button variant="ghost" size="icon" onClick={() => setFileModalOpen(true)}>
-                                <Icons.FilePlus />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" hideArrow>
-                            New File
-                        </TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                        <TooltipTrigger>
-                            <Button variant="ghost" size="icon" onClick={() => setFolderModalOpen(true)}>
-                                <Icons.DirectoryPlus />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" hideArrow>
-                            New Folder
-                        </TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                        <TooltipTrigger>
-                            <Button variant="ghost" size="icon" onClick={saveFile} disabled={!isDirty}>
-                                <Icons.FloppyDisk />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" hideArrow>
-                            Save changes
-                        </TooltipContent>
-                    </Tooltip>
-                </div>
-            </div>
 
             {/* Show connection status when sandbox is not ready */}
             {!isSandboxReady() && (
@@ -498,23 +454,27 @@ export const DevTab = observer(() => {
                     {/* Editor section */}
                     <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
                         {/* File tabs */}
-                        <div className="flex items-center justify-between h-10 border-b-[0.5px] flex-shrink-0">
-                            <div className="flex items-center h-full overflow-x-auto">
-                                {ide.openedFiles.map((file: EditorFile) => (
-                                    <FileTab
-                                        key={file.id}
-                                        filename={file.filename}
-                                        isActive={ide.activeFile?.id === file.id}
-                                        isDirty={file.isDirty}
-                                        onClick={() => handleFileSelect(file)}
-                                        onClose={() => closeFile(file.id)}
-                                    />
-                                ))}
+                        <div className="flex items-center justify-between h-11 pl-0 border-b-[0.5px] flex-shrink-0 relative">
+                            <div className="absolute left-0 top-0 bottom-0 z-20 border-r-[0.5px] h-full flex items-center p-1 bg-background">
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Button 
+                                            variant="ghost" 
+                                            size="icon" 
+                                            onClick={() => setIsFilesVisible(!isFilesVisible)}
+                                            className="text-muted-foreground hover:text-foreground"
+                                        >
+                                            <Icons.CollapseSidebar />
+                                        </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" className="mt-1" hideArrow>
+                                        {isFilesVisible ? 'Collapse sidebar' : 'Expand sidebar'}
+                                    </TooltipContent>
+                                </Tooltip>
                             </div>
-
-                            <div className="border-l-[0.5px] h-full flex items-center p-1">
+                            <div className="absolute right-0 top-0 bottom-0 z-20 flex items-center h-full border-l-[0.5px] p-1 bg-background w-12">
                                 <DropdownMenu>
-                                    <DropdownMenuTrigger className="text-foreground hover:text-foreground-hover hover:bg-foreground/5 p-1 rounded h-full w-full flex items-center justify-center px-3">
+                                    <DropdownMenuTrigger className="text-muted-foreground hover:text-foreground hover:bg-foreground/5 p-1 rounded h-full w-full flex items-center justify-center px-2.5">
                                         <Icons.DotsHorizontal className="h-4 w-4" />
                                     </DropdownMenuTrigger>
                                     <DropdownMenuContent align="end" className="-mt-1">
@@ -532,6 +492,18 @@ export const DevTab = observer(() => {
                                         </DropdownMenuItem>
                                     </DropdownMenuContent>
                                 </DropdownMenu>
+                            </div>
+                            <div className="flex items-center h-full overflow-x-auto w-full pl-11 pr-12">
+                                {ide.openedFiles.map((file) => (
+                                    <FileTab
+                                        key={file.id}
+                                        filename={file.filename}
+                                        isActive={ide.activeFile?.id === file.id}
+                                        isDirty={file.isDirty}
+                                        onClick={() => handleFileSelect(file)}
+                                        onClose={() => closeFile(file.id)}
+                                    />
+                                ))}
                             </div>
                         </div>
 

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/index.tsx
@@ -45,7 +45,7 @@ export const RightPanel = observer(() => {
                 maxWidth={1440}
             >
                 <Tabs className='h-full gap-0' onValueChange={(value) => editorEngine.state.rightPanelTab = value as EditorTabValue} value={selectedTab} >
-                    <TabsList className='flex flex-row h-10 w-full border-b-1 border-border items-center bg-transparent select-none pr-2 pl-1.5 justify-between'>
+                    <TabsList className='flex flex-row h-10 w-full border-b-1 border-border items-center bg-transparent select-none pr-1 pl-1.5 justify-between'>
                         <div className="flex flex-row items-center gap-2 ">
                             <ChatPanelDropdown
                                 isChatHistoryOpen={isChatHistoryOpen}

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/index.tsx
@@ -15,6 +15,7 @@ import { ChatControls } from './chat-tab/controls';
 import { ChatHistory } from './chat-tab/history';
 import { ChatPanelDropdown } from './chat-tab/panel-dropdown';
 import { DevTab } from './dev-tab';
+import { CodeControls } from './dev-tab/code-controls';
 
 const EDIT_PANEL_WIDTHS = {
     [EditorTabValue.CHAT]: 352,
@@ -68,6 +69,7 @@ export const RightPanel = observer(() => {
                             </TabsTrigger>
                         </div>
                         {selectedTab === EditorTabValue.CHAT && <ChatControls />}
+                        {selectedTab === EditorTabValue.DEV && <CodeControls />}
                     </TabsList>
                     <ChatHistory isOpen={isChatHistoryOpen} onOpenChange={setIsChatHistoryOpen} />
                     <TabsContent className="h-full overflow-y-auto" value={EditorTabValue.CHAT}>

--- a/packages/ui/src/components/icons/index.tsx
+++ b/packages/ui/src/components/icons/index.tsx
@@ -1308,7 +1308,6 @@ export const Icons = {
     EnvelopeClosed: EnvelopeClosedIcon,
 
     File: FileIcon,
-    FilePlus: FilePlusIcon,
     Frame: FrameIcon,
 
     Gear: GearIcon,
@@ -2035,25 +2034,104 @@ export const Icons = {
             />
         </svg>
     ),
-    FloppyDisk: ({ className, ...props }: IconProps) => (
+
+    SidebarLeftCollapse: ({ className, ...props }: IconProps) => (
         <svg
-            viewBox="0 0 16 16"
-            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
             fill="none"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="1.3"
+            xmlns="http://www.w3.org/2000/svg"
             className={cn(className)}
             {...props}
         >
-            <polygon points="2.75 2.75,2.75 13.25,13.25 13.25,13.25 5.75,10.25 2.75" />
-            <polyline points="5.75 13.25,5.75 9.75,10.25 9.75,10.25 13.25" />
+            <path
+                d="M11.4375 7.3125L9.75 9L11.4375 10.6875"
+                stroke="currentColor"
+                strokeWidth="1.125"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M2.8125 4.3125C2.8125 3.48407 3.48407 2.8125 4.3125 2.8125H13.6875C14.5159 2.8125 15.1875 3.48407 15.1875 4.3125V13.6875C15.1875 14.5159 14.5159 15.1875 13.6875 15.1875H4.3125C3.48407 15.1875 2.8125 14.5159 2.8125 13.6875V4.3125Z"
+                stroke="currentColor"
+                strokeWidth="1.125"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <path d="M6.1875 2.8125V15.1875" stroke="currentColor" strokeWidth="1.125" />
+        </svg>
+    ),
+
+    SidebarLeftExpand: ({ className, ...props }: IconProps) => (
+        <svg
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className={cn(className)}
+            {...props}
+        >
+            <path
+                d="M9.75 7.3125L11.4375 9L9.75 10.6875"
+                stroke="currentColor"
+                strokeWidth="1.125"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M2.8125 4.3125C2.8125 3.48407 3.48407 2.8125 4.3125 2.8125H13.6875C14.5159 2.8125 15.1875 3.48407 15.1875 4.3125V13.6875C15.1875 14.5159 14.5159 15.1875 13.6875 15.1875H4.3125C3.48407 15.1875 2.8125 14.5159 2.8125 13.6875V4.3125Z"
+                stroke="currentColor"
+                strokeWidth="1.125"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <path d="M6.1875 2.8125V15.1875" stroke="currentColor" strokeWidth="1.125" />
+        </svg>
+    ),
+
+    Save: ({ className, ...props }: IconProps) => (
+        <svg
+            width="15"
+            height="18"
+            viewBox="0 0 18 18"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                d="M5.8125 2.8125V5.4375C5.8125 5.85171 6.14829 6.1875 6.5625 6.1875H11.4375C11.8517 6.1875 12.1875 5.85171 12.1875 5.4375V2.8125M15.1875 5.68382V13.6875C15.1875 14.5159 14.5159 15.1875 13.6875 15.1875H4.3125C3.48407 15.1875 2.8125 14.5159 2.8125 13.6875V4.3125C2.8125 3.48407 3.48407 2.8125 4.3125 2.8125H12.3162C12.714 2.8125 13.0955 2.97053 13.3769 3.25184L14.7481 4.62316C15.0295 4.90447 15.1875 5.28599 15.1875 5.68382ZM5.8125 10.3125V14.4375C5.8125 14.8517 6.14829 15.1875 6.5625 15.1875H11.4375C11.8517 15.1875 12.1875 14.8517 12.1875 14.4375V10.3125C12.1875 9.89828 11.8517 9.5625 11.4375 9.5625H6.5625C6.14829 9.5625 5.8125 9.89828 5.8125 10.3125Z"
+                stroke="currentColor"
+                strokeWidth="1.125"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
         </svg>
     ),
     DirectoryPlus: ({ className, ...props }: IconProps) => (
         <svg
-            viewBox="0 0 23 23"
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            className={cn(className)}
+            {...props}
+        >
+            <path
+                d="M8.0625 14.4375H14.4375C15.2659 14.4375 15.9375 13.7659 15.9375 12.9375V6.5625C15.9375 5.73407 15.2659 5.0625 14.4375 5.0625H9.8028C9.30128 5.0625 8.8329 4.81185 8.55472 4.39455L7.94528 3.48045C7.6671 3.06315 7.19876 2.8125 6.69722 2.8125H3.5625C2.73407 2.8125 2.0625 3.48407 2.0625 4.3125V8.4375M3.5625 10.6875V12.9375M3.5625 12.9375V15.1875M3.5625 12.9375H1.3125M3.5625 12.9375H5.8125"
+                stroke="currentColor"
+                strokeWidth="1.125"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    ),
+    FilePlus: ({ className, ...props }: IconProps) => (
+        <svg
+            width="18"
+            height="18"
+            viewBox="0 0 18 18"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             stroke="currentColor"
@@ -2063,9 +2141,7 @@ export const Icons = {
             className={cn(className)}
             {...props}
         >
-            <path d="M3 5a2 2 0 012-2h5.5a2 2 0 011.5 1.5l1.5 1.5a2 2 0 001.5.5H19a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5z" />
-            <path d="M12 10v4" />
-            <path d="M10 12h4" />
+            <path d="M10.2486 2.375V5.375C10.2486 6.20343 10.9201 6.875 11.7486 6.875H14.7486M4.24609 7.4375L4.24859 3.5C4.24859 2.67157 4.92017 2 5.74859 2H9.62729C10.0251 2 10.4066 2.15803 10.6879 2.43934L14.6842 6.43566C14.9656 6.71697 15.1236 7.09849 15.1236 7.4963V14.375C15.1236 15.2034 14.452 15.875 13.6236 15.875H10.6548H8.7475M4.25 10.625V12.875M4.25 12.875V15.125M4.25 12.875H2M4.25 12.875H6.5" />
         </svg>
     ),
 } satisfies { [key: string]: React.FC<IconProps> };


### PR DESCRIPTION
## Description

* Custom branded icons
* improved styles
* Added horizontal scrolling for file tab
* layered the three-dot menu on top
* Tightened styling for the files / input / refresh
* Moved code controls to the upper right to save more vertical space / clean up the UI.
* Made the "Close tab" functionality visually cleaner
* Added empty state for no files selected
  
## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

<img width="723" alt="Screenshot 2025-06-11 at 9 28 30 PM" src="https://github.com/user-attachments/assets/1dfeb46a-96b3-4905-9d73-5a96f4732d0d" />



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI polish for code tab with new icons, improved styles, horizontal scrolling, and empty state handling.
> 
>   - **UI Enhancements**:
>     - Custom branded icons added to `icons/index.tsx`.
>     - Improved styles in `file-tab.tsx` and `file-tree.tsx` for better visual consistency.
>     - Added horizontal scrolling for file tabs in `index.tsx`.
>     - Three-dot menu layered on top in `index.tsx`.
>     - Code controls moved to upper right in `code-controls.tsx`.
>     - "Close tab" functionality visually improved in `file-tab.tsx`.
>     - Added empty state for no files selected in `index.tsx`.
>   - **Icons**:
>     - Added `SidebarLeftCollapse`, `SidebarLeftExpand`, `Save`, `DirectoryPlus`, and `FilePlus` icons.
>     - Removed `FloppyDisk` icon.
>   - **Misc**:
>     - Tightened styling for files/input/refresh in `file-tree.tsx`.
>     - Minor layout adjustments in `right-panel/index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for dc228f565bd823a05b50094d083261c5d87cceca. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->