### PR TITLE
fix: font checking too early

### DIFF
--- a/apps/web/client/src/components/store/editor/font/index.ts
+++ b/apps/web/client/src/components/store/editor/font/index.ts
@@ -41,14 +41,8 @@ export class FontManager {
                 if (isIndexedFiles) {
                     await this.loadInitialFonts();
                     await this.getDefaultFont();
+                    await this.syncFontsWithConfigs();
                 }
-            },
-        );
-
-        reaction(
-            () => this.editorEngine.sandbox.readFile(this.fontConfigManager.fontConfigPath),
-            async () => {
-                await this.syncFontsWithConfigs();
             },
         );
     }
@@ -62,12 +56,6 @@ export class FontManager {
     }
 
     async scanFonts(): Promise<Font[]> {
-        const sandbox = this.editorEngine.sandbox;
-        if (!sandbox) {
-            console.error('No sandbox session found');
-            return [];
-        }
-
         this._isScanning = true;
         try {
             // Scan existing fonts and move them to config


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes redundant font configuration check in `FontManager`, ensuring synchronization only after initial font loading and default font retrieval.
> 
>   - **Behavior**:
>     - Removes redundant `reaction` in `FontManager` that checked font configurations too early.
>     - Ensures `syncFontsWithConfigs()` is called only after `loadInitialFonts()` and `getDefaultFont()`.
>   - **Code Simplification**:
>     - Deletes `reaction` that triggered `syncFontsWithConfigs()` based on `fontConfigPath` changes.
>     - Removes unnecessary sandbox check in `scanFonts()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 027471b4e840170b3399fca2b6bdb43b38b27062. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->