### PR TITLE
fix: auto apply old request

### DIFF
--- a/apps/web/client/src/app/project/[id]/_hooks/use-start-project.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-start-project.tsx
@@ -16,12 +16,17 @@ export const useStartProject = () => {
     const [error, setError] = useState<string | null>(null);
 
     const { tabState } = useTabActive();
+    const apiUtils = api.useUtils();
     const { data: user, isLoading: isUserLoading, error: userError } = api.user.get.useQuery();
     const { data: project, isLoading: isProjectLoading, error: projectError } = api.project.get.useQuery({ projectId: editorEngine.projectId });
     const { data: canvasWithFrames, isLoading: isCanvasLoading, error: canvasError } = api.canvas.getWithFrames.useQuery({ projectId: editorEngine.projectId });
     const { data: conversations, isLoading: isConversationsLoading, error: conversationsError } = api.chat.conversation.get.useQuery({ projectId: editorEngine.projectId });
     const { data: creationRequest, isLoading: isCreationRequestLoading, error: creationRequestError } = api.project.createRequest.getPendingRequest.useQuery({ projectId: editorEngine.projectId });
-    const { mutateAsync: updateCreateRequest } = api.project.createRequest.updateStatus.useMutation();
+    const { mutateAsync: updateCreateRequest } = api.project.createRequest.updateStatus.useMutation({
+        onSettled: async () => {
+            await apiUtils.project.createRequest.getPendingRequest.invalidate({ projectId: editorEngine.projectId });
+        },
+    });
 
     const { sendMessages } = useChatContext();
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
Bug: When creating a new project via prompt, after it finishes, going back to the project list and re-entering the same project causes the previous question to auto re-apply.

Root Cause: The getPendingRequest query has a stale time of 30s. So if we navigate back immediately, it still returns the previous (stale) data.
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes stale data bug by invalidating `getPendingRequest` cache after `updateCreateRequest` mutation in `use-start-project.tsx`.
> 
>   - **Behavior**:
>     - Fixes bug where stale `getPendingRequest` data was used when re-entering a project immediately after creation.
>     - Adds `onSettled` callback to `updateCreateRequest` mutation in `use-start-project.tsx` to invalidate `getPendingRequest` cache.
>   - **Functions**:
>     - Modifies `updateCreateRequest` in `use-start-project.tsx` to include cache invalidation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 2774a8c7a53c858137900eceac083b0e03a3d553. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->