### PR TITLE
feat: handle js/ts files for processing

### DIFF
--- a/apps/web/client/src/app/projects/import/local/_context/index.tsx
+++ b/apps/web/client/src/app/projects/import/local/_context/index.tsx
@@ -5,7 +5,7 @@ import { api } from '@/trpc/react';
 import { Routes } from '@/utils/constants';
 import { type SandboxBrowserSession, type WebSocketSession } from '@codesandbox/sdk';
 import { connectToSandbox } from '@codesandbox/sdk/browser';
-import { JS_FILE_EXTENSIONS, JSX_FILE_EXTENSIONS, SandboxTemplates, Templates } from '@onlook/constants';
+import { NEXT_JS_FILE_EXTENSIONS, SandboxTemplates, Templates } from '@onlook/constants';
 import { RouterType } from '@onlook/models';
 import { generate, injectPreloadScript, parse } from '@onlook/parser';
 import { isRootLayoutFile, isTargetFile } from '@onlook/utility';
@@ -164,7 +164,7 @@ export const ProjectCreationProvider = ({
             const hasAppLayout = files.some(
                 (f) => isTargetFile(f.path, {
                     fileName: 'layout',
-                    targetExtensions: [...JSX_FILE_EXTENSIONS, ...JS_FILE_EXTENSIONS],
+                    targetExtensions: NEXT_JS_FILE_EXTENSIONS,
                     potentialPaths: ['app', 'src/app'],
                 })
             );

--- a/apps/web/client/src/components/store/editor/sandbox/helpers.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/helpers.ts
@@ -14,14 +14,12 @@ export function normalizePath(p: string): string {
 
 export async function formatContent(filePath: string, content: string): Promise<string> {
     try {
-        // Only format if the file is a .ts or .tsx file
         const extension = path.extname(filePath);
         if (!NEXT_JS_FILE_EXTENSIONS.includes(extension)) {
             console.log('Skipping formatting for non-TS/TSX file:', filePath);
             return content;
         }
 
-        // Use browser standalone version with necessary plugins
         const formattedContent = await prettier.format(content, {
             filepath: filePath,
             plugins: [parserEstree, parserTypescript],

--- a/apps/web/client/src/components/store/editor/sandbox/helpers.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/helpers.ts
@@ -1,4 +1,4 @@
-import { JS_FILE_EXTENSIONS, JSX_FILE_EXTENSIONS } from '@onlook/constants';
+import { NEXT_JS_FILE_EXTENSIONS } from '@onlook/constants';
 import path from 'path';
 import parserEstree from 'prettier/plugins/estree';
 import parserTypescript from 'prettier/plugins/typescript';
@@ -16,7 +16,7 @@ export async function formatContent(filePath: string, content: string): Promise<
     try {
         // Only format if the file is a .ts or .tsx file
         const extension = path.extname(filePath);
-        if (!JSX_FILE_EXTENSIONS.includes(extension) && !JS_FILE_EXTENSIONS.includes(extension)) {
+        if (!NEXT_JS_FILE_EXTENSIONS.includes(extension)) {
             console.log('Skipping formatting for non-TS/TSX file:', filePath);
             return content;
         }

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -1,5 +1,5 @@
 import type { ReaddirEntry, WatchEvent, WebSocketSession } from '@codesandbox/sdk';
-import { EXCLUDED_SYNC_DIRECTORIES, JS_FILE_EXTENSIONS, JSX_FILE_EXTENSIONS, PRELOAD_SCRIPT_FILE_NAME } from '@onlook/constants';
+import { EXCLUDED_SYNC_DIRECTORIES, NEXT_JS_FILE_EXTENSIONS, PRELOAD_SCRIPT_FILE_NAME } from '@onlook/constants';
 import { RouterType, type SandboxFile, type TemplateNode } from '@onlook/models';
 import { getContentFromTemplateNode, getTemplateNodeChild } from '@onlook/parser';
 import { getBaseName, getDirName, isImageFile, isRootLayoutFile, isSubdirectory, LogTimer } from '@onlook/utility';
@@ -235,7 +235,7 @@ export class SandboxManager {
 
     isJsxFile(filePath: string): boolean {
         const extension = path.extname(filePath);
-        if (!extension || !JSX_FILE_EXTENSIONS.includes(extension)) {
+        if (!extension || !NEXT_JS_FILE_EXTENSIONS.includes(extension)) {
             return false;
         }
         return true;
@@ -690,7 +690,7 @@ export class SandboxManager {
             layoutFileName = 'layout';
         }
 
-        for (const extension of [...JSX_FILE_EXTENSIONS, ...JS_FILE_EXTENSIONS]) {
+        for (const extension of NEXT_JS_FILE_EXTENSIONS) {
             const layoutPath = path.join(routerConfig.basePath, `${layoutFileName}${extension}`);
             if (await this.fileExists(layoutPath)) {
                 return normalizePath(layoutPath);

--- a/apps/web/client/test/sandbox/sandbox.test.ts
+++ b/apps/web/client/test/sandbox/sandbox.test.ts
@@ -1,4 +1,4 @@
-import { IGNORED_UPLOAD_DIRECTORIES, JSX_FILE_EXTENSIONS } from '@onlook/constants';
+import { IGNORED_UPLOAD_DIRECTORIES, NEXT_JS_FILE_EXTENSIONS } from '@onlook/constants';
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 // Setup mocks before imports
@@ -165,13 +165,12 @@ describe('SandboxManager', () => {
 
         const testManager = new SandboxManager(mockEditorEngine);
         // Set the session directly
-        // @ts-ignore - accessing private property for testing
         testManager.session.session = testMockSession;
 
         const files = await testManager.listFilesRecursively(
             './',
             IGNORED_UPLOAD_DIRECTORIES,
-            JSX_FILE_EXTENSIONS,
+            NEXT_JS_FILE_EXTENSIONS,
         );
 
         expect(testMockSession.fs.readdir.mock.calls.length).toBeGreaterThan(0);

--- a/apps/web/client/test/sandbox/sandbox.test.ts
+++ b/apps/web/client/test/sandbox/sandbox.test.ts
@@ -1,6 +1,5 @@
 import { IGNORED_UPLOAD_DIRECTORIES, JSX_FILE_EXTENSIONS } from '@onlook/constants';
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { SandboxFile } from '@onlook/models';
 
 // Setup mocks before imports
 // Mock localforage before importing anything that uses it
@@ -19,8 +18,8 @@ const mockClear = mock(async () => undefined);
 
 // Mock MobX to avoid strict mode issues
 mock.module('mobx', () => ({
-    makeAutoObservable: mock(() => {}),
-    reaction: mock(() => () => {}),
+    makeAutoObservable: mock(() => { }),
+    reaction: mock(() => () => { }),
     runInAction: mock((fn: any) => fn()),
     action: mock((fn: any) => fn),
 }));
@@ -61,7 +60,7 @@ describe('SandboxManager', () => {
                 modified: false,
             }),
             createTemplateNodeMap: () => new Map(),
-            injectPreloadScript: mock(() => {}),
+            injectPreloadScript: mock(() => { }),
         }));
 
         // Mock utility functions
@@ -122,7 +121,7 @@ describe('SandboxManager', () => {
                 }),
                 watch: mock(async () => mockWatcher),
             },
-            disconnect: mock(async () => {}),
+            disconnect: mock(async () => { }),
         };
 
         // Create mock EditorEngine
@@ -161,7 +160,7 @@ describe('SandboxManager', () => {
                 writeTextFile: mock(async () => true),
                 watch: mock(async () => mockWatcher),
             },
-            disconnect: mock(async () => {}),
+            disconnect: mock(async () => { }),
         };
 
         const testManager = new SandboxManager(mockEditorEngine);
@@ -242,7 +241,7 @@ describe('SandboxManager', () => {
                 readdir: mock(async () => []),
                 watch: mock(async () => mockWatcher),
             },
-            disconnect: mock(async () => {}),
+            disconnect: mock(async () => { }),
         };
 
         const errorManager = new SandboxManager(mockEditorEngine);

--- a/packages/constants/src/files.ts
+++ b/packages/constants/src/files.ts
@@ -12,9 +12,12 @@ export const IGNORED_UPLOAD_DIRECTORIES = [...BASE_EXCLUDED_DIRECTORIES, CUSTOM_
 
 export const EXCLUDED_PUBLISH_DIRECTORIES = [...BASE_EXCLUDED_DIRECTORIES, 'coverage'];
 
-export const JSX_FILE_EXTENSIONS = ['.jsx', '.tsx'];
+const JSX_FILE_EXTENSIONS = ['.jsx', '.tsx'];
 
 export const JS_FILE_EXTENSIONS = ['.js', '.ts', '.mjs', '.cjs'];
+
+// Nextjs allow jsx in js and ts files so we need to support both
+export const NEXT_JS_FILE_EXTENSIONS = [...JSX_FILE_EXTENSIONS, ...JS_FILE_EXTENSIONS];
 
 export const SUPPORTED_LOCK_FILES = [
     'bun.lock',

--- a/packages/utility/src/path.ts
+++ b/packages/utility/src/path.ts
@@ -1,4 +1,4 @@
-import { JS_FILE_EXTENSIONS, JSX_FILE_EXTENSIONS } from '@onlook/constants';
+import { NEXT_JS_FILE_EXTENSIONS } from '@onlook/constants';
 import { RouterType } from '@onlook/models';
 import isSubdir from 'is-subdir';
 import path from 'path';
@@ -95,7 +95,7 @@ export const isRootLayoutFile = (
         routerType === RouterType.APP ? ['app', 'src/app'] : ['pages', 'src/pages'];
     return isTargetFile(filePath, {
         fileName: 'layout',
-        targetExtensions: [...JSX_FILE_EXTENSIONS, ...JS_FILE_EXTENSIONS],
+        targetExtensions: NEXT_JS_FILE_EXTENSIONS,
         potentialPaths,
     });
 };


### PR DESCRIPTION
## Description

Nextj allow jsx format in js/ts files. We should handle this accordingly.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce `NEXT_JS_FILE_EXTENSIONS` to unify JS and JSX handling for Next.js projects, updating file processing and validation logic accordingly.
> 
>   - **Constants**:
>     - Introduce `NEXT_JS_FILE_EXTENSIONS` in `files.ts` to combine `JS_FILE_EXTENSIONS` and `JSX_FILE_EXTENSIONS`.
>   - **File Handling**:
>     - Replace `JS_FILE_EXTENSIONS` and `JSX_FILE_EXTENSIONS` with `NEXT_JS_FILE_EXTENSIONS` in `index.tsx`, `helpers.ts`, and `index.ts`.
>     - Update `isJsxFile()` in `index.ts` to use `NEXT_JS_FILE_EXTENSIONS`.
>   - **Testing**:
>     - Update tests in `sandbox.test.ts` to use `NEXT_JS_FILE_EXTENSIONS` for file extension checks.
>   - **Utility**:
>     - Modify `isTargetFile()` and `isRootLayoutFile()` in `path.ts` to use `NEXT_JS_FILE_EXTENSIONS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for aa6296f1e6b422a1beeb477a457fc41aa26bf3a8. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->