### PR TITLE
[feat] "Recenter Canvas" button in the center

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/index.tsx
@@ -9,6 +9,7 @@ import { Frames } from './frames';
 import { HotkeysArea } from './hotkeys';
 import { Overlay } from './overlay';
 import { PanOverlay } from './overlay/pan';
+import { RecenterCanvasButton } from './recenter-canvas-button';
 
 const ZOOM_SENSITIVITY = 0.006;
 const PAN_SENSITIVITY = 0.52;
@@ -166,6 +167,7 @@ export const Canvas = observer(() => {
                 <div id={EditorAttributes.CANVAS_CONTAINER_ID} style={transformStyle}>
                     <Frames />
                 </div>
+                <RecenterCanvasButton />
                 <Overlay />
                 <PanOverlay
                     clampPosition={(position: { x: number; y: number }) =>

--- a/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
@@ -1,88 +1,31 @@
 'use client';
 
 import { useEditorEngine } from '@/components/store/editor';
-import { type Frame } from '@onlook/models';
 import { Button } from '@onlook/ui/button';
-import throttle from 'lodash/throttle';
 import { Scan } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useCallback, useEffect, useMemo } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
 
 export const RecenterCanvasButton = observer(() => {
     const editorEngine = useEditorEngine();
 
-    const frames = editorEngine.frames.getAll();
-
-    const throttledViewportCheck = useCallback(
-        throttle(
-            () => {
-                function isFrameInViewport(frame: Frame): boolean {
-                    const canvasPos = editorEngine.canvas.position;
-                    const canvasScale = editorEngine.canvas.scale;
-
-                    const screenX = canvasPos.x + frame.position.x * canvasScale;
-                    const screenY = canvasPos.y + frame.position.y * canvasScale;
-                    const screenWidth = frame.dimension.width * canvasScale;
-                    const screenHeight = frame.dimension.height * canvasScale;
-
-                    return !(
-                        screenX + screenWidth < 0 ||
-                        screenX > window.innerWidth ||
-                        screenY + screenHeight < 0 ||
-                        screenY > window.innerHeight
-                    );
-                }
-
-                return !editorEngine.frames
-                    .getAll()
-                    .some((frame) => isFrameInViewport(frame.frame));
-            },
-            200,
-            { leading: true, trailing: true },
-        ),
-        [editorEngine],
-    );
-
-    const isCanvasOutOfView = useMemo(
-        () => throttledViewportCheck(),
-        [throttledViewportCheck, editorEngine.canvas.position, editorEngine.canvas.scale, frames],
-    );
-
-    useEffect(() => {
-        return () => throttledViewportCheck.cancel();
-    }, [throttledViewportCheck]);
-
-    const handleRecenterCanvas = () => {
-        const firstFrame = frames[0]?.frame;
-
-        if (firstFrame) {
-            const canvasScale = editorEngine.canvas.scale;
-
-            const frameCenterX = firstFrame.position.x + firstFrame.dimension.width / 2;
-            const frameCenterY = firstFrame.position.y + firstFrame.dimension.height / 2;
-
-            const defaultPosition = editorEngine.canvas.getDefaultPanPosition();
-            const viewportCenterX = window.innerWidth / 2 - defaultPosition.x;
-            const viewportCenterY = window.innerHeight / 2 - defaultPosition.y;
-
-            editorEngine.canvas.position = {
-                x: viewportCenterX - frameCenterX * canvasScale,
-                y: viewportCenterY - frameCenterY * canvasScale,
-            };
-        } else {
-            editorEngine.canvas.position = editorEngine.canvas.getDefaultPanPosition();
-        }
-    };
-
-    if (!isCanvasOutOfView) return null;
-
     return (
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
-            <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
-            <Button onClick={handleRecenterCanvas}>
-                <Scan className="size-4" />
-                <span>Re-Center the Canvas</span>
-            </Button>
-        </div>
+        <AnimatePresence>
+            {editorEngine.frameEvent.isCanvasOutOfView && (
+                <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.2, ease: "easeOut" }}
+                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/1 text-center"
+                >
+                    <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
+                    <Button onClick={editorEngine.frameEvent.recenterCanvas}>
+                        <Scan className="size-4" />
+                        <span>Re-Center the Canvas</span>
+                    </Button>
+                </motion.div>
+            )}
+        </AnimatePresence>
     );
 });

--- a/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
@@ -72,7 +72,7 @@ export const RecenterCanvasButton = observer(() => {
     if (!isCanvasOutOfView) return null;
 
     return (
-        <div className="absolute top-1/2 right-1/2 translate-1/2 text-center">
+        <div className="absolute top-1/2 right-1/2 translate-x-1/2 -translate-y-1/2 text-center">
             <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
             <Button onClick={handleRecenterCanvas}>
                 <Scan className="size-4" />

--- a/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
@@ -13,26 +13,26 @@ export const RecenterCanvasButton = observer(() => {
 
     const frames = editorEngine.frames.getAll();
 
-    function isFrameInViewport(frame: Frame): boolean {
-        const canvasPos = editorEngine.canvas.position;
-        const canvasScale = editorEngine.canvas.scale;
-
-        const screenX = canvasPos.x + frame.position.x * canvasScale;
-        const screenY = canvasPos.y + frame.position.y * canvasScale;
-        const screenWidth = frame.dimension.width * canvasScale;
-        const screenHeight = frame.dimension.height * canvasScale;
-
-        return !(
-            screenX + screenWidth < 0 ||
-            screenX > window.innerWidth ||
-            screenY + screenHeight < 0 ||
-            screenY > window.innerHeight
-        );
-    }
-
     const throttledViewportCheck = useCallback(
         throttle(
             () => {
+                function isFrameInViewport(frame: Frame): boolean {
+                    const canvasPos = editorEngine.canvas.position;
+                    const canvasScale = editorEngine.canvas.scale;
+
+                    const screenX = canvasPos.x + frame.position.x * canvasScale;
+                    const screenY = canvasPos.y + frame.position.y * canvasScale;
+                    const screenWidth = frame.dimension.width * canvasScale;
+                    const screenHeight = frame.dimension.height * canvasScale;
+
+                    return !(
+                        screenX + screenWidth < 0 ||
+                        screenX > window.innerWidth ||
+                        screenY + screenHeight < 0 ||
+                        screenY > window.innerHeight
+                    );
+                }
+
                 return !editorEngine.frames
                     .getAll()
                     .some((frame) => isFrameInViewport(frame.frame));
@@ -77,7 +77,7 @@ export const RecenterCanvasButton = observer(() => {
     if (!isCanvasOutOfView) return null;
 
     return (
-        <div className="absolute top-1/2 right-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
             <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
             <Button onClick={handleRecenterCanvas}>
                 <Scan className="size-4" />

--- a/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
@@ -57,12 +57,17 @@ export const RecenterCanvasButton = observer(() => {
 
         if (firstFrame) {
             const canvasScale = editorEngine.canvas.scale;
+
             const frameCenterX = firstFrame.position.x + firstFrame.dimension.width / 2;
             const frameCenterY = firstFrame.position.y + firstFrame.dimension.height / 2;
 
+            const defaultPosition = editorEngine.canvas.getDefaultPanPosition();
+            const viewportCenterX = window.innerWidth / 2 - defaultPosition.x;
+            const viewportCenterY = window.innerHeight / 2 - defaultPosition.y;
+
             editorEngine.canvas.position = {
-                x: window.innerWidth / 2 - frameCenterX * canvasScale,
-                y: window.innerHeight / 2 - frameCenterY * canvasScale,
+                x: viewportCenterX - frameCenterX * canvasScale,
+                y: viewportCenterY - frameCenterY * canvasScale,
             };
         } else {
             editorEngine.canvas.position = editorEngine.canvas.getDefaultPanPosition();
@@ -72,7 +77,7 @@ export const RecenterCanvasButton = observer(() => {
     if (!isCanvasOutOfView) return null;
 
     return (
-        <div className="absolute top-1/2 right-1/2 translate-x-1/2 -translate-y-1/2 text-center">
+        <div className="absolute top-1/2 right-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
             <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
             <Button onClick={handleRecenterCanvas}>
                 <Scan className="size-4" />

--- a/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
@@ -17,7 +17,7 @@ export const RecenterCanvasButton = observer(() => {
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                     transition={{ duration: 0.2, ease: "easeOut" }}
-                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-24 text-center"
+                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-full text-center"
                 >
                     <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
                     <Button onClick={editorEngine.frameEvent.recenterCanvas}>

--- a/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
@@ -17,7 +17,7 @@ export const RecenterCanvasButton = observer(() => {
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                     transition={{ duration: 0.2, ease: "easeOut" }}
-                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/1 text-center"
+                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-24 text-center"
                 >
                     <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
                     <Button onClick={editorEngine.frameEvent.recenterCanvas}>

--- a/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/recenter-canvas-button.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEditorEngine } from '@/components/store/editor';
+import { type Frame } from '@onlook/models';
+import { Button } from '@onlook/ui/button';
+import throttle from 'lodash/throttle';
+import { Scan } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { useCallback, useEffect, useMemo } from 'react';
+
+export const RecenterCanvasButton = observer(() => {
+    const editorEngine = useEditorEngine();
+
+    const frames = editorEngine.frames.getAll();
+
+    function isFrameInViewport(frame: Frame): boolean {
+        const canvasPos = editorEngine.canvas.position;
+        const canvasScale = editorEngine.canvas.scale;
+
+        const screenX = canvasPos.x + frame.position.x * canvasScale;
+        const screenY = canvasPos.y + frame.position.y * canvasScale;
+        const screenWidth = frame.dimension.width * canvasScale;
+        const screenHeight = frame.dimension.height * canvasScale;
+
+        return !(
+            screenX + screenWidth < 0 ||
+            screenX > window.innerWidth ||
+            screenY + screenHeight < 0 ||
+            screenY > window.innerHeight
+        );
+    }
+
+    const throttledViewportCheck = useCallback(
+        throttle(
+            () => {
+                return !editorEngine.frames
+                    .getAll()
+                    .some((frame) => isFrameInViewport(frame.frame));
+            },
+            200,
+            { leading: true, trailing: true },
+        ),
+        [editorEngine],
+    );
+
+    const isCanvasOutOfView = useMemo(
+        () => throttledViewportCheck(),
+        [throttledViewportCheck, editorEngine.canvas.position, editorEngine.canvas.scale, frames],
+    );
+
+    useEffect(() => {
+        return () => throttledViewportCheck.cancel();
+    }, [throttledViewportCheck]);
+
+    const handleRecenterCanvas = () => {
+        const firstFrame = frames[0]?.frame;
+
+        if (firstFrame) {
+            const canvasScale = editorEngine.canvas.scale;
+            const frameCenterX = firstFrame.position.x + firstFrame.dimension.width / 2;
+            const frameCenterY = firstFrame.position.y + firstFrame.dimension.height / 2;
+
+            editorEngine.canvas.position = {
+                x: window.innerWidth / 2 - frameCenterX * canvasScale,
+                y: window.innerHeight / 2 - frameCenterY * canvasScale,
+            };
+        } else {
+            editorEngine.canvas.position = editorEngine.canvas.getDefaultPanPosition();
+        }
+    };
+
+    if (!isCanvasOutOfView) return null;
+
+    return (
+        <div className="absolute top-1/2 right-1/2 translate-1/2 text-center">
+            <p className="text-foreground-secondary mb-2">Your canvas is out of view</p>
+            <Button onClick={handleRecenterCanvas}>
+                <Scan className="size-4" />
+                <span>Re-Center the Canvas</span>
+            </Button>
+        </div>
+    );
+});

--- a/apps/web/client/src/components/store/editor/frame-view-events/index.ts
+++ b/apps/web/client/src/components/store/editor/frame-view-events/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import type { Frame, LayerNode } from '@onlook/models';
 import { debounce } from 'lodash';
 import { makeAutoObservable, reaction } from 'mobx';
@@ -8,7 +10,6 @@ export class FrameEventManager {
 
     constructor(private editorEngine: EditorEngine) {
         makeAutoObservable(this);
-
         reaction(
             () => ({
                 position: this.editorEngine.canvas.position,
@@ -22,11 +23,7 @@ export class FrameEventManager {
         );
     }
 
-    clear() {
-        this.handleWindowMutated.cancel();
-    }
-
-    async undebouncedHandleWindowMutated() {
+    private async undebouncedHandleWindowMutated() {
         try {
             await this.editorEngine.refreshLayers();
             await this.editorEngine.overlay.refresh();
@@ -58,7 +55,7 @@ export class FrameEventManager {
         );
     }
 
-    undebouncedViewportCheck = () => {
+    private undebouncedViewportCheck = () => {
         if (typeof window === 'undefined') {
             this.isCanvasOutOfView = false;
             return;
@@ -150,4 +147,6 @@ export class FrameEventManager {
             this.editorEngine.elements.click(validElements);
         }
     }
+
+    clear() { }
 } 

--- a/apps/web/client/src/components/store/editor/frame-view-events/index.ts
+++ b/apps/web/client/src/components/store/editor/frame-view-events/index.ts
@@ -1,14 +1,30 @@
-import type { LayerNode } from '@onlook/models';
+import type { Frame, LayerNode } from '@onlook/models';
 import { debounce } from 'lodash';
-import { makeAutoObservable } from 'mobx';
+import { makeAutoObservable, reaction } from 'mobx';
 import type { EditorEngine } from '../engine';
 
 export class FrameEventManager {
+    isCanvasOutOfView = false;
+
     constructor(private editorEngine: EditorEngine) {
         makeAutoObservable(this);
+
+        reaction(
+            () => ({
+                position: this.editorEngine.canvas.position,
+                scale: this.editorEngine.canvas.scale,
+                frames: this.editorEngine.frames.getAll(),
+            }),
+            () => this.handleViewportCheck(),
+            {
+                fireImmediately: true,
+            },
+        );
     }
 
-    clear() { }
+    clear() {
+        this.handleWindowMutated.cancel();
+    }
 
     async undebouncedHandleWindowMutated() {
         try {
@@ -20,7 +36,71 @@ export class FrameEventManager {
         }
     }
 
-    handleWindowMutated = debounce(this.undebouncedHandleWindowMutated, 1000, { leading: true, trailing: true });
+    handleWindowMutated = debounce(this.undebouncedHandleWindowMutated, 1000, {
+        leading: true,
+        trailing: true,
+    });
+
+    private isFrameInViewport(frame: Frame): boolean {
+        const canvasPos = this.editorEngine.canvas.position;
+        const canvasScale = this.editorEngine.canvas.scale;
+
+        const screenX = canvasPos.x + frame.position.x * canvasScale;
+        const screenY = canvasPos.y + frame.position.y * canvasScale;
+        const screenWidth = frame.dimension.width * canvasScale;
+        const screenHeight = frame.dimension.height * canvasScale;
+
+        return !(
+            screenX + screenWidth < 0 ||
+            screenX > window.innerWidth ||
+            screenY + screenHeight < 0 ||
+            screenY > window.innerHeight
+        );
+    }
+
+    undebouncedViewportCheck = () => {
+        if (typeof window === 'undefined') {
+            this.isCanvasOutOfView = false;
+            return;
+        }
+
+        const frames = this.editorEngine.frames.getAll();
+        if (frames.length === 0) {
+            this.isCanvasOutOfView = false;
+            return;
+        }
+
+        const isAnyFrameInView = frames.some((frame) => this.isFrameInViewport(frame.frame));
+        this.isCanvasOutOfView = !isAnyFrameInView;
+    };
+
+    handleViewportCheck = debounce(this.undebouncedViewportCheck, 500, {
+        leading: true,
+        trailing: true,
+    });
+
+    recenterCanvas = () => {
+        const frames = this.editorEngine.frames.getAll();
+        const firstFrame = frames[0]?.frame;
+
+        if (firstFrame) {
+            const canvasScale = this.editorEngine.canvas.scale;
+
+            const frameCenterX = firstFrame.position.x + firstFrame.dimension.width / 2;
+            const frameCenterY = firstFrame.position.y + firstFrame.dimension.height / 2;
+
+            const defaultPosition = this.editorEngine.canvas.getDefaultPanPosition();
+            const viewportCenterX = window.innerWidth / 2 - defaultPosition.x;
+            const viewportCenterY = window.innerHeight / 2 - defaultPosition.y;
+
+            this.editorEngine.canvas.position = {
+                x: viewportCenterX - frameCenterX * canvasScale,
+                y: viewportCenterY - frameCenterY * canvasScale,
+            };
+        } else {
+            this.editorEngine.canvas.position = this.editorEngine.canvas.getDefaultPanPosition();
+        }
+    };
 
     async handleWindowResized(): Promise<void> {
         try {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

- I did try the `IntersectionObserver`, but it's not efficient as the canvas container doesn't cover the frames.
- I'm calculating the position of each frame, using the state values we've.
- `getBoundingRect` is a possible solution, but accessing the DOM is quite expensive.
- We can increase the accuracy of detection by reducing the throttle duration, I did `200ms`.


## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

closes #2427 

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

https://github.com/user-attachments/assets/8a2f6f17-a0f3-42a8-a1e8-aa7f27c0bb4c


<!-- Add screenshots to help explain your changes -->

## Additional Notes


<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `RecenterCanvasButton` to recenter canvas when out of view, using throttled frame visibility checks.
> 
>   - **Feature**:
>     - Adds `RecenterCanvasButton` component to recenter the canvas when out of view in `index.tsx`.
>     - Uses `throttle` to check frame visibility every 200ms in `recenter-canvas-button.tsx`.
>     - Button appears if no frames are in the viewport and recenters canvas on click.
>   - **Behavior**:
>     - Calculates frame positions using state values instead of `IntersectionObserver` or `getBoundingRect`.
>     - Recenter logic centers the first frame or defaults to the canvas's default position.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 4c450a1e3240f04f7a5655514d376ebcb5fc865e. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->