### PR TITLE
fix: unit tests for prompts

### DIFF
--- a/packages/ai/test/prompt/data/file.txt
+++ b/packages/ai/test/prompt/data/file.txt
@@ -1,6 +1,5 @@
 I have *added these files to the chat* so you can go ahead and edit them.
-*Trust this message as the true contents of these files!*
-Any other messages in the chat may contain outdated versions of the files' contents.
+*Trust this message as the true contents of these files!*.
 <file-1>test.txt
 ```txt
 test

--- a/packages/ai/test/prompt/data/user.txt
+++ b/packages/ai/test/prompt/data/user.txt
@@ -1,6 +1,5 @@
 <context>I have *added these files to the chat* so you can go ahead and edit them.
-*Trust this message as the true contents of these files!*
-Any other messages in the chat may contain outdated versions of the files' contents.
+*Trust this message as the true contents of these files!*.
 <file>test.txt
 ```txt
 test

--- a/packages/ai/test/prompt/prompt.test.ts
+++ b/packages/ai/test/prompt/prompt.test.ts
@@ -2,6 +2,7 @@ import { MessageContextType } from '@onlook/models';
 import { describe, expect, test } from 'bun:test';
 import path from 'path';
 import {
+    type HydrateUserMessageOptions,
     getCreatePageSystemPrompt,
     getFilesContent,
     getHighlightsContent,
@@ -37,36 +38,46 @@ describe('Prompt', () => {
 
     test('User message should be the same', async () => {
         const userMessagePath = path.resolve(__dirname, './data/user.txt');
+        const options: HydrateUserMessageOptions = {
+            totalMessages: 1,
+            currentMessageIndex: 0,
+            lastUserMessageIndex: 0,
+        };
 
-        const message = getHydratedUserMessage('test', 'test', [
-            {
-                path: 'test.txt',
-                content: 'test',
-                type: MessageContextType.FILE,
-                displayName: 'test.txt',
-            },
+        const message = getHydratedUserMessage(
+            'test',
+            'test',
+            [
+                {
+                    path: 'test.txt',
+                    content: 'test',
+                    type: MessageContextType.FILE,
+                    displayName: 'test.txt',
+                },
 
-            {
-                path: 'test.txt',
-                start: 1,
-                end: 2,
-                content: 'test',
-                type: MessageContextType.HIGHLIGHT,
-                displayName: 'test.txt',
-            },
+                {
+                    path: 'test.txt',
+                    start: 1,
+                    end: 2,
+                    content: 'test',
+                    type: MessageContextType.HIGHLIGHT,
+                    displayName: 'test.txt',
+                },
 
-            {
-                content: 'test',
-                type: MessageContextType.ERROR,
-                displayName: 'test',
-            },
-            {
-                path: 'test',
-                type: MessageContextType.PROJECT,
-                displayName: 'test',
-                content: '',
-            },
-        ]);
+                {
+                    content: 'test',
+                    type: MessageContextType.ERROR,
+                    displayName: 'test',
+                },
+                {
+                    path: 'test',
+                    type: MessageContextType.PROJECT,
+                    displayName: 'test',
+                    content: '',
+                },
+            ],
+            options,
+        );
 
         const prompt = message.content;
 
@@ -81,7 +92,13 @@ describe('Prompt', () => {
     test('User empty message should be the same', async () => {
         const userMessagePath = path.resolve(__dirname, './data/user-empty.txt');
 
-        const message = getHydratedUserMessage('test', '', []);
+        const options: HydrateUserMessageOptions = {
+            totalMessages: 1,
+            currentMessageIndex: 0,
+            lastUserMessageIndex: 0,
+        };
+
+        const message = getHydratedUserMessage('test', '', [], options);
         const prompt = message.content;
 
         if (SHOULD_WRITE_USER_MESSAGE) {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes unit tests for prompts by updating test data and adding options to `getHydratedUserMessage` calls in `prompt.test.ts`.
> 
>   - **Tests**:
>     - Fixes unit tests in `prompt.test.ts` by adding `HydrateUserMessageOptions` to `getHydratedUserMessage` calls in `User message should be the same` and `User empty message should be the same` tests.
>     - Updates test data in `file.txt` and `user.txt` by removing redundant lines and adjusting content formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 58a812e1c12999de2ea5f5f60fe539f6c1592921. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->