### PR TITLE
fix: maintain padding and font while editing text

### DIFF
--- a/apps/web/client/src/components/store/editor/overlay/prosemirror/index.ts
+++ b/apps/web/client/src/components/store/editor/overlay/prosemirror/index.ts
@@ -68,6 +68,8 @@ export function applyStylesToEditor(editorView: EditorView, styles: Record<strin
         wordBreak: 'break-word',
         overflow: 'visible',
         height: '100%',
+        fontFamily: styles.fontFamily,
+        padding: styles.padding,
     });
     dispatch(tr);
 }


### PR DESCRIPTION
## Description

## Related Issues

Closes: #2187

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `fontFamily` and `padding` styles to `applyStylesToEditor()` in `index.ts` to maintain these styles during text editing.
> 
>   - **Behavior**:
>     - In `applyStylesToEditor()` in `index.ts`, added `fontFamily` and `padding` to the editor's DOM style to maintain these styles during text editing.
>   - **Related Issues**:
>     - Closes issue #2187.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 431eb3c20a55759b1cb4ee8f579278a1220a4582. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->