### PR TITLE
docs: add 20 language links of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
         <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=fr">Français</a></p>
         <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=de">Deutsch</a></p>
         <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=es">Español</a></p>
-        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=it">Itapano</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=it">Italiano</a></p>
         <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=ru">Русский</a></p>
         <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=pt">Português</a></p>
         <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=nl">Nederlands</a></p>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="right">
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=en">English</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=zh-CN">简体中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=zh-TW">繁體中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=ja">日本語</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=ko">한국어</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=hi">हिन्दी</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=th">ไทย</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=fr">Français</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=de">Deutsch</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=es">Español</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=it">Itapano</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=ru">Русский</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=pt">Português</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=nl">Nederlands</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=pl">Polski</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=ar">العربية</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=fa">فارسی</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=tr">Türkçe</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=vi">Tiếng Việt</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=id">Bahasa Indonesia</a></p>
+      </div>
+    </div>
+  </details>
+</div>
+
 <!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
 
 <div align="center">


### PR DESCRIPTION
PR adds 20 languages link to the README and user can easily access translated README, supports google/bing multiple languages SEO search.

Page demo: https://openaitx.github.io/view.html?user=onlook-dev&project=onlook&lang=ja

> OpenAiTx is free and open-source:  https://github.com/OpenAiTx/OpenAiTx 

 ![Image](https://github.com/user-attachments/assets/1a95bf8c-ab15-4a32-a6fa-0acfdb8ff26f)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a language selection dropdown to `README.md` with links to 20 translated versions, enhancing accessibility and SEO.
> 
>   - **README.md**:
>     - Adds a language selection dropdown with links to 20 translated versions of the README.
>     - Supports languages including English, Simplified Chinese, Traditional Chinese, Japanese, Korean, Hindi, Thai, French, German, Spanish, Italian, Russian, Portuguese, Dutch, Polish, Arabic, Persian, Turkish, Vietnamese, and Indonesian.
>     - Enhances accessibility and SEO for non-English speakers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for ab0f441b9cbd7b82b6f38d12d45f29b83996a250. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->