### PR TITLE
fix: pages tab overflow

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/left-panel/page-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/page-tab/index.tsx
@@ -108,7 +108,7 @@ export const PagesTab = observer(() => {
 
     const dimensions = useMemo(
         () => ({
-            height: Math.max((height ?? 8) - 16, 100),
+            height: Math.max((height ?? 8) - 32, 100),
             width: width ?? 365,
         }),
         [height, width],


### PR DESCRIPTION
## Description

Fixes the pages tab overflow issue. User can now scroll down to the bottom

## Related Issues

closes #2316 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

## Screenshots (if applicable)

<img width="348" alt="Screenshot 2025-07-01 at 1 11 11 PM" src="https://github.com/user-attachments/assets/04347d07-2276-4726-bcc2-411853d19c26" />


## Additional Notes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes pages tab overflow by adjusting height calculation in `PagesTab` component.
> 
>   - **Bug Fix**:
>     - Adjusts height calculation in `PagesTab` component in `index.tsx` to prevent tab overflow by changing `height: Math.max((height ?? 8) - 16, 100)` to `height: Math.max((height ?? 8) - 32, 100)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for bafd456e2d55ab7eb091762756f00062b8202a40. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->