### PR TITLE
refactor: move script strategy to afterInteractive

### DIFF
--- a/apps/web/client/src/app/layout.tsx
+++ b/apps/web/client/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             </head>
             <body>
                 {isProduction && (
-                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="afterInteractive" />
+                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="lazyOnload" />
                 )}
                 <TRPCReactProvider>
                     <FeatureFlagsProvider>

--- a/apps/web/client/src/app/layout.tsx
+++ b/apps/web/client/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             </head>
             <body>
                 {isProduction && (
-                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="beforeInteractive" />
+                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="afterInteractive" />
                 )}
                 <TRPCReactProvider>
                     <FeatureFlagsProvider>

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/opacity.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/opacity.tsx
@@ -84,7 +84,7 @@ export const Opacity = observer(() => {
                         />
                         <span
                             onClick={(e) => e.stopPropagation()}
-                            className="pr-2 cursor-text text-muted-foreground text-xs pointer-events-none select-none bg-transparent group-hover:text-foreground-primary transition-colors duration-150">
+                            className="pr-2 text-muted-foreground text-xs bg-transparent">
                             %
                         </span>
                     </ToolbarButton>

--- a/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/opacity.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/editor-bar/dropdowns/opacity.tsx
@@ -82,7 +82,9 @@ export const Opacity = observer(() => {
                             className="w-14 text-left data-[state=open]:text-white text-small focus:text-foreground-primary focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none !bg-transparent border-none group-hover:text-foreground-primary focus:ring-0 focus:outline-none text-muted-foreground !hide-spin-buttons no-focus-ring [appearance:textfield] group-hover:text-foreground-primary transition-colors duration-150 hover"
                             aria-label="Opacity percentage"
                         />
-                        <span className="pr-2 cursor-text text-muted-foreground text-xs pointer-events-none select-none bg-transparent group-hover:text-foreground-primary transition-colors duration-150">
+                        <span
+                            onClick={(e) => e.stopPropagation()}
+                            className="pr-2 cursor-text text-muted-foreground text-xs pointer-events-none select-none bg-transparent group-hover:text-foreground-primary transition-colors duration-150">
                             %
                         </span>
                     </ToolbarButton>

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <html lang="en" className={inter.variable} suppressHydrationWarning>
             <body className="flex flex-col min-h-screen">
                 {isProduction && (
-                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="beforeInteractive" />
+                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="afterInteractive" />
                 )}
                 <RootProvider>
                     <DocsLayout tree={source.pageTree} {...docsOptions}>

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         <html lang="en" className={inter.variable} suppressHydrationWarning>
             <body className="flex flex-col min-h-screen">
                 {isProduction && (
-                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="afterInteractive" />
+                    <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="lazyOnload" />
                 )}
                 <RootProvider>
                     <DocsLayout tree={source.pageTree} {...docsOptions}>

--- a/packages/parser/src/code-edit/layout.ts
+++ b/packages/parser/src/code-edit/layout.ts
@@ -112,7 +112,7 @@ function getPreloadScript(): T.JSXElement {
             t.jsxIdentifier('Script'),
             [
                 t.jsxAttribute(t.jsxIdentifier('src'), t.stringLiteral(`${PRELOAD_SCRIPT_SRC}`)),
-                t.jsxAttribute(t.jsxIdentifier('strategy'), t.stringLiteral('beforeInteractive')),
+                t.jsxAttribute(t.jsxIdentifier('strategy'), t.stringLiteral('afterInteractive')),
                 t.jsxAttribute(t.jsxIdentifier('type'), t.stringLiteral('module')),
                 t.jsxAttribute(t.jsxIdentifier('id'), t.stringLiteral(PRELOAD_SCRIPT_SRC)),
             ],

--- a/packages/parser/test/data/layout/adds-script-if-missing/expected.tsx
+++ b/packages/parser/test/data/layout/adds-script-if-missing/expected.tsx
@@ -7,6 +7,6 @@ import Script from "next/script";export default function Document() {
             <body>
                 <main />
             
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
         </html>);}

--- a/packages/parser/test/data/layout/creates-body/expected.tsx
+++ b/packages/parser/test/data/layout/creates-body/expected.tsx
@@ -1,4 +1,4 @@
 import Script from "next/script";export default function Document() {
   return <html>
-    <body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script></body>
+    <body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script></body>
   </html>;}

--- a/packages/parser/test/data/layout/does-not-duplicate/expected.tsx
+++ b/packages/parser/test/data/layout/does-not-duplicate/expected.tsx
@@ -5,15 +5,15 @@ export default function Document() {
     <html>
             <head>
                 <title>Test</title>
-                <Script type="module" src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" />
+                <Script type="module" src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" />
             </head>
             <body>
                 <main />
                 <Script
           type="module"
-          src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"
+          src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"
           id="onlook-preload-script"
-          strategy="beforeInteractive" />
+          strategy="afterInteractive" />
 
             </body>
         </html>);

--- a/packages/parser/test/data/layout/does-not-duplicate/input.tsx
+++ b/packages/parser/test/data/layout/does-not-duplicate/input.tsx
@@ -5,15 +5,15 @@ export default function Document() {
         <html>
             <head>
                 <title>Test</title>
-                <Script type="module" src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" />
+                <Script type="module" src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" />
             </head>
             <body>
                 <main />
                 <Script
                     type="module"
-                    src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"
+                    src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"
                     id="onlook-preload-script"
-                    strategy="beforeInteractive"
+                    strategy="afterInteractive"
                 />
             </body>
         </html>

--- a/packages/parser/test/data/layout/handles-self-closing-body/expected.tsx
+++ b/packages/parser/test/data/layout/handles-self-closing-body/expected.tsx
@@ -2,6 +2,6 @@ import Script from "next/script";export default function Document() {
   return (
     <html>
             <body>
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
         </html>);}

--- a/packages/parser/test/data/layout/handles-self-closing-html-head/expected.tsx
+++ b/packages/parser/test/data/layout/handles-self-closing-html-head/expected.tsx
@@ -1,5 +1,5 @@
 import React from 'react';import Script from "next/script";
 export default function Layout() {
   return <html>
-    <body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script></body>
+    <body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script></body>
   </html>;}

--- a/packages/parser/test/data/layout/injects-at-bottom/expected.tsx
+++ b/packages/parser/test/data/layout/injects-at-bottom/expected.tsx
@@ -6,6 +6,6 @@ export default function Layout() {
                 <main />
                 <footer />
             
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
         </html>);}

--- a/packages/parser/test/data/layout/injects-in-first-body/expected.tsx
+++ b/packages/parser/test/data/layout/injects-in-first-body/expected.tsx
@@ -3,7 +3,7 @@ export default function Layout() {
   return (
     <>
             <body>
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
             <body>
                 <main />

--- a/packages/parser/test/data/layout/injects-with-existing-head-script/expected.tsx
+++ b/packages/parser/test/data/layout/injects-with-existing-head-script/expected.tsx
@@ -9,6 +9,6 @@ export default function Layout() {
             <body>
                 <main />
             
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
         </html>);}

--- a/packages/parser/test/data/layout/preserves-body-props/expected.tsx
+++ b/packages/parser/test/data/layout/preserves-body-props/expected.tsx
@@ -5,6 +5,6 @@ export default function Layout() {
             <body className="custom">
                 <main />
             
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
         </html>);}

--- a/packages/parser/test/data/layout/removes-deprecated-script-multiple/expected.tsx
+++ b/packages/parser/test/data/layout/removes-deprecated-script-multiple/expected.tsx
@@ -38,6 +38,6 @@ export default function Document() {
                     <Footer data-oid="j7nr0na" />
                 </ThemeProvider>
             
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
         </html>);}

--- a/packages/parser/test/data/layout/removes-deprecated-script/expected.tsx
+++ b/packages/parser/test/data/layout/removes-deprecated-script/expected.tsx
@@ -9,6 +9,6 @@ export default function Document() {
             <body>
                 <main />
             
-        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+        <Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       </body>
         </html>);}

--- a/packages/parser/test/data/layout/wraps-conditional-ternary/expected.tsx
+++ b/packages/parser/test/data/layout/wraps-conditional-ternary/expected.tsx
@@ -1,4 +1,4 @@
 import React from 'react';import Script from "next/script";
 export default function Layout() {
-  return <html lang="en"><body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+  return <html lang="en"><body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       {true ? <div /> : <span />}</body></html>;}

--- a/packages/parser/test/data/layout/wraps-fragment-only/expected.tsx
+++ b/packages/parser/test/data/layout/wraps-fragment-only/expected.tsx
@@ -1,6 +1,6 @@
 import React from 'react';import Script from "next/script";
 export default function Layout() {
-  return <html lang="en"><body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+  return <html lang="en"><body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       <>
             <div>Header</div>
             <main />

--- a/packages/parser/test/data/layout/wraps-plain-children/expected.tsx
+++ b/packages/parser/test/data/layout/wraps-plain-children/expected.tsx
@@ -1,4 +1,4 @@
 import React from 'react';import Script from "next/script";
 export default function Layout({ children }: {children: React.ReactNode;}) {
-  return <html lang="en"><body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="beforeInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
+  return <html lang="en"><body><Script src="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js" strategy="afterInteractive" type="module" id="https://cdn.jsdelivr.net/gh/onlook-dev/onlook@main/apps/web/client/public/onlook-preload-script.js"></Script>
       {children}</body></html>;}

--- a/packages/parser/test/preload.test.ts
+++ b/packages/parser/test/preload.test.ts
@@ -333,7 +333,7 @@ describe('scanForPreloadScript', () => {
         const scriptWithoutSrc = t.jsxElement(
             t.jsxOpeningElement(
                 t.jsxIdentifier('Script'),
-                [t.jsxAttribute(t.jsxIdentifier('strategy'), t.stringLiteral('beforeInteractive'))],
+                [t.jsxAttribute(t.jsxIdentifier('strategy'), t.stringLiteral('afterInteractive'))],
                 false,
             ),
             t.jsxClosingElement(t.jsxIdentifier('Script')),


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [x] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor script loading strategy to `afterInteractive` or `lazyOnload` across application and parser, updating tests accordingly.
> 
>   - **Behavior**:
>     - Change script loading strategy from `beforeInteractive` to `lazyOnload` in `layout.tsx` and `docs/src/app/layout.tsx`.
>     - Change script loading strategy from `beforeInteractive` to `afterInteractive` in `code-edit/layout.ts`.
>   - **Tests**:
>     - Update expected test outputs in `adds-script-if-missing/expected.tsx`, `creates-body/expected.tsx`, and 10 other files to reflect new script strategy.
>     - Modify `preload.test.ts` to test for `afterInteractive` strategy and ensure deprecated scripts are removed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for bd504f02e6ade46437eb6cc9f3b06b277997cebc. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->