### PR TITLE
fix: resolve resize handle inversion by standardizing coordinate systems

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/overlay/elements/rect/resize.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/overlay/elements/rect/resize.tsx
@@ -374,10 +374,7 @@ export const ResizeHandles: React.FC<ResizeHandlesProps> = ({
             const newOverlayDimensions = calculateNewOverlayDimensions(
                 position,
                 { width, height },
-                {
-                    x: deltaX,
-                    y: deltaY,
-                },
+                adjustedDelta,
             );
 
             const widthChanged = newElementDimensions.width !== startDimensions.width;


### PR DESCRIPTION
# Fix Resize Handle Inversion Issue

## Description

This PR resolves a critical bug where element resize handles behaved inversely to user expectations. When users attempted to resize elements by dragging from their edges, the resize behavior was inverted:

- Problem: Dragging from the right edge would affect the left side instead of the right
- Problem: Dragging from the top edge would affect the bottom side instead of the top

### Root Cause Analysis

The issue was caused by a coordinate system mismatch in the `handleMouseDownDimensions` function within the resize component:

- `calculateNewElementDimensions` correctly used `adjustedDelta` (canvas-scaled coordinates) 
- `calculateNewOverlayDimensions` incorrectly used raw `deltaX, deltaY` (screen coordinates)

This inconsistency caused the visual overlay to behave differently from the actual element resize, especially noticeable at non-1.0 zoom levels.

### Technical Solution

- Fixed: Standardized both calculations to use `adjustedDelta` consistently
- Result: Both element and overlay calculations now use the same canvas-scaled coordinate system
- Impact: Resize handles now behave intuitively and consistently across all zoom levels

## Related Issues

Fixes #2061

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe)

## Screenshots

https://github.com/user-attachments/assets/780c70c5-88fa-48c7-8c7a-37e7d27b8bf5



