### PR TITLE
fix: prevent too many iframe reload

### DIFF
--- a/apps/web/client/src/components/store/editor/dev/index.ts
+++ b/apps/web/client/src/components/store/editor/dev/index.ts
@@ -151,13 +151,11 @@ export class IDEManager {
                 ],
             });
             const file = this.openedFiles.find((f) => f.id === this.activeFile!.id);
-            if (file){
+            if (file) {
                 file.isDirty = false;
                 file.savedContent = file.content;
             }
             this.activeFile = { ...this.activeFile, isDirty: false, savedContent: file?.content || '' };
-
-            this.refreshPreviewAfterSave();
         } catch (error) {
             console.error('Error saving file:', error);
         } finally {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `refreshPreviewAfterSave()` call in `saveActiveFile()` to prevent excessive iframe reloads in `IDEManager`.
> 
>   - **Behavior**:
>     - Removes `refreshPreviewAfterSave()` call in `saveActiveFile()` method of `IDEManager` class to prevent excessive iframe reloads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 2e567a1bca4bfa6dc0bcc59d768e162a01b9cf60. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->