### PR TITLE
bugs: prevent extra read on index

### DIFF
--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -53,6 +53,12 @@ export class SandboxManager {
         try {
             const files = await this.listFilesRecursively('./', IGNORED_DIRECTORIES);
             for (const file of files) {
+                const extension = path.extname(file);
+                if (!extension || !JSX_FILE_EXTENSIONS.includes(extension)) {
+                    // Skip non-JSX files from indexing
+                    continue;
+                }
+
                 const normalizedPath = normalizePath(file);
                 const content = await this.readFile(normalizedPath);
                 if (content === null) {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `SandboxManager` to skip non-JSX files during indexing, preventing unnecessary reads.
> 
>   - **Behavior**:
>     - In `SandboxManager` class, `index()` method now skips non-JSX files during indexing to prevent unnecessary reads.
>     - Uses `path.extname()` to check file extensions against `JSX_FILE_EXTENSIONS`.
>   - **Misc**:
>     - Added a check for file extension in `index.ts` to optimize file processing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 3884876dcdaf465f64188695beaa7ecc16fba15d. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->