### PR TITLE
fix: file cache mixing between projects

### DIFF
--- a/apps/web/client/src/components/store/editor/sandbox/file-sync.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/file-sync.ts
@@ -10,13 +10,14 @@ export class FileSyncManager {
     private binaryStorageKey
 
     constructor(
-        private editorEngine: EditorEngine,
+        private readonly editorEngine: EditorEngine,
     ) {
         this.cache = new Map();
         this.binaryCache = new Map();
-        this.restoreFromLocalStorage();
         this.storageKey = 'file-cache-' + this.editorEngine.projectId;
         this.binaryStorageKey = 'binary-file-cache-' + this.editorEngine.projectId;
+
+        this.restoreFromLocalStorage();
         makeAutoObservable(this);
     }
 

--- a/apps/web/client/src/components/store/editor/sandbox/file-sync.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/file-sync.ts
@@ -1,16 +1,22 @@
 import { convertToBase64 } from '@onlook/utility';
 import localforage from 'localforage';
 import { makeAutoObservable } from 'mobx';
+import type { EditorEngine } from '../engine';
+
 export class FileSyncManager {
     private cache: Map<string, string>;
     private binaryCache: Map<string, Uint8Array>;
-    private storageKey = 'file-sync-cache';
-    private binaryStorageKey = 'binary-file-sync-cache';
+    private storageKey
+    private binaryStorageKey
 
-    constructor() {
+    constructor(
+        private editorEngine: EditorEngine,
+    ) {
         this.cache = new Map();
         this.binaryCache = new Map();
         this.restoreFromLocalStorage();
+        this.storageKey = 'file-cache-' + this.editorEngine.projectId;
+        this.binaryStorageKey = 'binary-file-cache-' + this.editorEngine.projectId;
         makeAutoObservable(this);
     }
 
@@ -23,9 +29,9 @@ export class FileSyncManager {
     }
 
     // Track binary file path without reading content (using empty placeholder)
-    async trackBinaryFile(filePath: string) {        
+    async trackBinaryFile(filePath: string) {
         if (!this.hasBinary(filePath)) {
-            this.binaryCache.set(filePath, new Uint8Array(0)); 
+            this.binaryCache.set(filePath, new Uint8Array(0));
             await this.saveToLocalStorage();
         }
     }
@@ -39,7 +45,7 @@ export class FileSyncManager {
     async readOrFetchBinaryFile(
         filePath: string,
         readFile: (path: string) => Promise<Uint8Array | null>,
-    ): Promise<Uint8Array | null> {        
+    ): Promise<Uint8Array | null> {
         if (this.hasBinary(filePath)) {
             const cachedContent = this.binaryCache.get(filePath);
             // If content is empty (placeholder), fetch the actual content
@@ -64,7 +70,7 @@ export class FileSyncManager {
             if (content === null) {
                 throw new Error(`File content for ${filePath} not found`);
             }
-            
+
             this.updateBinaryCache(filePath, content);
             return content;
         } catch (error) {
@@ -124,7 +130,7 @@ export class FileSyncManager {
     ): Promise<boolean> {
         try {
             // Write to cache first
-            
+
             this.updateBinaryCache(filePath, content);
 
             // Then write to remote
@@ -160,11 +166,11 @@ export class FileSyncManager {
 
     async rename(oldPath: string, newPath: string) {
         let hasChanges = false;
-        
+
         // Handle folder renaming - find all files that start with oldPath
         const normalizedOldPath = oldPath.endsWith('/') ? oldPath : oldPath + '/';
         const normalizedNewPath = newPath.endsWith('/') ? newPath : newPath + '/';
-        
+
         // Update binary cache entries
         const binaryEntriesToUpdate: Array<{ oldKey: string; newKey: string; content: Uint8Array }> = [];
         for (const [filePath, content] of this.binaryCache.entries()) {
@@ -178,12 +184,12 @@ export class FileSyncManager {
                 hasChanges = true;
             }
         }
-        
+
         for (const { oldKey, newKey, content } of binaryEntriesToUpdate) {
             this.binaryCache.set(newKey, content);
             this.binaryCache.delete(oldKey);
         }
-        
+
         // Update text cache entries
         const textEntriesToUpdate: Array<{ oldKey: string; newKey: string; content: string }> = [];
         for (const [filePath, content] of this.cache.entries()) {
@@ -197,13 +203,13 @@ export class FileSyncManager {
                 hasChanges = true;
             }
         }
-        
+
         // Apply text cache updates
         for (const { oldKey, newKey, content } of textEntriesToUpdate) {
             this.cache.set(newKey, content);
             this.cache.delete(oldKey);
         }
-        
+
         if (hasChanges) {
             await this.saveToLocalStorage();
         }
@@ -300,7 +306,7 @@ export class FileSyncManager {
         readFile: (path: string) => Promise<string | null>,
     ): Promise<Record<string, string>> {
         const results: Record<string, string> = {};
-        
+
         const promises = filePaths.map(async (filePath) => {
             try {
                 const content = await this.readOrFetch(filePath, readFile);
@@ -314,7 +320,7 @@ export class FileSyncManager {
         });
 
         const batchResults = await Promise.all(promises);
-        
+
         for (const result of batchResults) {
             if (result) {
                 results[result.path] = result.content;
@@ -351,14 +357,14 @@ export class FileSyncManager {
      */
     async trackBinaryFilesBatch(filePaths: string[]): Promise<void> {
         let hasChanges = false;
-        
+
         for (const filePath of filePaths) {
             if (!this.hasBinary(filePath)) {
                 this.binaryCache.set(filePath, new Uint8Array(0));
                 hasChanges = true;
             }
         }
-        
+
         if (hasChanges) {
             await this.saveToLocalStorage();
         }

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -3,7 +3,6 @@ import { EXCLUDED_SYNC_DIRECTORIES, JSX_FILE_EXTENSIONS } from '@onlook/constant
 import { type TemplateNode } from '@onlook/models';
 import { getContentFromTemplateNode } from '@onlook/parser';
 import { getBaseName, getDirName, isImageFile, isSubdirectory, LogTimer } from '@onlook/utility';
-import localforage from 'localforage';
 import { makeAutoObservable, reaction } from 'mobx';
 import path from 'path';
 import type { EditorEngine } from '../engine';
@@ -17,14 +16,16 @@ import { SessionManager } from './session';
 export class SandboxManager {
     readonly session: SessionManager;
     private fileWatcher: FileWatcher | null = null;
-    private fileSync: FileSyncManager = new FileSyncManager();
-    private templateNodeMap: TemplateNodeMapper = new TemplateNodeMapper(localforage);
+    private fileSync: FileSyncManager
+    private templateNodeMap: TemplateNodeMapper
     readonly fileEventBus: FileEventBus = new FileEventBus();
     private isIndexed = false;
     private isIndexing = false;
 
     constructor(private readonly editorEngine: EditorEngine) {
         this.session = new SessionManager(this.editorEngine);
+        this.fileSync = new FileSyncManager(this.editorEngine);
+        this.templateNodeMap = new TemplateNodeMapper(this.editorEngine);
         makeAutoObservable(this);
 
         reaction(

--- a/apps/web/client/src/components/store/editor/sandbox/mapping.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/mapping.ts
@@ -5,18 +5,21 @@ import {
     getAstFromContent,
     getContentFromAst,
 } from '@onlook/parser';
+import localforage from 'localforage';
+import type { EditorEngine } from '../engine';
 
 export class TemplateNodeMapper {
     private oidToTemplateNodeMap = new Map<string, TemplateNode>();
-    private storageKey = 'template-node-map';
+    private storageKey
 
-    constructor(private localforage: LocalForage) {
+    constructor(private readonly editorEngine: EditorEngine) {
+        this.storageKey = 'template-node-map-' + this.editorEngine.projectId;
         this.restoreFromLocalStorage();
     }
 
     private async restoreFromLocalStorage() {
         try {
-            const storedCache = await this.localforage.getItem<Record<string, TemplateNode>>(
+            const storedCache = await localforage.getItem<Record<string, TemplateNode>>(
                 this.storageKey,
             );
             if (storedCache) {
@@ -32,7 +35,7 @@ export class TemplateNodeMapper {
     private async saveToLocalStorage() {
         try {
             const cacheObject = Object.fromEntries(this.oidToTemplateNodeMap.entries());
-            await this.localforage.setItem(this.storageKey, cacheObject);
+            await localforage.setItem(this.storageKey, cacheObject);
         } catch (error) {
             console.error('Error saving to localForage:', error);
         }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes file cache mixing between projects by appending `projectId` to cache keys in `FileSyncManager` and `TemplateNodeMapper`.
> 
>   - **Behavior**:
>     - Fixes file cache mixing between projects by appending `projectId` to `storageKey` and `binaryStorageKey` in `FileSyncManager`.
>     - Ensures `TemplateNodeMapper` uses `projectId` for `storageKey` to prevent cache mixing.
>   - **Constructor Changes**:
>     - `FileSyncManager` and `TemplateNodeMapper` constructors now require `EditorEngine` to access `projectId`.
>   - **Misc**:
>     - Removes unused `localforage` import in `index.ts`.
>     - Fixes whitespace issues in `file-sync.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 96cf43045733877bd90e75d603ff8bee69ed0335. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->