### PR TITLE
fix: images tab height

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/left-panel/image-tab/image-list.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/image-tab/image-list.tsx
@@ -25,7 +25,7 @@ export const ImageList = memo(({ images, currentFolder }: ImageListProps) => {
 
 
     return (
-        <div className="flex flex-col gap-2 max-h-[50vh]">
+        <div className="flex flex-col gap-2 h-full">
             <p className="text-sm text-gray-200 font-medium">Images</p>
             {uploadState.isUploading && (
                 <div className="mb-2 px-3 py-2 text-sm text-blue-600 bg-blue-50 dark:bg-blue-950/50 rounded-md flex items-center gap-2">


### PR DESCRIPTION
## Description

Fixes the height of images tab

## Related Issues

fixes #2317 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

## Screenshots (if applicable)

<img width="360" alt="Screenshot 2025-07-01 at 12 03 08 PM" src="https://github.com/user-attachments/assets/36ff5a6f-296f-4d29-bff4-92de4761c2bc" />


## Additional Notes

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes image tab height by setting `h-full` in `image-list.tsx`.
> 
>   - **Bug Fix**:
>     - Adjusted CSS class in `image-list.tsx` to set `h-full` instead of `max-h-[50vh]` for the image tab container, ensuring full height usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 28213d1a9b3c5dcdd77e26851e6d14a5031c6c2f. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->