### PR TITLE
fix: website changes don't reflect

### DIFF
--- a/apps/web/client/src/components/store/editor/dev/index.ts
+++ b/apps/web/client/src/components/store/editor/dev/index.ts
@@ -167,7 +167,7 @@ export class IDEManager {
 
         if (this.shouldRefreshPreview(this.activeFile.path)) {
             setTimeout(() => {
-                this.editorEngine.frames.reloadAllFrames();
+                this.editorEngine.frames.reloadAll();
             }, 100);
         }
     }

--- a/apps/web/client/src/components/store/editor/frames/index.ts
+++ b/apps/web/client/src/components/store/editor/frames/index.ts
@@ -149,12 +149,6 @@ export class FramesManager {
     }
 
     reloadAll() {
-        for (const frame of this.selected) {
-            frame.view.reload();
-        }
-    }
-
-    reloadAllFrames() {
         for (const frameData of this.getAll()) {
             frameData.view.reload();
         }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Now changes will reflect immeadiately after changes in code and saving the file

## Related Issues
fixes #2182 
<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)


https://github.com/user-attachments/assets/3e9793a5-d7d2-4da2-b7e3-ebb6064c7d25


<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
cc: @drfarrell @Kitenite 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes immediate reflection of code changes by renaming `reloadAll()` to `reloadAllFrames()` to ensure all frames reload after saving a file.
> 
>   - **Behavior**:
>     - Fixes immediate reflection of code changes in the preview by renaming `reloadAll()` to `reloadAllFrames()` in `IDEManager` and `FramesManager`.
>     - Ensures all frames are reloaded after saving a file in `IDEManager`.
>   - **Functions**:
>     - Adds `reloadAllFrames()` method to `FramesManager` to reload all frames.
>     - Replaces `reloadAll()` with `reloadAllFrames()` in `IDEManager` to refresh preview after file save.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 2ff4d2f90af59e3501681677ae554d82c0d3d75b. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->