### PR TITLE
Add Google Vertex mapping for Claude models

### DIFF
--- a/apps/web/client/.env.example
+++ b/apps/web/client/.env.example
@@ -40,3 +40,9 @@ STRIPE_SECRET_KEY="<Your Stripe secret key from https://dashboard.stripe.com/api
 AWS_ACCESS_KEY_ID="<Your AWS access key from https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock>"
 AWS_SECRET_ACCESS_KEY="<Your AWS access key from https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock>"
 AWS_REGION="<Your AWS region from https://ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock>"
+
+# Google Vertex - Alternative LLM provider credentials
+GOOGLE_APPLICATION_CREDENTIALS="<Path to your Google service account JSON file>"
+GOOGLE_CLIENT_EMAIL="<Your client email from the Google credentials file>"
+GOOGLE_PRIVATE_KEY="<Your private key from the Google credentials file>"
+GOOGLE_PRIVATE_KEY_ID="<Optional private key id from the Google credentials file>"

--- a/apps/web/client/package.json
+++ b/apps/web/client/package.json
@@ -29,6 +29,7 @@
     },
     "dependencies": {
         "@ai-sdk/amazon-bedrock": "^2.2.10",
+        "@ai-sdk/google-vertex": "2.2.24",
         "@ai-sdk/openai": "^1.3.20",
         "@ai-sdk/react": "^1.2.9",
         "@codemirror/lang-css": "^6.2.0",

--- a/apps/web/client/src/env.ts
+++ b/apps/web/client/src/env.ts
@@ -20,6 +20,10 @@ export const env = createEnv({
         AWS_ACCESS_KEY_ID: z.string().optional(),
         AWS_SECRET_ACCESS_KEY: z.string().optional(),
         AWS_REGION: z.string().optional(),
+        GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
+        GOOGLE_CLIENT_EMAIL: z.string().optional(),
+        GOOGLE_PRIVATE_KEY: z.string().optional(),
+        GOOGLE_PRIVATE_KEY_ID: z.string().optional(),
     },
     /**
      * Specify your client-side environment variables schema here. This way you can ensure the app
@@ -61,6 +65,10 @@ export const env = createEnv({
         AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
         AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
         AWS_REGION: process.env.AWS_REGION,
+        GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+        GOOGLE_CLIENT_EMAIL: process.env.GOOGLE_CLIENT_EMAIL,
+        GOOGLE_PRIVATE_KEY: process.env.GOOGLE_PRIVATE_KEY,
+        GOOGLE_PRIVATE_KEY_ID: process.env.GOOGLE_PRIVATE_KEY_ID,
     },
     /**
      * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^2.2.10",
+        "@ai-sdk/google-vertex": "2.2.24",
         "@ai-sdk/openai": "^1.3.20",
         "@ai-sdk/react": "^1.2.9",
         "@codemirror/lang-css": "^6.2.0",
@@ -219,6 +220,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.2.10",
+        "@ai-sdk/google-vertex": "2.2.24",
         "ai": "^4.3.10",
         "diff-match-patch": "^1.0.5",
         "fg": "^0.0.3",
@@ -507,6 +509,10 @@
     "@ai-sdk/amazon-bedrock": ["@ai-sdk/amazon-bedrock@2.2.10", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@smithy/eventstream-codec": "^4.0.1", "@smithy/util-utf8": "^4.0.0", "aws4fetch": "^1.0.20" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-icLGO7Q0NinnHIPgT+y1QjHVwH4HwV+brWbvM+FfCG2Afpa89PyKa3Ret91kGjZpBgM/xnj1B7K5eM+rRlsXQA=="],
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@1.2.12", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@1.2.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-Xgl6eftIRQ4srUdCzxM112JuewVMij5q4JLcNmHcB68Bxn9dpr3MVUSPlJwmameuiQuISIA8lMB+iRiRbFsaqA=="],
+
+    "@ai-sdk/google-vertex": ["@ai-sdk/google-vertex@2.2.24", "", { "dependencies": { "@ai-sdk/anthropic": "1.2.12", "@ai-sdk/google": "1.2.19", "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "google-auth-library": "^9.15.0" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-zi1ZN6jQEBRke/WMbZv0YkeqQ3nOs8ihxjVh/8z1tUn+S1xgRaYXf4+r6+Izh2YqVHIMNwjhUYryQRBGq20cgQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@1.3.22", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-QwA+2EkG0QyjVR+7h6FE7iOu2ivNqAVMm9UJZkVxxTk5OIq5fFJDTEI/zICEMuHImTTXR2JjsL6EirJ28Jc4cw=="],
 
@@ -2206,6 +2212,8 @@
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "buffer-writer": ["buffer-writer@1.0.0", "", {}, "sha512-EwqHsY9HX59gLKIDAnnsa8G9FFdD7OlTZ6kVj0BXM1WSguvxH4g2FQPaWHtfT6EFWff5ISMr4fH1cZHvne/xWA=="],
@@ -2483,6 +2491,8 @@
     "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -2806,6 +2816,8 @@
 
     "globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
 
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
     "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
@@ -2815,6 +2827,8 @@
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -3079,6 +3093,10 @@
     "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.0", "", { "dependencies": { "jwa": "^2.0.0", "safe-buffer": "^5.0.1" } }, "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -32,6 +32,7 @@
     },
     "dependencies": {
         "@ai-sdk/anthropic": "^1.2.10",
+        "@ai-sdk/google-vertex": "2.2.24",
         "ai": "^4.3.10",
         "diff-match-patch": "^1.0.5",
         "fg": "^0.0.3",

--- a/packages/ai/src/chat/providers.ts
+++ b/packages/ai/src/chat/providers.ts
@@ -1,12 +1,19 @@
 import { bedrock } from '@ai-sdk/amazon-bedrock';
 import { createAnthropic } from '@ai-sdk/anthropic';
-import { BEDROCK_MODEL_MAP, CLAUDE_MODELS, LLMProvider } from '@onlook/models';
+import { vertex } from '@ai-sdk/google-vertex';
+import {
+    BEDROCK_MODEL_MAP,
+    CLAUDE_MODELS,
+    LLMProvider,
+    VERTEX_MODELS,
+    VERTEX_MODEL_MAP,
+} from '@onlook/models';
 import { assertNever } from '@onlook/utility';
 import { type LanguageModelV1 } from 'ai';
 
 export async function initModel(
     provider: LLMProvider,
-    model: CLAUDE_MODELS,
+    model: CLAUDE_MODELS | VERTEX_MODELS,
 ): Promise<{ model: LanguageModelV1; providerOptions: Record<string, any> }> {
     switch (provider) {
         case LLMProvider.ANTHROPIC:
@@ -18,6 +25,11 @@ export async function initModel(
             return {
                 model: await getBedrockProvider(model),
                 providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+            };
+        case LLMProvider.GOOGLE_VERTEX:
+            return {
+                model: await getVertexProvider(model),
+                providerOptions: {},
             };
         default:
             assertNever(provider);
@@ -42,4 +54,19 @@ async function getBedrockProvider(claudeModel: CLAUDE_MODELS) {
 
     const bedrockModel = BEDROCK_MODEL_MAP[claudeModel];
     return bedrock(bedrockModel);
+}
+
+async function getVertexProvider(model: CLAUDE_MODELS | VERTEX_MODELS) {
+    if (
+        !process.env.GOOGLE_APPLICATION_CREDENTIALS &&
+        (!process.env.GOOGLE_CLIENT_EMAIL || !process.env.GOOGLE_PRIVATE_KEY)
+    ) {
+        throw new Error(
+            'GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_CLIENT_EMAIL and GOOGLE_PRIVATE_KEY must be set',
+        );
+    }
+
+    const vertexModel = VERTEX_MODEL_MAP[model as CLAUDE_MODELS] ?? (model as VERTEX_MODELS);
+
+    return vertex(vertexModel);
 }

--- a/packages/models/src/llm/index.ts
+++ b/packages/models/src/llm/index.ts
@@ -1,6 +1,7 @@
 export enum LLMProvider {
     ANTHROPIC = 'anthropic',
     BEDROCK = 'bedrock',
+    GOOGLE_VERTEX = 'google-vertex',
 }
 
 export enum CLAUDE_MODELS {
@@ -9,8 +10,18 @@ export enum CLAUDE_MODELS {
     HAIKU = 'claude-3-5-haiku-20241022',
 }
 
+export enum VERTEX_MODELS {
+    GEMINI_FLASH = 'gemini-1.5-flash',
+}
+
 export const BEDROCK_MODEL_MAP = {
     [CLAUDE_MODELS.SONNET_4]: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
     [CLAUDE_MODELS.SONNET_3_7]: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
     [CLAUDE_MODELS.HAIKU]: 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
+};
+
+export const VERTEX_MODEL_MAP = {
+    [CLAUDE_MODELS.SONNET_4]: 'claude-sonnet-4',
+    [CLAUDE_MODELS.SONNET_3_7]: 'claude-3-7-sonnet',
+    [CLAUDE_MODELS.HAIKU]: 'claude-3-5-haiku',
 };


### PR DESCRIPTION
## Description

Adds a mapping for Anthropic Claude models to their Google Vertex AI equivalents and updates the chat provider to use this map when initializing Vertex models.

## Related Issues

- closes #NN

## Type of Change

- [x] New feature

## Testing

- `bun format`
- `bun lint` *(fails: script exited with code 1)*
- `bun test` *(fails: 8 tests failed)*

## Additional Notes

Network access to ai-sdk.dev was blocked when retrieving documentation.

------
https://chatgpt.com/codex/tasks/task_e_685dab24b210832384ff5201f0a29486