### PR TITLE
Fix: Persist prompt and image input on initial login redirects

### DIFF
--- a/apps/web/client/src/app/auth/auth-context.tsx
+++ b/apps/web/client/src/app/auth/auth-context.tsx
@@ -30,7 +30,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
     const handleLogin = async (method: SignInMethod) => {
         setIsPending(true);
-        await login(method);
+        const returnUrl = localStorage.getItem('returnUrl') || '/';
+        await login(method, returnUrl);
 
         localforage.setItem(LAST_SIGN_IN_METHOD_KEY, method);
         setTimeout(() => {

--- a/apps/web/client/src/app/login/actions.tsx
+++ b/apps/web/client/src/app/login/actions.tsx
@@ -6,9 +6,14 @@ import { SignInMethod } from '@onlook/models';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-export async function login(provider: SignInMethod) {
+export async function login(provider: SignInMethod, returnUrl?: string) {
     const supabase = await createClient();
-    const origin = (await headers()).get('origin');
+    const headersList = await headers();
+    let origin = headersList.get('origin');
+    
+    const redirectTo = returnUrl
+        ? `${origin}/auth/callback?returnUrl=${encodeURIComponent(returnUrl)}`
+        : `${origin}/auth/callback`;
 
     // If already session, redirect
     const {


### PR DESCRIPTION
## Description

After login, users are redirected to the correct local page, and any draft prompt/images are restored and auto-submitted.

## Related Issues

fixes #2517

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

Tested locally on my computer

## Additional
After logged in using GitHub it was redirecting to onlook.com from localhost, so I have modify the supabase config.toml
additional_redirect_urls = [
    "http://localhost:3000",
    "http://localhost:3000/auth/callback",
    "http://localhost:3000/auth/callback?returnUrl=%2F"
]
added another url in the additional_redirect_url

## Screenshots (if applicable)

https://github.com/user-attachments/assets/61542da7-5c36-44e1-b3a8-bc057a24ae30


