### PR TITLE
Fix template mapping cleanup

### DIFF
--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -286,6 +286,7 @@ export class SandboxManager {
             const eventType = event.type;
             if (event.type === 'remove') {
                 await this.fileSync.delete(normalizedPath);
+                this.templateNodeMap.removeMappingForFile(normalizedPath);
             } else if (eventType === 'change' || eventType === 'add') {
                 const content = await this.readRemoteFile(normalizedPath);
                 if (content === null) {
@@ -405,8 +406,9 @@ export class SandboxManager {
             // Delete the file using the filesystem API
             await this.session.session.fs.remove(normalizedPath, recursive);
 
-            // Clean up the file sync cache
+            // Clean up the file sync cache and template mappings
             await this.fileSync.delete(normalizedPath);
+            this.templateNodeMap.removeMappingForFile(normalizedPath);
 
             // Publish file deletion event
             this.fileEventBus.publish({

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -33,6 +33,7 @@ export class SandboxManager {
                 this.isIndexed = false;
                 if (session) {
                     this.fileSync.clear(); // Clear cache when switching projects
+                    this.templateNodeMap.clear(); // Remove stale template mappings
                     this.index();
                 }
             },

--- a/apps/web/client/src/components/store/editor/sandbox/mapping.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/mapping.ts
@@ -44,11 +44,13 @@ export class TemplateNodeMapper {
     }
 
     updateMappingForFile(filePath: string, newMap: Map<string, TemplateNode>) {
+        const keysToDelete = [];
         for (const [oid, node] of this.oidToTemplateNodeMap.entries()) {
             if (node.path === filePath) {
-                this.oidToTemplateNodeMap.delete(oid);
+                keysToDelete.push(oid);
             }
         }
+        keysToDelete.forEach(oid => this.oidToTemplateNodeMap.delete(oid));
         this.updateMapping(newMap);
     }
 

--- a/apps/web/client/src/components/store/editor/sandbox/mapping.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/mapping.ts
@@ -43,6 +43,15 @@ export class TemplateNodeMapper {
         this.saveToLocalStorage();
     }
 
+    updateMappingForFile(filePath: string, newMap: Map<string, TemplateNode>) {
+        for (const [oid, node] of this.oidToTemplateNodeMap.entries()) {
+            if (node.path === filePath) {
+                this.oidToTemplateNodeMap.delete(oid);
+            }
+        }
+        this.updateMapping(newMap);
+    }
+
     async processFileForMapping(
         file: string,
         readFile: (path: string) => Promise<string | null>,
@@ -62,7 +71,7 @@ export class TemplateNodeMapper {
 
         const { ast: astWithIds, modified } = addOidsToAst(ast);
         const templateNodeMap = createTemplateNodeMap(astWithIds, file);
-        this.updateMapping(templateNodeMap);
+        this.updateMappingForFile(file, templateNodeMap);
 
         // Write the file if it has changed
         if (modified) {

--- a/apps/web/client/src/components/store/editor/sandbox/mapping.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/mapping.ts
@@ -52,6 +52,15 @@ export class TemplateNodeMapper {
         this.updateMapping(newMap);
     }
 
+    removeMappingForFile(filePath: string) {
+        for (const [oid, node] of this.oidToTemplateNodeMap.entries()) {
+            if (node.path === filePath) {
+                this.oidToTemplateNodeMap.delete(oid);
+            }
+        }
+        this.saveToLocalStorage();
+    }
+
     async processFileForMapping(
         file: string,
         readFile: (path: string) => Promise<string | null>,

--- a/apps/web/client/test/sandbox/mapping.test.ts
+++ b/apps/web/client/test/sandbox/mapping.test.ts
@@ -52,6 +52,23 @@ describe('TemplateNodeMapper', () => {
         expect(result.has('oid2')).toBe(true);
     });
 
+    test('updateMappingForFile should replace existing entries for the same file', () => {
+        const file = 'test.tsx';
+        const map1 = new Map<string, TemplateNode>();
+        map1.set('oid1', createMockTemplateNode('oid1', 'Component1'));
+
+        const map2 = new Map<string, TemplateNode>();
+        const node2 = createMockTemplateNode('oid2', 'Component2');
+        map2.set('oid2', node2);
+
+        mapper.updateMappingForFile(file, map1);
+        mapper.updateMappingForFile(file, map2);
+
+        const result = mapper.getTemplateNodeMap();
+        expect(result.size).toBe(1);
+        expect(result.get('oid2')).toEqual(node2);
+    });
+
     test('updateMapping should call localforage.setItem with correct parameters', async () => {
         // Arrange
         const nodeMap = new Map<string, TemplateNode>();
@@ -134,7 +151,7 @@ describe('TemplateNodeMapper', () => {
             return true;
         });
 
-        const processFileSpy = spyOn(mapper, 'updateMapping');
+        const processFileSpy = spyOn(mapper, 'updateMappingForFile');
 
         // Act
         await mapper.processFileForMapping('test.tsx', mockReadFile, mockWriteFile);

--- a/apps/web/client/test/sandbox/mapping.test.ts
+++ b/apps/web/client/test/sandbox/mapping.test.ts
@@ -69,6 +69,17 @@ describe('TemplateNodeMapper', () => {
         expect(result.get('oid2')).toEqual(node2);
     });
 
+    test('removeMappingForFile should delete all entries for the file', () => {
+        const file = 'test.tsx';
+        const map = new Map<string, TemplateNode>();
+        map.set('oid1', createMockTemplateNode('oid1', 'Component1'));
+        mapper.updateMappingForFile(file, map);
+
+        mapper.removeMappingForFile(file);
+
+        expect(mapper.getTemplateNodeMap().size).toBe(0);
+    });
+
     test('updateMapping should call localforage.setItem with correct parameters', async () => {
         // Arrange
         const nodeMap = new Map<string, TemplateNode>();


### PR DESCRIPTION
## Summary
- ensure template mappings are cleared when switching sessions
- remove stale mapping entries when files are re-processed
- update tests for new helper method

## Testing
- `bun format`
- `bun lint` *(fails: Invalid environment variables)*
- `bun test` *(fails: No available storage method found)*

------
https://chatgpt.com/codex/tasks/task_e_684aff68ad8c8323a86531d4bf282b10
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve template mapping management in `SandboxManager` and `TemplateNodeMapper` by clearing and updating mappings on session changes and file modifications.
> 
>   - **Behavior**:
>     - Clear `templateNodeMap` in `SandboxManager` when switching sessions.
>     - Remove stale template mappings in `SandboxManager` when files are deleted or re-processed.
>   - **Functions**:
>     - Add `updateMappingForFile()` and `removeMappingForFile()` to `TemplateNodeMapper` to handle file-specific mapping updates.
>     - Modify `processFileForMapping()` in `TemplateNodeMapper` to use `updateMappingForFile()`.
>   - **Tests**:
>     - Add tests for `updateMappingForFile()` and `removeMappingForFile()` in `mapping.test.ts`.
>     - Update existing tests to reflect changes in `TemplateNodeMapper`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for a55d5d5fec8719aaba8241152b08a173e0b7789c. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->