### PR TITLE
feat: use Bun as default package manager in AI prompts

### DIFF
--- a/packages/ai/src/prompt/edit/edit.ts
+++ b/packages/ai/src/prompt/edit/edit.ts
@@ -3,8 +3,9 @@ import { CODE_FENCE } from '../format';
 export const SYSTEM_PROMPT = `You are running in Onlook to help users develop their app. Act as an expert React, Next.js and Tailwind developer. Your goal is to analyze the provided code, understand the requested modifications, and implement them accurately while explaining your thought process.
 
 - Always use best practices when coding. 
-= Respect and use existing conventions, libraries, etc that are already present in the code base. 
-= Refactor your code when possible, keep files and functions small for easier maintenance.
+- Respect and use existing conventions, libraries, etc that are already present in the code base. 
+- Refactor your code when possible, keep files and functions small for easier maintenance.
+- Always use Bun (bun) as the package manager by default instead of npm or yarn.
 
 Once you understand the request you MUST:
 1. Decide if you need to propose edits to any files that haven't been added to the chat. You can create new files without asking!


### PR DESCRIPTION
## Description

Updated the AI system prompt to use Bun as the default package manager instead of npm or yarn. This change ensures that when the AI suggests package manager commands, it will default to using Bun, which is faster and more efficient.


## Type of Change

<!-- Put an `x` in the boxes that apply -->
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- [ ] Verified the prompt change in the AI interface
- [ ] Confirmed the instruction is clear and unambiguous
- [ ] Tested that the AI now suggests Bun commands by default



## Additional Notes

- This change aligns with the growing adoption of Bun in the JavaScript/TypeScript ecosystem
- The change is backward compatible as it only affects the default suggestion behavior
- Existing npm/yarn commands will still work if explicitly specified
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `SYSTEM_PROMPT` in `edit.ts` to use Bun as the default package manager, ensuring AI suggests Bun commands by default.
> 
>   - **Behavior**:
>     - Updated `SYSTEM_PROMPT` in `edit.ts` to use Bun as the default package manager instead of npm or yarn.
>     - Ensures AI suggests Bun commands by default.
>   - **Compatibility**:
>     - Backward compatible; npm/yarn commands still work if specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 4a9989088c93d525ad456a6f45b9922e28df2a45. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->