### PR TITLE
feat: add delete confirmation modal based on user preference

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/warning-model.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/warning-model.tsx
@@ -1,0 +1,60 @@
+import {
+    AlertDialog,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@onlook/ui/alert-dialog';
+import { Button } from '@onlook/ui/button';
+import { Icons } from '@onlook/ui/icons/index';
+
+export default function DeleteConfirmationModal({
+    isOpen,
+    isLoading,
+    handleWarningClose,
+    handleDelete
+}: {
+    isOpen: boolean;
+    isLoading: boolean;
+    handleWarningClose: () => void;
+    handleDelete: () => void;
+}) {
+
+    return (
+        <AlertDialog open={isOpen} onOpenChange={handleWarningClose}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Delete Element</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        <>
+                            Are you sure you want to delete the selected element?
+                            <span className="block mt-2 text-sm">
+                                This action cannot be undone.
+                            </span>
+                        </>
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <Button variant={'ghost'} onClick={handleWarningClose}>
+                        Cancel
+                    </Button>
+                    <Button
+                        variant={'default'}
+                        className="rounded-md text-sm"
+                        onClick={handleDelete}
+                    >
+                        {isLoading ? (
+                            <>
+                                <Icons.Reload className="w-4 h-4 animate-spin mr-2" />
+                                Deleting...
+                            </>
+                        ) : (
+                            'Delete'
+                        )}
+                    </Button>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+} 

--- a/apps/web/client/src/components/ui/settings-modal/preferences-tab.tsx
+++ b/apps/web/client/src/components/ui/settings-modal/preferences-tab.tsx
@@ -10,8 +10,13 @@ import { Icons } from '@onlook/ui/icons';
 import { observer } from 'mobx-react-lite';
 
 export const PreferencesTab = observer(() => {
+    const utils = api.useContext();
     const { data: settings } = api.user.settings.get.useQuery();
-    const { mutate: updateSettings } = api.user.settings.upsert.useMutation();
+    const { mutate: updateSettings } = api.user.settings.upsert.useMutation({
+        onSuccess: () => {
+            utils.user.settings.get.invalidate();
+        }
+    });
     const shouldWarnDelete = settings?.editor?.shouldWarnDelete ?? true;
 
     async function updateDeleteWarning(enabled: boolean) {


### PR DESCRIPTION
## Description

This PR adds a new feature to show a confirmation modal whenever the user tries to delete elements on the canvas — only if the user has enabled the “warn before delete” preference in settings.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
