### PR TITLE
fix: chat history dropdown hijacks panning

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/panel-dropdown.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/panel-dropdown.tsx
@@ -34,7 +34,7 @@ export const ChatPanelDropdown = observer(({
     };
 
     return (
-        <DropdownMenu>
+        <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild disabled={selectedTab !== EditorTabValue.CHAT}>
                 <div className="flex items-center">{children}</div>
             </DropdownMenuTrigger>


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

closes #
<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `modal` to `false` in `DropdownMenu` in `panel-dropdown.tsx` to prevent chat history dropdown from hijacking panning.
> 
>   - **Behavior**:
>     - Set `modal` to `false` in `DropdownMenu` in `panel-dropdown.tsx` to prevent chat history dropdown from hijacking panning.
>   - **Misc**:
>     - No other changes or additions were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 0bd8423e37e7f009fd0da6803cf925f2c9ef59a1. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->