### PR TITLE
fix: update type verification_request_status (#2453)

### DIFF
--- a/apps/backend/supabase/migrations/0010_bent_edwin_jarvis.sql
+++ b/apps/backend/supabase/migrations/0010_bent_edwin_jarvis.sql
@@ -1,5 +1,5 @@
 -- Create new type
-CREATE TYPE "public"."verification_request_status" AS ENUM('active', 'expired', 'used');--> statement-breakpoint
+CREATE TYPE "public"."verification_request_status" AS ENUM('pending', 'verified', 'cancelled');--> statement-breakpoint
 CREATE TABLE "custom_domains" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"apex_domain" text NOT NULL,
@@ -37,7 +37,7 @@ CREATE TABLE "custom_domain_verification" (
 	"verification_code" text NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"status" "verification_request_status" DEFAULT 'active' NOT NULL
+	"status" "verification_request_status" DEFAULT 'pending' NOT NULL
 );
 --> statement-breakpoint
 ALTER TABLE "preview_domains" ADD CONSTRAINT "preview_domains_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint

--- a/apps/backend/supabase/migrations/0011_typical_clea.sql
+++ b/apps/backend/supabase/migrations/0011_typical_clea.sql
@@ -64,8 +64,6 @@ ALTER TABLE "custom_domains" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 ALTER TABLE "preview_domains" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 ALTER TABLE "published_domains" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
-ALTER TABLE "custom_domain_verification" ALTER COLUMN "status" SET DATA TYPE "public"."verification_request_status";--> statement-breakpoint
-ALTER TABLE "custom_domain_verification" ALTER COLUMN "status" SET DEFAULT 'active';--> statement-breakpoint
 ALTER TABLE "messages" ADD COLUMN "commit_oid" text;--> statement-breakpoint
 ALTER TABLE "user_settings" ADD COLUMN "should_warn_delete" boolean DEFAULT true NOT NULL;--> statement-breakpoint
 ALTER TABLE "project_settings" ADD CONSTRAINT "project_settings_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint

--- a/apps/backend/supabase/migrations/0014_military_marrow.sql
+++ b/apps/backend/supabase/migrations/0014_military_marrow.sql
@@ -15,9 +15,6 @@ ALTER TABLE "custom_domain_verification" RENAME COLUMN "domain_id" TO "custom_do
 ALTER TABLE "custom_domain_verification" RENAME COLUMN "verification_id" TO "freestyle_verification_id";--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" DROP CONSTRAINT "custom_domain_verification_domain_id_custom_domains_id_fk";
 --> statement-breakpoint
-DROP TYPE IF EXISTS "public"."verification_request_status";--> statement-breakpoint
-CREATE TYPE "public"."verification_request_status" AS ENUM('pending', 'verified', 'cancelled');--> statement-breakpoint
-ALTER TABLE "custom_domain_verification" ALTER COLUMN "status" SET DEFAULT 'pending';--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ADD COLUMN "full_domain" text NOT NULL;--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ADD COLUMN "txt_record" jsonb NOT NULL;--> statement-breakpoint
 ALTER TABLE "custom_domain_verification" ADD COLUMN "a_records" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
I manually modified the SQL queries to resolve the following issues.
```
│ ERROR: cannot drop type verification_request_status because other objects depend on it (SQLSTATE 2BP01)
│ column status of table custom_domain_verification depends on type verification_request_status          
│ At statement: 7                                                                                        
│ --> statement-breakpoint                                                                               
│ DROP TYPE IF EXISTS "public"."verification_request_status"                                             
│ Try rerunning the command with --debug to troubleshoot the error.
```

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
https://github.com/onlook-dev/onlook/issues/2453

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `verification_request_status` ENUM and default values in SQL migrations to resolve dependency issues.
> 
>   - **SQL Migrations**:
>     - Update `verification_request_status` ENUM in `0010_bent_edwin_jarvis.sql` to ('pending', 'verified', 'cancelled').
>     - Change default `status` in `custom_domain_verification` table to 'pending'.
>     - Remove redundant type alterations in `0011_typical_clea.sql` and `0014_military_marrow.sql`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 0e6af1b6f3ca5697b43e9fe6c3ad83c9522c480b. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->