### PR TITLE
Fix Unicorn animation blocking

### DIFF
--- a/apps/web/client/src/app/_components/hero/unicorn-background.tsx
+++ b/apps/web/client/src/app/_components/hero/unicorn-background.tsx
@@ -78,6 +78,8 @@ export function UnicornBackground({ setIsMounted }: { setIsMounted: (isMounted: 
     useEffect(() => {
         if (!isLoaded) return;
 
+        setIsMounted(true);
+
         const initializeScene = async () => {
             const container = document.querySelector('[data-us-project="Gr1LmwbKSeJOXhpYEdit"]');
             if (!container) {
@@ -118,9 +120,24 @@ export function UnicornBackground({ setIsMounted }: { setIsMounted: (isMounted: 
             }
         };
 
-        void initializeScene();
+        let idleId: number;
+
+        const startInit = () => {
+            void initializeScene();
+        };
+
+        if ('requestIdleCallback' in window) {
+            idleId = (window as unknown as { requestIdleCallback: (cb: () => void) => number }).requestIdleCallback(startInit);
+        } else {
+            idleId = window.setTimeout(startInit, 0);
+        }
 
         return () => {
+            if ('cancelIdleCallback' in window && idleId) {
+                (window as unknown as { cancelIdleCallback: (id: number) => void }).cancelIdleCallback(idleId);
+            } else {
+                clearTimeout(idleId);
+            }
             if (sceneRef.current?.destroy) {
                 sceneRef.current.destroy();
                 sceneRef.current = null;


### PR DESCRIPTION
## Description
Make the unicorn background load during idle time so the rest of the UI does not wait for the animation to initialize.

## Related Issues

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing
- `bun install`
- `bun format`
- `bun lint` *(fails: Next.js config error)*
- `bun test` *(fails: localForage errors)*

## Screenshots (if applicable)

## Additional Notes
The lint and test commands fail in this environment due to missing or incompatible dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684e235608408323a91a54bc87a50e5f
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `UnicornBackground` component now loads unicorn animation during idle time to prevent UI blocking, using `requestIdleCallback` or `setTimeout` as fallback.
> 
>   - **Behavior**:
>     - `UnicornBackground` component now loads unicorn animation during idle time using `requestIdleCallback` or `setTimeout` as fallback.
>     - Sets `isMounted` to `true` immediately after `isLoaded` check.
>     - Initializes scene asynchronously to prevent UI blocking.
>   - **Functions**:
>     - Adds `startInit` function to handle scene initialization.
>     - Uses `requestIdleCallback` for idle time execution, with `setTimeout` as fallback.
>     - Cancels idle callback or timeout on cleanup.
>   - **Misc**:
>     - Minor refactoring in `useEffect` to improve readability and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 7cee85c2801e01672b754822876a53266f8e29a1. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->