### PR TITLE
fix: send chat input buffering and tool call duplicated

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
@@ -121,12 +121,12 @@ export const ChatInput = observer(() => {
             console.warn('Already waiting for response');
             return;
         }
-        const input = inputValue.trim();
+        const savedInput = inputValue.trim();
         setInputValue('');
-        const streamMessages = await editorEngine.chat.getEditMessages(input);
+        const streamMessages = await editorEngine.chat.getEditMessages(savedInput);
         if (!streamMessages) {
             toast.error('Failed to send message. Please try again.');
-            setInputValue(input);
+            setInputValue(savedInput);
             return;
         }
 

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
@@ -121,14 +121,16 @@ export const ChatInput = observer(() => {
             console.warn('Already waiting for response');
             return;
         }
-        const streamMessages = await editorEngine.chat.getEditMessages(inputValue);
+        const input = inputValue.trim();
+        setInputValue('');
+        const streamMessages = await editorEngine.chat.getEditMessages(input);
         if (!streamMessages) {
             toast.error('Failed to send message. Please try again.');
+            setInputValue(input);
             return;
         }
 
         sendMessages(streamMessages, ChatType.EDIT);
-        setInputValue('');
     }
 
     const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {

--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
@@ -16,7 +16,9 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         maxSteps: 10,
         onToolCall: (toolCall) => handleToolCall(toolCall.toolCall, editorEngine),
         onFinish: (message, config) => {
-            editorEngine.chat.conversation.addAssistantMessage(message);
+            if (config.finishReason !== 'tool-calls') {
+                editorEngine.chat.conversation.addAssistantMessage(message);
+            }
             if (config.finishReason === 'stop') {
                 editorEngine.chat.context.clearAttachments();
             }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes chat input duplication and tool call message duplication in `index.tsx` and `use-chat.tsx`.
> 
>   - **Behavior**:
>     - Fixes chat input duplication by resetting `inputValue` before sending messages in `index.tsx`.
>     - Restores `inputValue` if message sending fails in `index.tsx`.
>     - Prevents duplicate assistant messages by checking `config.finishReason` in `onFinish` in `use-chat.tsx`.
>   - **Functions**:
>     - Modifies `sendMessage` in `index.tsx` to handle input value correctly.
>     - Updates `onFinish` in `use-chat.tsx` to avoid adding messages for 'tool-calls'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for a8f61c841c74a94665a21697f901ff45dff2b981. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->