### PR TITLE
fix: persist chat input text when switching between code and design modes

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
@@ -19,12 +19,17 @@ import { type SuggestionsRef } from '../suggestions';
 import { ActionButtons } from './action-buttons';
 import { ChatModeToggle } from './chat-mode-toggle';
 
-export const ChatInput = observer(() => {
+export const ChatInput = observer(({
+    inputValue,
+    setInputValue,
+}: {
+    inputValue: string;
+    setInputValue: React.Dispatch<React.SetStateAction<string>>;
+}) => {
     const { sendMessages, stop, isWaiting } = useChatContext();
     const editorEngine = useEditorEngine();
     const t = useTranslations();
     const textareaRef = useRef<HTMLTextAreaElement>(null);
-    const [inputValue, setInputValue] = useState('');
     const [isComposing, setIsComposing] = useState(false);
     const [actionTooltipOpen, setActionTooltipOpen] = useState(false);
     const [isDragging, setIsDragging] = useState(false);

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/index.tsx
@@ -2,14 +2,20 @@ import { ChatInput } from './chat-input';
 import { ChatMessages } from './chat-messages';
 import { ErrorSection } from './error';
 
-export const ChatTab = () => {
+export const ChatTab = ({
+    inputValue,
+    setInputValue,
+}: {
+    inputValue: string;
+    setInputValue: React.Dispatch<React.SetStateAction<string>>;
+}) => {
     return (
         <div className="flex flex-col h-full justify-end gap-2 pt-2">
             <div className="h-full flex-1 overflow-y-auto">
                 <ChatMessages />
             </div>
             <ErrorSection />
-            <ChatInput />
+            <ChatInput inputValue={inputValue} setInputValue={setInputValue} />
         </div>
     );
 };

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/index.tsx
@@ -26,6 +26,8 @@ export const RightPanel = observer(() => {
     const editorEngine = useEditorEngine();
     const t = useTranslations();
     const [isChatHistoryOpen, setIsChatHistoryOpen] = useState(false);
+    const [inputValue, setInputValue] = useState('');
+
     const selectedTab = editorEngine.state.rightPanelTab;
     const editPanelWidth = EDIT_PANEL_WIDTHS[selectedTab];
 
@@ -73,7 +75,7 @@ export const RightPanel = observer(() => {
                     </TabsList>
                     <ChatHistory isOpen={isChatHistoryOpen} onOpenChange={setIsChatHistoryOpen} />
                     <TabsContent className="h-full overflow-y-auto" value={EditorTabValue.CHAT}>
-                        <ChatTab />
+                        <ChatTab inputValue={inputValue} setInputValue={setInputValue} />
                     </TabsContent>
                     <TabsContent forceMount className={cn('h-full overflow-y-auto', editorEngine.state.rightPanelTab !== EditorTabValue.DEV && 'hidden')} value={EditorTabValue.DEV}>
                         <DevTab />


### PR DESCRIPTION
## Description

## Related Issues

Closes: #2383

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Persist chat input text across mode switches by passing `inputValue` and `setInputValue` through `ChatInput`, `ChatTab`, and `RightPanel`.
> 
>   - **Behavior**:
>     - Persist chat input text when switching between code and design modes by passing `inputValue` and `setInputValue` as props in `ChatInput`, `ChatTab`, and `RightPanel`.
>   - **Components**:
>     - `ChatInput` now accepts `inputValue` and `setInputValue` as props to manage input state.
>     - `ChatTab` updated to pass `inputValue` and `setInputValue` to `ChatInput`.
>     - `RightPanel` initializes and passes `inputValue` and `setInputValue` to `ChatTab` to maintain input state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 18b8755b96a5f973279f8d7669a2a18962d88582. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->