### PR TITLE
fix: refetch usage data

### DIFF
--- a/apps/web/client/src/components/ui/avatar-dropdown/plans.tsx
+++ b/apps/web/client/src/components/ui/avatar-dropdown/plans.tsx
@@ -7,14 +7,19 @@ import { Button } from '@onlook/ui/button';
 import { Icons } from '@onlook/ui/icons';
 import { Progress } from '@onlook/ui/progress';
 import { observer } from 'mobx-react-lite';
+import { useEffect } from 'react';
 
 export const UsageSection = observer(() => {
     const userManager = useUserManager();
     const { data: subscription } = api.subscription.get.useQuery();
-    const { data: usageData } = api.usage.get.useQuery();
+    const { data: usageData, refetch: refetchUsage } = api.usage.get.useQuery();
     const product = subscription?.product ?? FREE_PRODUCT_CONFIG;
     const price = product?.type === ProductType.FREE ? 'Trial' : 'Active';
     let usage = product?.type === ProductType.FREE ? usageData?.daily : usageData?.monthly;
+
+    useEffect(() => {
+        refetchUsage();
+    }, [userManager.user, refetchUsage]);
 
     if (!usage) {
         return (


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `useEffect` in `UsageSection` to refetch usage data when `userManager.user` changes in `plans.tsx`.
> 
>   - **Behavior**:
>     - Adds `useEffect` in `UsageSection` to refetch usage data when `userManager.user` changes.
>   - **Functions**:
>     - Modifies `UsageSection` in `plans.tsx` to include `refetchUsage` in the dependency array of `useEffect`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 1847a0f55ea81ad47f3a09566e3dfb6d341903d0. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->