### PR TITLE
Fix for login button loading states

### DIFF
--- a/apps/web/client/src/app/_components/login-button.tsx
+++ b/apps/web/client/src/app/_components/login-button.tsx
@@ -12,18 +12,24 @@ export const GithubLoginButton = ({
     className?: string;
 }) => {
     const t = useTranslations();
-    const { lastSignInMethod, handleLogin, isPending } = useAuthContext();
+    const { lastSignInMethod, handleLogin, signingInMethod } = useAuthContext();
     const isLastSignInMethod = lastSignInMethod === SignInMethod.GITHUB;
+    const isSigningIn = signingInMethod === SignInMethod.GITHUB;
 
     return (
         <div className={cn('flex flex-col items-center w-full', className)}>
             <Button
                 variant="outline"
-                className={`w-full items-center justify-center text-active text-small ${isLastSignInMethod ? 'bg-teal-100 dark:bg-teal-950 border-teal-300 dark:border-teal-700 text-teal-900 dark:text-teal-100 text-small hover:bg-teal-200/50 dark:hover:bg-teal-800 hover:border-teal-500/70 dark:hover:border-teal-500' : 'bg-background-onlook'}`}
+                className={cn(
+                    'w-full items-center justify-center text-active text-small',
+                    isLastSignInMethod
+                        ? 'bg-teal-100 dark:bg-teal-950 border-teal-300 dark:border-teal-700 text-teal-900 dark:text-teal-100 text-small hover:bg-teal-200/50 dark:hover:bg-teal-800 hover:border-teal-500/70 dark:hover:border-teal-500'
+                        : 'bg-background-onlook',
+                )}
                 onClick={() => handleLogin(SignInMethod.GITHUB)}
-                disabled={isPending}
+                disabled={!!signingInMethod}
             >
-                {isPending && isLastSignInMethod ? (
+                {isSigningIn ? (
                     <Icons.LoadingSpinner className="w-4 h-4 mr-2 animate-spin" />
                 ) : (
                     <Icons.GitHubLogo className="w-4 h-4 mr-2" />
@@ -43,18 +49,24 @@ export const GoogleLoginButton = ({
     className?: string;
 }) => {
     const t = useTranslations();
-    const { lastSignInMethod, handleLogin, isPending } = useAuthContext();
+    const { lastSignInMethod, handleLogin, signingInMethod } = useAuthContext();
     const isLastSignInMethod = lastSignInMethod === SignInMethod.GOOGLE;
+    const isSigningIn = signingInMethod === SignInMethod.GOOGLE;
 
     return (
         <div className={cn('flex flex-col items-center w-full', className)}>
             <Button
                 variant="outline"
-                className={`w-full items-center justify-center text-active text-small ${isLastSignInMethod ? 'bg-teal-100 dark:bg-teal-950 border-teal-300 dark:border-teal-700 text-teal-900 dark:text-teal-100 text-small hover:bg-teal-200/50 dark:hover:bg-teal-800 hover:border-teal-500/70 dark:hover:border-teal-500' : 'bg-background-onlook'}`}
+                className={cn(
+                    'w-full items-center justify-center text-active text-small',
+                    isLastSignInMethod
+                        ? 'bg-teal-100 dark:bg-teal-950 border-teal-300 dark:border-teal-700 text-teal-900 dark:text-teal-100 text-small hover:bg-teal-200/50 dark:hover:bg-teal-800 hover:border-teal-500/70 dark:hover:border-teal-500'
+                        : 'bg-background-onlook',
+                )}
                 onClick={() => handleLogin(SignInMethod.GOOGLE)}
-                disabled={isPending}
+                disabled={!!signingInMethod}
             >
-                {isPending && isLastSignInMethod ? (
+                {isSigningIn ? (
                     <Icons.LoadingSpinner className="w-4 h-4 mr-2 animate-spin" />
                 ) : (
                     <Icons.GoogleLogo viewBox="0 0 24 24" className="w-4 h-4 mr-2" />
@@ -67,3 +79,26 @@ export const GoogleLoginButton = ({
         </div>
     );
 };
+
+export const DevLoginButton = ({
+    className,
+}: {
+    className?: string;
+}) => {
+    const t = useTranslations();
+    const { handleDevLogin, signingInMethod } = useAuthContext();
+    const isSigningIn = signingInMethod === SignInMethod.DEV;
+
+    return (
+        <Button
+            variant="outline"
+            className="w-full text-active text-small"
+            onClick={handleDevLogin}
+            disabled={!!signingInMethod}
+        >
+            {isSigningIn ? (
+                <Icons.LoadingSpinner className="w-4 h-4 mr-2 animate-spin" />
+            ) : 'DEV MODE: Sign in as demo user'}
+        </Button>
+    )
+}

--- a/apps/web/client/src/app/auth/auth-context.tsx
+++ b/apps/web/client/src/app/auth/auth-context.tsx
@@ -9,11 +9,11 @@ import { devLogin, login } from '../login/actions';
 const LAST_SIGN_IN_METHOD_KEY = 'lastSignInMethod';
 
 interface AuthContextType {
-    isPending: boolean;
+    signingInMethod: SignInMethod | null;
     lastSignInMethod: SignInMethod | null;
     isAuthModalOpen: boolean;
     setIsAuthModalOpen: (open: boolean) => void;
-    handleLogin: (method: SignInMethod) => void;
+    handleLogin: (method: SignInMethod.GITHUB | SignInMethod.GOOGLE) => void;
     handleDevLogin: () => void;
 }
 
@@ -21,34 +21,35 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const [lastSignInMethod, setLastSignInMethod] = useState<SignInMethod | null>(null);
-    const [isPending, setIsPending] = useState(false);
+    const [signingInMethod, setSigningInMethod] = useState<SignInMethod | null>(null);
     const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+
     useEffect(() => {
         localforage.getItem(LAST_SIGN_IN_METHOD_KEY).then((lastSignInMethod: unknown) => {
             setLastSignInMethod(lastSignInMethod as SignInMethod | null);
         });
     }, []);
 
-    const handleLogin = async (method: SignInMethod) => {
-        setIsPending(true);
+    const handleLogin = async (method: SignInMethod.GITHUB | SignInMethod.GOOGLE) => {
+        setSigningInMethod(method);
         await login(method);
 
         localforage.setItem(LAST_SIGN_IN_METHOD_KEY, method);
         setTimeout(() => {
-            setIsPending(false);
+            setSigningInMethod(null);
         }, 5000);
     };
 
     const handleDevLogin = async () => {
-        setIsPending(true);
+        setSigningInMethod(SignInMethod.DEV);
         await devLogin();
         setTimeout(() => {
-            setIsPending(false);
+            setSigningInMethod(null);
         }, 5000);
     }
 
     return (
-        <AuthContext.Provider value={{ isPending, lastSignInMethod, handleLogin, handleDevLogin, isAuthModalOpen, setIsAuthModalOpen }}>
+        <AuthContext.Provider value={{ signingInMethod, lastSignInMethod, handleLogin, handleDevLogin, isAuthModalOpen, setIsAuthModalOpen }}>
             {children}
         </AuthContext.Provider>
     );

--- a/apps/web/client/src/app/login/actions.tsx
+++ b/apps/web/client/src/app/login/actions.tsx
@@ -6,7 +6,7 @@ import { SignInMethod } from '@onlook/models';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-export async function login(provider: SignInMethod) {
+export async function login(provider: SignInMethod.GITHUB | SignInMethod.GOOGLE) {
     const supabase = await createClient();
     const origin = (await headers()).get('origin');
 

--- a/apps/web/client/src/app/login/page.tsx
+++ b/apps/web/client/src/app/login/page.tsx
@@ -8,7 +8,7 @@ import { Icons } from '@onlook/ui/icons';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import Link from 'next/link';
-import { GithubLoginButton, GoogleLoginButton } from '../_components/login-button';
+import { DevLoginButton, GithubLoginButton, GoogleLoginButton } from '../_components/login-button';
 import { useAuthContext } from '../auth/auth-context';
 
 export default function LoginPage() {
@@ -41,11 +41,7 @@ export default function LoginPage() {
                         <GithubLoginButton />
                         <GoogleLoginButton />
                     </div>
-                    {isDev && (
-                        <Button variant="outline" className="w-full text-active text-small" onClick={handleDevLogin}>
-                            DEV MODE: Sign in as demo user
-                        </Button>
-                    )}
+                    {isDev && <DevLoginButton />}
                     <p className="text-small text-foreground-onlook">
                         {t(transKeys.welcome.terms.agreement)}{' '}
                         <Link

--- a/packages/models/src/auth/index.ts
+++ b/packages/models/src/auth/index.ts
@@ -1,4 +1,5 @@
 export enum SignInMethod {
     GITHUB = 'github',
     GOOGLE = 'google',
+    DEV = 'dev',
 }


### PR DESCRIPTION
## Description

Fixes both auth login buttons from showing loading animation when either one is actually loading

## Related Issues

No related issues

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

simple fix, tests aren't required 

## Screenshots (if applicable)

Neither are screenshots

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes loading animation in `GithubLoginButton` and `GoogleLoginButton` to show only for the last sign-in method.
> 
>   - **Behavior**:
>     - Fixes loading animation in `GithubLoginButton` and `GoogleLoginButton` in `login-button.tsx` to show only when the respective button is the last sign-in method.
>     - Uses `isPending && isLastSignInMethod` condition to control loading spinner visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 3d7657ea364b990bf1e4638c75ad67693567209f. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->