### PR TITLE
feat: Handle network disconnection errors better 

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/index.tsx
@@ -11,6 +11,7 @@ import { observer } from 'mobx-react-lite';
 import { useTranslations } from 'next-intl';
 import { AssistantMessage } from './assistant-message';
 import { ErrorMessage } from './error-message';
+import { NetworkWarning } from './network-warning';
 import { StreamMessage } from './stream-message';
 import { UserMessage } from './user-message';
 
@@ -38,22 +39,28 @@ export const ChatMessages = observer(() => {
 
     if (!conversation) {
         return (
-            <div className="flex-1 flex flex-row items-center justify-center text-foreground-tertiary/80 h-full gap-2">
-                <Icons.LoadingSpinner className="animate-spin" />
-                <p className="text-regularPlus">Loading conversation...</p>
-            </div>
+            <>
+                <NetworkWarning />
+                <div className="flex-1 flex flex-row items-center justify-center text-foreground-tertiary/80 h-full gap-2">
+                    <Icons.Shadow className="animate-spin" />
+                    <p className="text-regularPlus">Loading conversation...</p>
+                </div>
+            </>
         );
     }
 
     if (!messages || messages.length === 0) {
         return (
             !editorEngine.elements.selected.length && (
-                <div className="flex-1 flex flex-col items-center justify-center text-foreground-tertiary/80 h-full">
-                    <Icons.EmptyState className="size-32" />
-                    <p className="text-center text-regularPlus text-balance max-w-[300px]">
-                        {t(transKeys.editor.panels.edit.tabs.chat.emptyState)}
-                    </p>
-                </div>
+                <>
+                    <NetworkWarning />
+                    <div className="flex-1 flex flex-col items-center justify-center text-foreground-tertiary/80 h-full">
+                        <Icons.EmptyState className="size-32" />
+                        <p className="text-center text-regularPlus text-balance max-w-[300px]">
+                            {t(transKeys.editor.panels.edit.tabs.chat.emptyState)}
+                        </p>
+                    </div>
+                </>
             )
         );
     }
@@ -62,6 +69,7 @@ export const ChatMessages = observer(() => {
         <ChatMessageList contentKey={uiMessages?.map((message) => message.content).join('|') ?? ''}>
             {messages?.map((message) => renderMessage(message))}
             <StreamMessage />
+            <NetworkWarning />
             <ErrorMessage />
         </ChatMessageList>
     );

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/network-warning.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/network-warning.tsx
@@ -1,0 +1,160 @@
+import { useChatContext } from '@/app/project/[id]/_hooks/use-chat';
+import { useEditorEngine } from '@/components/store/editor';
+import { Icons } from '@onlook/ui/icons/index';
+import { cn } from '@onlook/ui/utils';
+import { observer } from 'mobx-react-lite';
+import { useEffect, useState } from 'react';
+
+export const NetworkWarning = observer(() => {
+    const { isNetworkPaused, canResume, resumeStream, retryLastMessage } = useChatContext();
+    const editorEngine = useEditorEngine();
+    const [isVisible, setIsVisible] = useState(false);
+    const [showRetryButton, setShowRetryButton] = useState(false);
+
+    
+    const maxAttemptsReached = editorEngine.network.status.reconnectAttempts >= editorEngine.network.status.maxReconnectAttempts && !editorEngine.network.status.isOnline;
+    const isOffline = !editorEngine.network.status.isOnline;
+    const isReconnecting = editorEngine.network.status.isConnecting;
+
+  
+    const shouldShowWarning = isNetworkPaused || isOffline || isReconnecting || maxAttemptsReached;
+    
+
+
+    
+    useEffect(() => {
+        if (shouldShowWarning) {
+            setIsVisible(true);
+            
+            if (maxAttemptsReached) {
+                const timer = setTimeout(() => setShowRetryButton(true), 500);
+                return () => clearTimeout(timer);
+            }
+        } else {
+            setIsVisible(false);
+            setShowRetryButton(false);
+        }
+    }, [shouldShowWarning, maxAttemptsReached]);
+
+    if (!shouldShowWarning && !isVisible) {
+        return null;
+    }
+
+    
+    const getWarningConfig = () => {
+        if (maxAttemptsReached) {
+            return {
+                message: "Connection lost - unable to reconnect automatically",
+                subMessage: "Click 'Try Again' to retry or check your internet connection",
+                icon: Icons.CrossCircled,
+                bgColor: "bg-red-50 border-red-200",
+                textColor: "text-red-700",
+                iconColor: "text-red-500"
+            };
+        }
+        
+        if (isReconnecting) {
+            return {
+                message: "Connection lost, attempting to reconnect...",
+                subMessage: `Attempt ${editorEngine.network.status.reconnectAttempts}/${editorEngine.network.status.maxReconnectAttempts}`,
+                icon: Icons.Reload,
+                bgColor: "bg-orange-50 border-orange-200",
+                textColor: "text-orange-700",
+                iconColor: "text-orange-500"
+            };
+        }
+        
+        if (isOffline || isNetworkPaused) {
+            return {
+                message: "Connection lost, attempting to reconnect...",
+                subMessage: isNetworkPaused 
+                    ? "Your chat will automatically resume when connection is restored"
+                    : "Check your internet connection. Any new chat will wait for connectivity.",
+                icon: Icons.ExclamationTriangle,
+                bgColor: "bg-yellow-50 border-yellow-200",
+                textColor: "text-yellow-700",
+                iconColor: "text-yellow-500"
+            };
+        }
+
+        return null;
+    };
+
+    const config = getWarningConfig();
+    if (!config) return null;
+
+    const IconComponent = config.icon;
+
+    return (
+        <div 
+            className={cn(
+                "mx-4 my-3 p-4 rounded-lg border transition-all duration-300 ease-in-out",
+                config.bgColor,
+                isVisible ? "opacity-100 transform translate-y-0" : "opacity-0 transform -translate-y-2"
+            )}
+        >
+            {/* Warning Message */}
+            <div className="flex items-start gap-3">
+                <IconComponent 
+                    className={cn(
+                        "h-5 w-5 mt-0.5 flex-shrink-0",
+                        config.iconColor,
+                        isReconnecting && "animate-spin"
+                    )}
+                />
+                <div className="flex-1 space-y-1">
+                    <p className={cn("text-sm font-medium", config.textColor)}>
+                        {config.message}
+                    </p>
+                    <p className={cn("text-xs opacity-80", config.textColor)}>
+                        {config.subMessage}
+                    </p>
+                </div>
+            </div>
+
+            {/* Action Buttons - Only show after max attempts */}
+            {maxAttemptsReached && showRetryButton && (
+                <div 
+                    className={cn(
+                        "mt-3 flex gap-2 transition-all duration-300 ease-in-out",
+                        showRetryButton ? "opacity-100 transform translate-y-0" : "opacity-0 transform translate-y-2"
+                    )}
+                >
+                    {/* Network Retry Button */}
+                    <button
+                        onClick={() => {
+                            editorEngine.network.manualRetry();
+                        }}
+                        className="px-3 py-1.5 text-xs font-medium bg-red-500 text-white rounded-md hover:bg-red-600 transition-colors duration-200 flex items-center gap-1"
+                    >
+                        <Icons.Reload className="h-3 w-3" />
+                        Try Again
+                    </button>
+
+                    {/* Chat Resume Button (if chat was paused) */}
+                    {canResume && (
+                        <button
+                            onClick={async () => {
+                                await retryLastMessage();
+                            }}
+                            className="px-3 py-1.5 text-xs font-medium bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors duration-200 flex items-center gap-1"
+                        >
+                            <Icons.ChatBubble className="h-3 w-3" />
+                            Retry Chat
+                        </button>
+                    )}
+                </div>
+            )}
+
+            {/* Automatic Resume Indicator */}
+            {isNetworkPaused && !maxAttemptsReached && (
+                <div className="mt-2 flex items-center gap-2">
+                    <div className="h-1 w-1 bg-current rounded-full animate-pulse" />
+                    <p className={cn("text-xs opacity-60", config.textColor)}>
+                        Waiting for connection to resume chat...
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}); 

--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
@@ -12,14 +12,32 @@ import {
     READ_STYLE_GUIDE_TOOL_NAME,
 } from '@onlook/ai';
 import type { Message, ToolCall } from 'ai';
-import { createContext, useContext } from 'react';
+import { reaction } from 'mobx';
+import { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
 import { z } from 'zod';
+import { debounce } from '@/components/store/editor/network/utils';
 
-type ExtendedUseChatHelpers = UseChatHelpers & { sendMessages: (messages: Message[], type: ChatType) => Promise<string | null | undefined> };
+type ExtendedUseChatHelpers = UseChatHelpers & { 
+    sendMessages: (messages: Message[], type: ChatType) => Promise<string | null | undefined>
+    isNetworkPaused:boolean,
+    canResume:boolean,
+    resumeStream:() => Promise<void>,
+    retryLastMessage:() => Promise<void>,
+};
+
 const ChatContext = createContext<ExtendedUseChatHelpers | null>(null);
 
 export function ChatProvider({ children }: { children: React.ReactNode }) {
     const editorEngine = useEditorEngine();
+   
+    const [isNetworkPaused,setIsNetworkPaused] = useState(false);
+    const [canResume,setCanResume] = useState(false);
+    const [lastFailedMessages,setLastFailedMessages] = useState<Message[] | null>(null);
+    const [lastChatType,setLastChatType] = useState<ChatType>(ChatType.EDIT);
+
+    
+    const networkPauseRef = useRef(false);
+
     const chat = useChat({
         id: 'user-chat',
         api: '/api/chat',
@@ -29,16 +47,234 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
             console.log('config', config);
             if (config.finishReason === 'stop' || config.finishReason === 'error') {
                 editorEngine.chat.conversation.addAssistantMessage(message);
+
+                
+
+                if (!networkPauseRef.current) {
+                    setIsNetworkPaused(false);
+                    setCanResume(false);
+                    setLastFailedMessages(null);
+                }
             }
         },
         onError: (error) => {
             console.error('Error in chat', error);
             editorEngine.chat.error.handleChatError(error);
+            handleChatError(error);
         },
     });
+    
+    
+    const debouncedHandleDisconnection = useCallback(
+        debounce(() => handleNetworkDisconnection(), 200),
+        []
+    );
+
+    const debouncedHandleReconnection = useCallback(
+        debounce(() => handleNetworkReconnection(), 500),
+        []
+    );
+
+    const debouncedHandleQualityChange = useCallback(
+        debounce((quality: string) => handleNetworkQualityChange(quality), 300),
+        []
+    );
+
+    useEffect(() => {
+       
+        const disposeReaction = reaction(
+            () => ({
+                isOnline: editorEngine.network.status.isOnline,
+                connectionQuality: editorEngine.network.status.connectionQuality,
+                isConnecting: editorEngine.network.status.isConnecting,
+                reconnectAttempts: editorEngine.network.status.reconnectAttempts,
+                maxReconnectAttempts: editorEngine.network.status.maxReconnectAttempts,
+            }),
+            (current, previous) => {
+                console.log('🌐 Network state changed:', { current, previous });
+                
+                
+                if (previous) {
+                    if (!current.isOnline && previous.isOnline) {
+                        
+                        console.log('🔴 Network went offline');
+                        
+                       
+                        if (chat.isLoading) {
+                            handleNetworkDisconnection();
+                        } else {
+                            debouncedHandleDisconnection();
+                        }
+                    } else if (current.isOnline && !previous.isOnline) {
+                        
+                        console.log('🟢 Network came online');
+                        debouncedHandleReconnection();
+                    } else if (current.connectionQuality !== previous.connectionQuality) {
+                        
+                        console.log('⚡ Connection quality changed:', previous.connectionQuality, '→', current.connectionQuality);
+                        debouncedHandleQualityChange(current.connectionQuality);
+                    } else if (current.reconnectAttempts >= current.maxReconnectAttempts && !current.isOnline && current.reconnectAttempts !== previous.reconnectAttempts) {
+                        
+                        console.log('❌ Max reconnect attempts reached');
+                        handleMaxAttemptsReached();
+                    }
+                }
+            },
+            { 
+                fireImmediately: false,
+                name: 'NetworkStateReaction' // For debugging
+            }
+        );
+
+        return () => {
+            disposeReaction();
+            
+            debouncedHandleDisconnection.cancel();
+            debouncedHandleReconnection.cancel();
+            debouncedHandleQualityChange.cancel();
+        };
+    }, [editorEngine.network, debouncedHandleDisconnection, debouncedHandleReconnection, debouncedHandleQualityChange]);
+
+    const handleNetworkDisconnection = () =>{
+        if(chat.isLoading){
+            console.log('🔴 Network lost during streaming - pausing chat');
+            
+            
+            const snapshot = [...chat.messages];
+            
+            
+            setLastFailedMessages(snapshot);
+            setLastChatType(lastChatType);
+            
+            
+            chat.stop();
+            
+            chat.setMessages(snapshot);
+
+            setIsNetworkPaused(true);
+            setCanResume(true);
+            networkPauseRef.current = true;
+        }
+    };
+
+    const handleNetworkReconnection = () => {
+        console.log('🟢 Network reconnected');
+        
+        if (isNetworkPaused && canResume) {
+           
+            setTimeout(async () => {
+                if (editorEngine.network.status.connectionQuality !== 'offline') {
+                    await resumeStream();
+                }
+            }, 1000); 
+        }
+    }
+    
+    const handleNetworkQualityChange = (newQuality: string) => {
+        if (newQuality === 'poor' && chat.isLoading) {
+            console.warn('⚠️ Poor network quality detected during streaming');
+            
+        }
+    };
+
+    const handleChatError = (error: any) => {
+        
+        const isNetworkError = isNetworkRelatedError(error);
+            
+        if (isNetworkError) {
+            console.log('🌐 Network error detected in chat:', error);
+            handleNetworkDisconnection();
+        } else {
+            console.error('Chat error:', error);
+        }
+    };
+
+    
+    const isNetworkRelatedError = (error: any): boolean => {
+        if (!error) return false;
+
+       
+        const networkErrorNames = [
+            'NetworkError',
+            'TypeError', 
+            'AbortError',
+            'TimeoutError'
+        ];
+        
+        if (networkErrorNames.includes(error.name)) {
+            return true;
+        }
+
+       
+        const networkErrorCodes = [
+            'NETWORK_ERROR',
+            'FETCH_ERROR', 
+            'TIMEOUT_ERROR',
+            'ABORT_ERROR',
+            'ERR_NETWORK',
+            'ERR_INTERNET_DISCONNECTED',
+            'ERR_CONNECTION_REFUSED',
+            'ERR_CONNECTION_RESET',
+            'ERR_CONNECTION_TIMED_OUT',
+            'ECONNRESET'
+        ];
+
+        if (error.code && networkErrorCodes.includes(error.code)) {
+            return true;
+        }
+
+        
+        if (error instanceof TypeError && error.message === 'Failed to fetch') {
+            return true;
+        }
+
+        
+        if (error.name === 'AbortError' || error instanceof DOMException) {
+            return true;
+        }
+
+        
+        if (error.cause && isNetworkRelatedError(error.cause)) {
+            return true;
+        }
+
+       
+        if (error.name === 'StreamingError' && error.message?.includes('network')) {
+            return true;
+        }
+
+       
+        if (error instanceof Error && (
+            error.message.includes('ECONNRESET') ||
+            error.message.includes('terminated') ||
+            error.message.includes('failed to pipe') ||
+            error.message.includes('Connection reset')
+        )) {
+            return true;
+        }
+
+        
+        if (!editorEngine.network.status.isOnline) {
+            console.log('🌐 Network is offline, treating error as network-related');
+            return true;
+        }
+
+        return false;
+    };
 
     const sendMessages = async (messages: Message[], type: ChatType = ChatType.EDIT) => {
         editorEngine.chat.error.clear();
+        setLastChatType(type);
+        if(!editorEngine.network.status.isOnline){
+            console.warn('❌ Cannot send message - no network connection');
+            setLastFailedMessages(messages);
+            setCanResume(true);
+            return null;
+        }
+        if (editorEngine.network.status.connectionQuality === 'poor') {
+            console.warn('⚠️ Sending message with poor network quality');
+        }
+
         chat.setMessages(messages);
         return chat.reload({
             body: {
@@ -47,7 +283,114 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         });
     };
 
-    return <ChatContext.Provider value={{ ...chat, sendMessages }}>{children}</ChatContext.Provider>;
+   
+    const sanitizeMessages = (messages: Message[]): Message[] => {
+        const copy = [...messages];
+        const last = copy[copy.length - 1];
+        if (last && last.role === 'assistant') {
+            copy.pop();
+        }
+        return copy;
+    };
+
+    const resumeStream = async () => {
+        if (!canResume || !lastFailedMessages) {
+            console.warn('Cannot resume - no failed messages to retry');
+            return;
+        }
+        
+        if (!editorEngine.network.status.isOnline) {
+            console.warn('Cannot resume - still offline');
+            return;
+        }
+        
+        console.log('🔄 Resuming interrupted stream');
+        setIsNetworkPaused(false);
+        setCanResume(false);
+        networkPauseRef.current = false;
+        
+        try {
+            const sanitized = sanitizeMessages(lastFailedMessages);
+            const result = await sendMessages(sanitized, lastChatType);
+            if (result) {
+                console.log('✅ Stream resumed successfully');
+                setCanResume(false);
+                setLastFailedMessages(null);
+            } else {
+                console.warn('⚠️ Resume failed - no result returned');
+                setIsNetworkPaused(true);
+            }
+        } catch (error) {
+            console.error('❌ Failed to resume stream:', error);
+            setIsNetworkPaused(true);
+            setCanResume(true);
+            
+            if (!isNetworkRelatedError(error)) {
+                console.error('Non-network error during resume:', error);
+            }
+        }
+    };
+    const retryLastMessage = async () => {
+        if (!lastFailedMessages) {
+            console.warn('No failed messages to retry');
+            return;
+        }
+        
+        const isConnected = await editorEngine.network.checkConnection();
+        if (!isConnected) {
+            console.warn('Still no network connection - cannot retry');
+            return;
+        }
+        
+        console.log('🔁 Retrying last message');
+        setIsNetworkPaused(false);
+        setCanResume(false);
+        networkPauseRef.current = false;
+        
+        try {
+            const sanitized = sanitizeMessages(lastFailedMessages);
+            const result = await sendMessages(sanitized, lastChatType);
+            if (result) {
+                console.log('✅ Message retry successful');
+                setLastFailedMessages(null);
+            } else {
+                console.warn('⚠️ Retry failed - no result returned');
+                setCanResume(true);
+                setIsNetworkPaused(true);
+            }
+        } catch (error) {
+            console.error('❌ Failed to retry message:', error);
+            setCanResume(true);
+            setIsNetworkPaused(true);
+            
+            if (isNetworkRelatedError(error)) {
+                console.log('🌐 Network error during retry - will auto-retry when connection restored');
+            } else {
+                console.error('Non-network error during retry:', error);
+            }
+        }
+    };
+
+
+    const handleMaxAttemptsReached = () => {
+        console.log('🚨 Max reconnect attempts reached - chat functionality limited');
+       
+        if (chat.isLoading) {
+            setIsNetworkPaused(true);
+            setCanResume(true);
+            chat.stop();
+        }
+    };
+
+    const contextValue:ExtendedUseChatHelpers = {
+        ...chat,
+        sendMessages,
+        isNetworkPaused,
+        canResume,
+        resumeStream,
+        retryLastMessage,
+    }
+    return <ChatContext.Provider value={contextValue}>{children}</ChatContext.Provider>;
 }
 
 export function useChatContext() {

--- a/apps/web/client/src/components/store/editor/engine.ts
+++ b/apps/web/client/src/components/store/editor/engine.ts
@@ -18,6 +18,7 @@ import { HostingManager } from './hosting';
 import { ImageManager } from './image';
 import { InsertManager } from './insert';
 import { MoveManager } from './move';
+import { NetworkStore } from './network';
 import { OverlayManager } from './overlay';
 import { PagesManager } from './pages';
 import { SandboxManager } from './sandbox';
@@ -34,6 +35,7 @@ export class EditorEngine {
     readonly pages: PagesManager;
     readonly canvas: CanvasManager;
     readonly frames: FramesManager;
+    readonly network: NetworkStore;
 
     readonly error: ErrorManager = new ErrorManager();
     readonly state: StateManager = new StateManager();
@@ -64,6 +66,7 @@ export class EditorEngine {
         this.font = new FontManager(this, this.projectManager);
         this.canvas = new CanvasManager(this.projectManager)
         this.frames = new FramesManager(this, this.projectManager);
+        this.network = new NetworkStore();
         makeAutoObservable(this);
     }
 
@@ -90,6 +93,7 @@ export class EditorEngine {
         this.ide.clear();
         this.error.clear();
         this.sandbox.clear();
+        this.network.destroy();
     }
 
     clearUI() {

--- a/apps/web/client/src/components/store/editor/network/index.ts
+++ b/apps/web/client/src/components/store/editor/network/index.ts
@@ -1,0 +1,374 @@
+import {makeAutoObservable, runInAction} from "mobx";
+
+import type { NetworkStatus,NetworkConfig,NetworkEvent,NetworkEventCallback } from "./types";
+
+import {pingServer,calculateConnectionQuality,calculateBackoffDelay,debounce} from "./utils";
+
+
+
+export class NetworkStore{
+
+    status:NetworkStatus = {
+        isOnline: typeof window !== 'undefined' ? navigator.onLine : false,
+        isConnecting:false,
+        lastSeen:new Date(),
+        reconnectAttempts:0,
+        maxReconnectAttempts:5,
+        connectionQuality:'offline',
+        latency:undefined,
+
+    };
+
+
+    private config:NetworkConfig = {
+        pingUrl: 'https://www.cloudflare.com/cdn-cgi/trace', // Reliable CDN endpoint for real internet connectivity
+        pingInterval:2000, 
+        maxReconnectAttempts:5,
+        reconnectDelay:1000,
+        timeoutDuration:3000, 
+    };
+
+    private pingIntervalId:ReturnType<typeof setInterval> | null = null;
+    private reconnectTimeoutId:ReturnType<typeof setTimeout> | null = null;
+    private eventCallbacks:Set<NetworkEventCallback> = new Set();
+    private isDestroyed:boolean = false;
+
+    private debounceOnlineHandler: (() => void) & { cancel: () => void };
+    private debounceOfflineHandler: (() => void) & { cancel: () => void };
+    private debouncedUpdateStatus: ((isOnline: boolean, latency?: number) => void) & { cancel: () => void };
+    private visibilityChangeHandler: () => void;
+
+    constructor(customConfig?:Partial<NetworkConfig>){
+        makeAutoObservable(this);
+
+        if(customConfig){
+            this.config = {...this.config,...customConfig};
+            this.status.maxReconnectAttempts = this.config.maxReconnectAttempts;
+        }
+
+    
+        
+        this.debounceOnlineHandler = debounce(()=>this.handleOnlineEvent(),1000);
+        this.debounceOfflineHandler = debounce(()=>this.handleOfflineEvent(),100); 
+        
+        
+        this.debouncedUpdateStatus = debounce((isOnline: boolean, latency?: number) => {
+            this.updateStatusImmediate(isOnline, latency);
+        }, 200);
+
+        
+        this.visibilityChangeHandler = () => {
+            if (!document.hidden) {
+                
+                this.performQuickCheck();
+            }
+        };
+
+        this.initializeNetwork();
+    }
+
+    private initializeNetwork():void{
+        
+        if (typeof window !== 'undefined') {
+            window.addEventListener('online',this.debounceOnlineHandler);
+            window.addEventListener('offline',this.debounceOfflineHandler);
+            
+            
+            document.addEventListener('visibilitychange', this.visibilityChangeHandler);
+        }
+
+        this.performInitialCheck();
+        this.startPingMonitoring();
+    }
+
+    private async performInitialCheck():Promise<void>{
+        
+        if (typeof window !== 'undefined' && !navigator.onLine) {
+            console.log('Browser reports offline');
+            this.updateStatusImmediate(false);
+            return;
+        }
+
+       
+        try{
+            const result = await pingServer(this.config);
+            this.updateStatus(result.success, result.latency);
+
+            if(result.success){
+                this.emitEvent({
+                    type:'online',
+                    timestamp:new Date(),
+                    data:{latency:result.latency}
+                });
+            } else {
+                console.log('Internet connectivity test failed');
+            }
+        }
+        catch(error){
+            console.warn('Initial Network Check Failed',error);
+            this.updateStatus(false);
+        }
+    }
+
+    private async performQuickCheck():Promise<void>{
+        
+        if (typeof window !== 'undefined' && !navigator.onLine) {
+            this.updateStatusImmediate(false);
+            return;
+        }
+
+        try{
+            const result = await pingServer({
+                ...this.config,
+                timeoutDuration: 1500 
+            });
+            this.updateStatusImmediate(result.success, result.latency);
+        }
+        catch(error){
+            this.updateStatusImmediate(false);
+        }
+    }
+
+    private startPingMonitoring():void{
+        if(this.pingIntervalId){
+            clearInterval(this.pingIntervalId);
+        }
+        this.pingIntervalId = setInterval(async()=>{
+            if(this.isDestroyed) return;
+
+            
+            if (typeof window !== 'undefined' && !navigator.onLine) {
+                this.handlePingResult(false);
+                return;
+            }
+
+            
+            try{
+             const result = await pingServer(this.config);
+             this.handlePingResult(result.success, result.latency);
+            }
+            catch(error){
+             console.warn('Internet connectivity test failed', error);
+             this.handlePingResult(false);
+            }
+            
+        },this.config.pingInterval);
+    }
+
+    private handlePingResult(success:boolean,latency?:number):void{
+        const wasOnline = this.status.isOnline;
+        this.updateStatus(success,latency);
+
+        if(!wasOnline && success){
+            this.emitEvent({
+                type:'reconnected',
+                timestamp: new Date(),
+                data:{latency}
+            });
+            this.resetReconnectAttempts();
+        }
+        else if(wasOnline && !success){
+            this.emitEvent({
+                type:'disconnected',
+                timestamp:new Date(),
+            })
+            this.startReconnectProcess();
+        }
+    }
+
+    
+    private updateStatus(isOnline:boolean,latency?:number):void{
+        this.debouncedUpdateStatus(isOnline, latency);
+    }
+
+    
+    private updateStatusImmediate(isOnline:boolean,latency?:number):void{
+        runInAction(() => {
+            const previousQuality = this.status.connectionQuality;
+
+            this.status.isOnline = isOnline;
+            this.status.latency = latency;
+            this.status.connectionQuality = calculateConnectionQuality(latency,isOnline);
+
+            if(isOnline){
+                this.status.lastSeen = new Date();
+                this.status.isConnecting = false;
+            }
+
+            if(previousQuality !== this.status.connectionQuality){
+                this.emitEvent({
+                    type:'quality-change',
+                    timestamp:new Date(),
+                    data:{
+                        from:previousQuality,
+                        to:this.status.connectionQuality,
+                        latency
+                    }
+                });
+            }
+        });
+    }
+
+    private handleOnlineEvent():void{
+        console.log('Browser detected online');
+        this.performInitialCheck();
+    }
+
+    private handleOfflineEvent():void{
+        console.log('Browser detected offline');
+        this.updateStatusImmediate(false); 
+        this.emitEvent({
+            type:'offline',
+            timestamp:new Date()
+        });
+        this.startReconnectProcess();
+    }
+
+    private startReconnectProcess():void{
+        if(this.status.isConnecting||this.isDestroyed) return;
+        if(this.status.reconnectAttempts >= this.config.maxReconnectAttempts){
+            console.warn('Max reconnect attempts reached - stopping automatic retries');
+            this.status.isConnecting = false;
+            this.emitEvent({
+                type:'max-attempts-reached',
+                timestamp:new Date(),
+                data:{
+                    attempts: this.status.reconnectAttempts,
+                    maxAttempts: this.status.maxReconnectAttempts
+                }
+            });
+            return;
+        }
+        this.status.isConnecting = true;
+        this.status.reconnectAttempts++;
+
+        const delay = calculateBackoffDelay(this.status.reconnectAttempts - 1,this.config.reconnectDelay);
+
+        console.log(`Reconnect attempt ${this.status.reconnectAttempts}/${this.status.maxReconnectAttempts} in ${Math.round(delay)}ms`);
+        
+        this.emitEvent({
+            type:'reconnecting',
+            timestamp:new Date(),
+            data:{
+                attempt:this.status.reconnectAttempts,
+                maxAttempts:this.status.maxReconnectAttempts,
+                delay:Math.round(delay)
+            }
+        });
+
+        this.reconnectTimeoutId = setTimeout(async()=>{
+            if(this.isDestroyed) return;
+            try{
+                const result = await pingServer(this.config);
+               if(result.success){
+                this.updateStatus(true,result.latency);
+                this.emitEvent({
+                    type:'reconnected',
+                    timestamp:new Date(),
+                    data:{latency:result.latency}
+                });
+                this.resetReconnectAttempts();
+               }
+               else{
+                this.status.isConnecting = false;
+                this.startReconnectProcess();
+               }
+            }
+            catch(error){
+                console.warn('Reconnection attempt failed:', error);
+                this.status.isConnecting = false;
+                this.startReconnectProcess();
+            }
+        },delay);
+    }
+
+    public manualRetry():void{
+        this.resetReconnectAttempts();
+        this.startReconnectProcess();
+    }
+
+    private resetReconnectAttempts():void{
+        this.status.reconnectAttempts = 0;
+        this.status.isConnecting = false;
+        if(this.reconnectTimeoutId){
+            clearTimeout(this.reconnectTimeoutId);
+            this.reconnectTimeoutId = null;
+        }
+    }
+
+    private emitEvent(event:NetworkEvent):void{
+        this.eventCallbacks.forEach(callback => {
+            try{
+               callback(event);
+            }
+            catch(error){
+               console.error('Error in network event callback:', error);
+            }
+        })
+    }
+
+    public subscribe(callback:NetworkEventCallback): ()=>void{
+        this.eventCallbacks.add(callback);
+        return ()=>{
+            this.eventCallbacks.delete(callback);
+        };
+
+    }
+
+    public async checkConnection():Promise<boolean>{
+        try{
+         const result = await pingServer(this.config);
+         this.updateStatus(result.success,result.latency);
+         return result.success;
+        }
+        catch(error){
+          this.updateStatus(false);
+          return false;
+        }
+    }
+
+    public updateConfig(newConfig:Partial<NetworkConfig>):void{
+        this.config = {...this.config,...newConfig};
+        this.startPingMonitoring();
+    }
+    public destroy():void
+    {
+         this.isDestroyed = true;
+
+       
+        if (this.pingIntervalId) {
+            clearInterval(this.pingIntervalId);
+            this.pingIntervalId = null;
+        }
+
+        if (this.reconnectTimeoutId) {
+            clearTimeout(this.reconnectTimeoutId);
+            this.reconnectTimeoutId = null;
+        }
+
+        
+        // Safely cancel any pending debounced handlers (guard in case they were not initialized)
+        if (this.debouncedUpdateStatus && typeof (this.debouncedUpdateStatus as any).cancel === 'function') {
+            (this.debouncedUpdateStatus as any).cancel();
+        }
+        if (this.debounceOnlineHandler && typeof (this.debounceOnlineHandler as any).cancel === 'function') {
+            (this.debounceOnlineHandler as any).cancel();
+        }
+        if (this.debounceOfflineHandler && typeof (this.debounceOfflineHandler as any).cancel === 'function') {
+            (this.debounceOfflineHandler as any).cancel();
+        }
+
+        
+        if (typeof window !== 'undefined') {
+            window.removeEventListener('online', this.debounceOnlineHandler);
+            window.removeEventListener('offline', this.debounceOfflineHandler);
+            document.removeEventListener('visibilitychange', this.visibilityChangeHandler);
+        }
+
+        
+        this.eventCallbacks.clear();
+    }
+
+
+
+}

--- a/apps/web/client/src/components/store/editor/network/types.ts
+++ b/apps/web/client/src/components/store/editor/network/types.ts
@@ -1,0 +1,33 @@
+export interface NetworkStatus {
+    isOnline: boolean;
+    isConnecting: boolean;
+    lastSeen: Date;
+    reconnectAttempts: number;
+    maxReconnectAttempts: number;
+    connectionQuality: 'excellent' | 'good' | 'poor' | 'offline';
+    latency?: number;
+
+}
+
+export interface NetworkConfig{
+    pingUrl: string;
+    pingInterval: number;
+    maxReconnectAttempts: number;
+    reconnectDelay: number;
+    timeoutDuration: number;
+}
+
+export interface NetworkEvent {
+    type: 'online' | 'offline' | 'reconnecting' | 'reconnected' | 'disconnected' | 'quality-change' | 'max-attempts-reached';
+    timestamp: Date;
+    data?:any;
+
+}
+export type NetworkEventCallback = (event: NetworkEvent) => void;
+
+export interface PingResult {
+    success: boolean;
+    latency?: number;
+    error?: string;
+    timestamp: Date;
+}

--- a/apps/web/client/src/components/store/editor/network/utils.ts
+++ b/apps/web/client/src/components/store/editor/network/utils.ts
@@ -1,0 +1,86 @@
+import type { PingResult, NetworkConfig } from "./types";
+
+
+export async function pingServer(config:NetworkConfig):Promise<PingResult>{
+    const startTime = performance.now();
+
+    try{
+        const controller = new AbortController();
+        const timeoutId = setTimeout(()=>controller.abort(),config.timeoutDuration);
+        
+        const resp = await fetch(config.pingUrl,{
+            method:'GET',
+            signal:controller.signal,
+            mode: 'no-cors',
+            cache: 'no-store', 
+            headers: {
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                'Pragma': 'no-cache'
+            }
+        });
+
+        clearTimeout(timeoutId);
+        const endTime = performance.now();
+        const latency = endTime - startTime;
+
+        return {
+            success: true, 
+            latency,
+            timestamp:new Date(),
+        };
+    }
+    catch(error){
+        const endTime = performance.now();
+        const latency = endTime - startTime;
+
+        return {
+            success:false,
+            latency,
+            error:error instanceof Error ? error.message : 'Error Pinging Server',
+            timestamp:new Date(),
+        };
+    }
+}
+
+export function calculateConnectionQuality(latency?:number,success?:boolean):'excellent' |'good' | 'poor' | 'offline'{
+    if(!success)return 'offline';
+    if(!latency)return 'poor';
+
+    if (latency < 100) return 'excellent';
+    if (latency < 200) return 'good';
+    if (latency < 1000) return 'poor';
+    
+    return 'offline';
+}
+
+export function calculateBackoffDelay(attempt:number,baseDelay:number,maxDelay:number=30000):number {
+    const delay = Math.min(baseDelay * Math.pow(2,attempt),maxDelay);
+    const jitter = Math.random() * 0.5;
+    return delay * (1 + jitter);
+}
+
+export function debounce<T extends (...args: any[]) => any>(
+    func: T,
+    delay: number
+): ((...args: Parameters<T>) => void) & { cancel: () => void } {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    
+    const debouncedFunction = (...args: Parameters<T>) => {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+        timeoutId = setTimeout(() => {
+            timeoutId = null;
+            func(...args);
+        }, delay);
+    };
+
+    debouncedFunction.cancel = () => {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+            timeoutId = null;
+        }
+    };
+
+    return debouncedFunction;
+}


### PR DESCRIPTION
## Description

- Adds graceful network-loss handling to the web client.
- NetworkStore (MobX) – constantly pings an external endpoint, classifies latency, performs exponential back-off, exposes  
helpers (manualRetry, checkConnection, events).
- use-chat hook – snapshots partial assistant messages, pauses streaming when the connection drops, and automatically resumes (or lets the user retry) when the connection is back.
- NetworkWarning banner – surfaces live connection status with animated icons and “Try Again” / “Retry Chat” buttons.

## Related Issues

closes #2226 - Handle network disconnection errors better 


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

1. Disabled network (Airplane-mode or DevTools “Offline”).
2. Send a chat prompt – banner appears, stream pauses, retry buttons enabled then Auto-resumed.
3. Re-enabled network – banner disappeared, stream continues from the exact point where it stopped.
4. Max retries - Stay offline past the max back-off interval – banner switches to red state, “Try Again” and “Retry Chat” buttons work.
5.Regression checks - Normal online chat flow unaffected.
Lint & type-check show same warnings as main.

## Screenshots (if applicable)

[Watch demo video on Loom](https://www.loom.com/share/1711b482f7e544568f1c6897f27a818f?sid=e7a412ce-7c6e-4f57-97ff-47e2e8cb23b3)

> **Heads-up:** the video was recorded before the latest UI polish (icon swap + color tweaks on the warning banner).  
> Functionality is identical—only the visual styling changed in my most recent commits.

## Additional Notes

Scope limited to apps/web/client; backend & shared packages untouched.
No DB migrations, env-var, or API changes
