### PR TITLE
Handle About Page Blur on Mobile Safari

### DIFF
--- a/apps/web/client/src/app/about/page.tsx
+++ b/apps/web/client/src/app/about/page.tsx
@@ -52,10 +52,12 @@ function BlurInElement({ children, delay = 0, className = "" }: {
         const isSafari = /safari/.test(userAgent) && !/chrome/.test(userAgent);
         const isFirefox = /firefox/.test(userAgent);
         const isMobile = /mobile|android|iphone|ipad/.test(userAgent);
+        const isMobileSafari = isSafari && isMobile;
 
-        // Disable blur on mobile Safari, older browsers, and Firefox for better performance
-        // Firefox can have performance issues with blur filters in some cases
-        if ((isSafari && isMobile) || isFirefox || !blurSupported) {
+        // Disable blur on mobile Safari (has animation completion issues), Firefox, and unsupported browsers
+        // Mobile Safari blur animations can start but not resolve properly
+        // Desktop Safari can handle blur animations with proper configuration
+        if (isMobileSafari || isFirefox || !blurSupported) {
             setSupportsBlur(false);
         } else {
             setSupportsBlur(blurSupported);
@@ -79,7 +81,9 @@ function BlurInElement({ children, delay = 0, className = "" }: {
                 transition: { 
                     duration: 0.6, 
                     delay, 
-                    ease: "easeOut" 
+                    ease: "easeOut",
+                    // Force Safari to complete the animation
+                    type: "tween"
                 }
             };
         }

--- a/apps/web/client/src/app/about/page.tsx
+++ b/apps/web/client/src/app/about/page.tsx
@@ -81,9 +81,7 @@ function BlurInElement({ children, delay = 0, className = "" }: {
                 transition: { 
                     duration: 0.6, 
                     delay, 
-                    ease: "easeOut",
-                    // Force Safari to complete the animation
-                    type: "tween"
+                    ease: "easeOut"
                 }
             };
         }


### PR DESCRIPTION
## Description

Blur would get stuck on the about page for mobile safari. Hopefully this solves it!


## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refines blur disabling conditions in `page.tsx` to address animation issues on mobile Safari, allowing desktop Safari to handle blur if configured.
> 
>   - **Behavior**:
>     - In `page.tsx`, refine blur disabling conditions in `BlurInElement` to specifically target mobile Safari due to animation completion issues.
>     - Desktop Safari is now allowed to handle blur animations if properly configured.
>   - **Comments**:
>     - Update comments in `page.tsx` to clarify the reasoning behind disabling blur on certain browsers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for cc28b1020c4001ffc9171ee9fd5026bb6ed06378. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->