### PR TITLE
fix : panning while modal is open

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/top-bar/publish/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/top-bar/publish/index.tsx
@@ -9,6 +9,7 @@ export const PublishButton = observer(() => {
 
     return (
         <DropdownMenu
+            modal={false}
             open={editorEngine.state.publishOpen}
             onOpenChange={(open: boolean) => {
                 editorEngine.state.publishOpen = open;


### PR DESCRIPTION
## Description

Solves the panning issue while the modal is open.

## Related Issues

closes #2250 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

## Screenshots (if applicable)

## Additional Notes


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `modal={false}` in `DropdownMenu` in `index.tsx` to fix panning issue when modal is open.
> 
>   - **Bug Fix**:
>     - Set `modal={false}` in `DropdownMenu` in `index.tsx` to fix panning issue when modal is open.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for d0dc29a10bef1e493891c4738ebf7b3287d51064. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->