### PR TITLE
feat: make drop type idempotent in migration

### DIFF
--- a/apps/backend/supabase/migrations/0014_military_marrow.sql
+++ b/apps/backend/supabase/migrations/0014_military_marrow.sql
@@ -15,7 +15,7 @@ ALTER TABLE "custom_domain_verification" RENAME COLUMN "domain_id" TO "custom_do
 ALTER TABLE "custom_domain_verification" RENAME COLUMN "verification_id" TO "freestyle_verification_id";--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" DROP CONSTRAINT "custom_domain_verification_domain_id_custom_domains_id_fk";
 --> statement-breakpoint
-DROP TYPE "public"."verification_request_status";--> statement-breakpoint
+DROP TYPE IF EXISTS "public"."verification_request_status";--> statement-breakpoint
 CREATE TYPE "public"."verification_request_status" AS ENUM('pending', 'verified', 'cancelled');--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ALTER COLUMN "status" SET DEFAULT 'pending';--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ADD COLUMN "full_domain" text NOT NULL;--> statement-breakpoint


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `DROP TYPE` operation idempotent in `0014_military_marrow.sql` migration by adding `IF EXISTS`.
> 
>   - **Migration Update**:
>     - In `0014_military_marrow.sql`, changed `DROP TYPE "public"."verification_request_status"` to `DROP TYPE IF EXISTS "public"."verification_request_status"` to make the operation idempotent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for ee6291536f7d9be4c2fca61f26dac7e56a1191ad. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->