### PR TITLE
fix: reset isDirty state when edits revert to original

### DIFF
--- a/apps/web/client/src/components/store/editor/dev/index.ts
+++ b/apps/web/client/src/components/store/editor/dev/index.ts
@@ -13,6 +13,7 @@ export interface EditorFile {
     language: string;
     isDirty: boolean;
     isBinary: boolean;
+    savedContent: string;
 }
 
 export interface CodeRange {
@@ -98,6 +99,7 @@ export class IDEManager {
                 filename: fileName,
                 path: filePath,
                 content: content || '',
+                savedContent: content || '',
                 language,
                 isDirty: false,
                 isBinary
@@ -116,7 +118,7 @@ export class IDEManager {
     updateFileContent(id: string, content: string) {
         const file = this.openedFiles.find((f) => f.id === id);
         if (!file) return;
-        const hasChanged = content !== file.content;
+        const hasChanged = content !== file.savedContent;
         file.content = content;
         file.isDirty = hasChanged;
         if (this.activeFile && this.activeFile.id === id) {
@@ -149,8 +151,11 @@ export class IDEManager {
                 ],
             });
             const file = this.openedFiles.find((f) => f.id === this.activeFile!.id);
-            if (file) file.isDirty = false;
-            this.activeFile = { ...this.activeFile, isDirty: false };
+            if (file){
+                file.isDirty = false;
+                file.savedContent = file.content;
+            }
+            this.activeFile = { ...this.activeFile, isDirty: false, savedContent: file?.content || '' };
 
             this.refreshPreviewAfterSave();
         } catch (error) {


### PR DESCRIPTION
## Description

## Related Issues

Closes: #2183

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `isDirty` state in `IDEManager` by using `savedContent` to track original file content.
> 
>   - **Behavior**:
>     - Fixes `isDirty` state in `IDEManager` by introducing `savedContent` in `EditorFile` to track original content.
>     - Updates `updateFileContent()` to compare `content` with `savedContent` instead of `content`.
>     - Modifies `saveActiveFile()` to update `savedContent` after saving, ensuring `isDirty` is reset.
>   - **Data Structures**:
>     - Adds `savedContent` to `EditorFile` interface to store original file content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 3120136ef4c4f37a726f545db413ffa4946f15aa. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->