### PR TITLE
fix: file tree not using full height Fixes #2374

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/dev-tab/file-tree.tsx
@@ -8,6 +8,7 @@ import { nanoid } from 'nanoid';
 import path from 'path';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import { Tree, type TreeApi } from 'react-arborist';
+import useResizeObserver from 'use-resize-observer';
 import { FileTreeNode } from './file-tree-node';
 import { FileTreeRow } from './file-tree-row';
 
@@ -26,19 +27,8 @@ function UnmemoizedFileTree({ onFileSelect, files, isLoading = false, onRefresh,
     const [treeData, setTreeData] = useState<FileNode[]>([]);
     const treeRef = useRef<TreeApi<FileNode>>(null);
     const inputRef = useRef<HTMLInputElement>(null);
-    const [filesWidth, setFilesWidth] = useState(250);
-    const containerRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        if (!containerRef.current) return;
-        const resizeObserver = new ResizeObserver(entries => {
-            for (const entry of entries) {
-                setFilesWidth(entry.contentRect.width);
-            }
-        });
-        resizeObserver.observe(containerRef.current);
-        return () => resizeObserver.disconnect();
-    }, []);
+    const { ref: containerRef, width: filesWidth } = useResizeObserver();
+    const { ref: treeContainerRef, height: filesHeight } = useResizeObserver();
 
     // Convert flat file paths to tree structure
     const buildFileTree = useMemo(() => (files: string[]): FileNode[] => {
@@ -198,9 +188,9 @@ function UnmemoizedFileTree({ onFileSelect, files, isLoading = false, onRefresh,
     const filesTreeDimensions = useMemo(
         () => ({
             width: filesWidth ?? 250,
-            height: 1000,
+            height: filesHeight ?? 300,
         }),
-        [filesWidth],
+        [filesWidth, filesHeight],
     );
 
     const handleRefresh = async () => {
@@ -267,7 +257,7 @@ function UnmemoizedFileTree({ onFileSelect, files, isLoading = false, onRefresh,
                         </Tooltip>
                     </div>
                 </div>
-                <div className="min-w-full h-full overflow-x-auto text-xs w-full h-full px-2 flex-1">
+                <div ref={treeContainerRef} className="min-w-full h-full overflow-x-auto text-xs w-full h-full px-2 flex-1">
                     {isLoading ? (
                         <div className="flex flex-col justify-center items-center h-full text-sm text-foreground/50">
                             <div className="animate-spin h-6 w-6 border-2 border-foreground-hover rounded-full border-t-transparent mb-2"></div>


### PR DESCRIPTION
## Description

This PR fixes an issue where the file tree component did not utilize the full height of its container.
### What Changed
- Replaced the hardcoded `height: 1000` with a dynamic height using `use-resize-observer`.
- Removed the manual `ResizeObserver` implementation and replaced it with the `use-resize-observer` hook for consistency across components.

### Technical Details
- Width is still calculated from the outer container.
- Height is now observed from the tree container itself.
- The structure and logic follow the existing patterns in `LayersTab` and `PagesTab`.

## Related Issues

Fixes #2374

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other


## Screenshots
![Screenshot 2025-07-09 at 1 19 55 PM](https://github.com/user-attachments/assets/ab809f6a-db2f-4665-8d77-113035cd7f34)







<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces hardcoded height with dynamic height using `use-resize-observer` in `file-tree.tsx`, removing manual `ResizeObserver` for consistency.
> 
>   - **Behavior**:
>     - Replaces hardcoded `height: 1000` with dynamic height using `use-resize-observer` in `file-tree.tsx`.
>     - Removes manual `ResizeObserver` implementation, using `use-resize-observer` hook instead.
>   - **Technical Details**:
>     - Width still calculated from outer container.
>     - Height observed from tree container itself.
>     - Follows existing patterns in `LayersTab` and `PagesTab`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 97f5100ee149e33c1dc6b01a8f9bfa8c7453f753. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->