### PR TITLE
hide pages setting when no page

### DIFF
--- a/apps/web/client/src/components/ui/settings-modal/with-project.tsx
+++ b/apps/web/client/src/components/ui/settings-modal/with-project.tsx
@@ -36,14 +36,14 @@ export const SettingsModalWithProjects = observer(() => {
             return acc;
         }, [] as PageNode[]);
     }, [pagesManager.tree]);
-    
+
     const globalTabs: SettingTab[] = [
         {
             label: SettingsTabValue.PREFERENCES,
             icon: <Icons.Person className="mr-2 h-4 w-4" />,
             component: <PreferencesTab />,
         },
-    ]
+    ];
 
     const projectTabs: SettingTab[] = [
         {
@@ -68,12 +68,13 @@ export const SettingsModalWithProjects = observer(() => {
         },
     ];
 
-    const pagesTabs: SettingTab[] = flattenPages.filter((page) => page.path !== '/').map((page) => ({
-        label: page.path,
-        icon: <Icons.File className="mr-2 h-4 min-w-4" />,
-        component: <PageTab metadata={page.metadata} path={page.path} />,
-    }));
-    
+    const pagesTabs: SettingTab[] = flattenPages
+        .filter((page) => page.path !== '/')
+        .map((page) => ({
+            label: page.path,
+            icon: <Icons.File className="mr-2 h-4 min-w-4" />,
+            component: <PageTab metadata={page.metadata} path={page.path} />,
+        }));
 
     const tabs = [...globalTabs, ...pagesTabs, ...projectTabs];
 
@@ -149,44 +150,50 @@ export const SettingsModalWithProjects = observer(() => {
                                             ))}
                                         </div>
                                         <Separator />
-                                        <div className="shrink-0 w-48 space-y-1 p-5 text-regularPlus">
-                                            <p className="text-muted-foreground text-smallPlus ml-2.5 mt-2 mb-2">
-                                                Pages Settings
-                                            </p>
-                                            {pagesTabs.map((tab) => (
-                                                <Button
-                                                    key={tab.label}
-                                                    variant="ghost"
-                                                    className={cn(
-                                                        'w-full justify-start px-0 hover:bg-transparent',
-                                                        'truncate',
-                                                        stateManager.settingsTab === tab.label
-                                                            ? 'text-foreground-active'
-                                                            : 'text-muted-foreground',
-                                                    )}
-                                                    onClick={() =>
-                                                        (stateManager.settingsTab = tab.label)
-                                                    }
-                                                >
-                                                    {tab.icon}
-                                                    <Tooltip>
-                                                        <TooltipTrigger asChild>
-                                                            <span className="truncate">
-                                                                {capitalizeFirstLetter(
-                                                                    tab.label.toLowerCase(),
-                                                                )}
-                                                            </span>
-                                                        </TooltipTrigger>
-                                                        <TooltipContent>
-                                                            {capitalizeFirstLetter(
-                                                                tab.label.toLowerCase(),
+                                        {pagesTabs.length > 0 && (
+                                            <>
+                                                <div className="shrink-0 w-48 space-y-1 p-5 text-regularPlus">
+                                                    <p className="text-muted-foreground text-smallPlus ml-2.5 mt-2 mb-2">
+                                                        Pages Settings
+                                                    </p>
+                                                    {pagesTabs.map((tab) => (
+                                                        <Button
+                                                            key={tab.label}
+                                                            variant="ghost"
+                                                            className={cn(
+                                                                'w-full justify-start px-0 hover:bg-transparent',
+                                                                'truncate',
+                                                                stateManager.settingsTab ===
+                                                                    tab.label
+                                                                    ? 'text-foreground-active'
+                                                                    : 'text-muted-foreground',
                                                             )}
-                                                        </TooltipContent>
-                                                    </Tooltip>
-                                                </Button>
-                                            ))}
-                                        </div>
-                                        <Separator />
+                                                            onClick={() =>
+                                                                (stateManager.settingsTab =
+                                                                    tab.label)
+                                                            }
+                                                        >
+                                                            {tab.icon}
+                                                            <Tooltip>
+                                                                <TooltipTrigger asChild>
+                                                                    <span className="truncate">
+                                                                        {capitalizeFirstLetter(
+                                                                            tab.label.toLowerCase(),
+                                                                        )}
+                                                                    </span>
+                                                                </TooltipTrigger>
+                                                                <TooltipContent>
+                                                                    {capitalizeFirstLetter(
+                                                                        tab.label.toLowerCase(),
+                                                                    )}
+                                                                </TooltipContent>
+                                                            </Tooltip>
+                                                        </Button>
+                                                    ))}
+                                                </div>
+                                                <Separator />
+                                            </>
+                                        )}
                                         <div className="shrink-0 w-48 space-y-1 p-5 text-regularPlus">
                                             <p className="text-muted-foreground text-smallPlus ml-2.5 mt-2 mb-2">
                                                 Global Settings


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Hide pages setting section when project does not have other pages
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
![89894](https://github.com/user-attachments/assets/53889ec3-ff18-4263-aa88-3de02049a43c)

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Hide 'Pages Settings' in `SettingsModalWithProjects` when no pages are available.
> 
>   - **Behavior**:
>     - Hide 'Pages Settings' section in `SettingsModalWithProjects` if no pages are available.
>     - Conditional rendering based on `pagesTabs.length` in `with-project.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for cc5a4a121fb3b0358750cb3323e7bd7ba06f4c2a. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->