### PR TITLE
refactor: clear manager when navigating

### DIFF
--- a/apps/web/client/src/app/project/[id]/layout.tsx
+++ b/apps/web/client/src/app/project/[id]/layout.tsx
@@ -6,6 +6,17 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { ChatProvider } from './_hooks/use-chat';
 
+const isProjectRoute = (href: string | URL): boolean => {
+    try {
+        const url = typeof href === 'string' ? new URL(href, window.location.origin) : href;
+        return url.pathname.startsWith('/project/');
+    } catch {
+        // Fallback for relative paths
+        const path = typeof href === 'string' ? href : href.toString();
+        return path.startsWith('/project/');
+    }
+};
+
 export default function ProjectLayout({ children }: { children: React.ReactNode }) {
     const editorEngine = useEditorEngine();
     const projectManager = useProjectManager();
@@ -31,7 +42,7 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
         const originalReplace = router.replace;
 
         router.push = (href, options) => {
-            if (!href.toString().includes('/project/')) {
+            if (!isProjectRoute(href)) {
                 projectManager.clear();
                 editorEngine.clear();
             }
@@ -39,7 +50,7 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
         };
 
         router.replace = (href, options) => {
-            if (!href.toString().includes('/project/')) {
+            if (!isProjectRoute(href)) {
                 projectManager.clear();
                 editorEngine.clear();
             }
@@ -50,7 +61,7 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
             router.push = originalPush;
             router.replace = originalReplace;
         };
-    }, [router, projectManager, editorEngine]);
+    }, [router, projectManager, editorEngine, isProjectRoute]);
 
     return <ChatProvider>{children}</ChatProvider>;
 }

--- a/apps/web/client/src/app/project/[id]/layout.tsx
+++ b/apps/web/client/src/app/project/[id]/layout.tsx
@@ -2,12 +2,14 @@
 
 import { useEditorEngine } from '@/components/store/editor';
 import { useProjectManager } from '@/components/store/project';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { ChatProvider } from './_hooks/use-chat';
 
 export default function ProjectLayout({ children }: { children: React.ReactNode }) {
     const editorEngine = useEditorEngine();
     const projectManager = useProjectManager();
+    const router = useRouter();
 
     useEffect(() => {
         const handleBeforeUnload = () => {
@@ -15,13 +17,40 @@ export default function ProjectLayout({ children }: { children: React.ReactNode 
             editorEngine.clear();
         };
 
-        // Only cleanup on actual browser navigation/close
+        // Cleanup when browser tab/window closes
         window.addEventListener('beforeunload', handleBeforeUnload);
-        
+
         return () => {
             window.removeEventListener('beforeunload', handleBeforeUnload);
         };
     }, [projectManager, editorEngine]);
+
+    // Cleanup when navigating away from project route
+    useEffect(() => {
+        const originalPush = router.push;
+        const originalReplace = router.replace;
+
+        router.push = (href, options) => {
+            if (!href.toString().includes('/project/')) {
+                projectManager.clear();
+                editorEngine.clear();
+            }
+            return originalPush.call(router, href, options);
+        };
+
+        router.replace = (href, options) => {
+            if (!href.toString().includes('/project/')) {
+                projectManager.clear();
+                editorEngine.clear();
+            }
+            return originalReplace.call(router, href, options);
+        };
+
+        return () => {
+            router.push = originalPush;
+            router.replace = originalReplace;
+        };
+    }, [router, projectManager, editorEngine]);
 
     return <ChatProvider>{children}</ChatProvider>;
 }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Clear state when navigating out of 'project' route.
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `ProjectLayout` to clear states when navigating away from `/project/` route by overriding router methods.
> 
>   - **Behavior**:
>     - Clears `projectManager` and `editorEngine` states when navigating away from `/project/` route in `layout.tsx`.
>     - Overrides `router.push` and `router.replace` to check route path using `isProjectRoute()`.
>   - **Functions**:
>     - Adds `isProjectRoute()` to determine if a URL is a project route.
>   - **Misc**:
>     - Ensures cleanup on browser tab/window close with `beforeunload` event.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for fe7ae227b84d22635dd4bbdce23fce024e758c80. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->