### PR TITLE
feat: retry penpal connection if failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+- This is a Bun workspace, only use bun, not npm
+- Unit tests can be ran with bun test


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds retry logic for Penpal connection in `web-frame.tsx` with exponential backoff and updates `CLAUDE.md` for Bun usage.
> 
>   - **Behavior**:
>     - Adds retry logic for Penpal connection in `web-frame.tsx` with `retrySetupPenpalConnection()` and updates `setupPenpalConnection()` to handle retries up to 3 times with exponential backoff.
>     - Reloads iframe after max retries are reached.
>   - **Misc**:
>     - Adds `CLAUDE.md` with instructions to use Bun for the workspace and running unit tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 8374f26322aed4fe5cdd475229881dbe3e0bb086. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->