### PR TITLE
hotfix: image upload no folder

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/left-panel/image-tab/folder/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/image-tab/folder/index.tsx
@@ -1,3 +1,4 @@
+import { DefaultSettings } from '@onlook/constants';
 import { Button } from '@onlook/ui/button';
 import { Icons } from '@onlook/ui/icons';
 import { Input } from '@onlook/ui/input';
@@ -278,7 +279,7 @@ export default function Folder() {
                     </div>
                 </div>
             ) : (
-                <ImageList images={filteredImages} currentFolder={currentFolder?.fullPath || ''} />
+                <ImageList images={filteredImages} currentFolder={currentFolder?.fullPath ?? DefaultSettings.IMAGE_FOLDER} />
             )}
 
             <FolderCreateModal

--- a/apps/web/client/src/app/project/[id]/_components/left-panel/image-tab/hooks/use-image-upload.ts
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/image-tab/hooks/use-image-upload.ts
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react';
 import { useEditorEngine } from '@/components/store/editor';
+import { useCallback, useState } from 'react';
 import type { UploadState } from '../providers/types';
 
 export const useImageUpload = () => {
@@ -34,6 +34,7 @@ export const useImageUpload = () => {
 
     const handleUploadFile = useCallback(
         async (e: React.ChangeEvent<HTMLInputElement>, destinationFolder: string) => {
+            console.log('handleUploadFile', destinationFolder);
             const files = Array.from(e.target.files ?? []);
             const imageFiles = files.filter((file) => file.type.startsWith('image/'));
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes image upload bug by setting default folder path and adding logging in `index.tsx` and `use-image-upload.ts`.
> 
>   - **Behavior**:
>     - Sets default folder path to `DefaultSettings.IMAGE_FOLDER` in `index.tsx` when `currentFolder` is undefined.
>     - Adds console log in `handleUploadFile` in `use-image-upload.ts` to log `destinationFolder`.
>   - **Imports**:
>     - Adds `DefaultSettings` import in `index.tsx`.
>     - Reorders imports in `use-image-upload.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 3158e91cc71060aeb4ce24808c051668ab10aa4a. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->