### PR TITLE
feat: Allow users to right-click elements in the layers panel and open…

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/left-panel/layers-tab/tree/tree-node.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/layers-tab/tree/tree-node.tsx
@@ -1,6 +1,12 @@
 import { useEditorEngine } from '@/components/store/editor';
-import { MouseAction } from '@onlook/models/editor';
+import { MouseAction, EditorTabValue } from '@onlook/models/editor';
 import type { DomElement, LayerNode } from '@onlook/models/element';
+import {
+    ContextMenu,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuTrigger,
+} from '@onlook/ui/context-menu';
 import { Icons } from '@onlook/ui/icons';
 import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@onlook/ui/tooltip';
 import { cn } from '@onlook/ui/utils';
@@ -252,17 +258,36 @@ export const TreeNode = memo(
                 );
             }
 
+            function viewSource(oid: string | null) {
+                if (!oid) {
+                    console.error('No oid found');
+                    return;
+                }
+                editorEngine.code.viewCodeBlock(oid);
+            }
+
+            const menuItems = [
+                {
+                    label: 'View Code',
+                    action: () => viewSource(node.data.oid),
+                    icon: <Icons.ExternalLink className="mr-2 h-4 w-4" />,
+                    disabled: !node.data.oid || isWindow,
+                },
+            ];
+
             return (
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <div ref={nodeRef}>
-                            <div
-                                ref={dragHandle}
-                                style={style}
-                                onMouseDown={(e) => handleSelectNode(e)}
-                                onMouseOver={(e) => handleHoverNode(e)}
-                                className={nodeClassName}
-                            >
+                <ContextMenu>
+                    <ContextMenuTrigger asChild>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <div ref={nodeRef}>
+                                    <div
+                                        ref={dragHandle}
+                                        style={style}
+                                        onMouseDown={(e) => handleSelectNode(e)}
+                                        onMouseOver={(e) => handleHoverNode(e)}
+                                        className={nodeClassName}
+                                    >
                                 <span className="w-4 h-4 flex-none relative">
                                     {!node.isLeaf && (
                                         <div
@@ -358,9 +383,9 @@ export const TreeNode = memo(
                                         onClick={toggleVisibility}
                                     />
                                 )}
-                            </div>
-                        </div>
-                    </TooltipTrigger>
+                                    </div>
+                                </div>
+                            </TooltipTrigger>
                     {node.data.textContent !== '' && (
                         <TooltipPortal container={document.getElementById('style-panel')}>
                             <TooltipContent
@@ -374,7 +399,24 @@ export const TreeNode = memo(
                         </TooltipPortal>
                     )}
                 </Tooltip>
-            );
+            </ContextMenuTrigger>
+            <ContextMenuContent>
+                {menuItems.map((item) => (
+                    <ContextMenuItem
+                        key={item.label}
+                        onClick={item.action}
+                        className="cursor-pointer"
+                        disabled={item.disabled}
+                    >
+                        <span className={cn('flex w-full items-center gap-1')}>
+                            {item.icon}
+                            {item.label}
+                        </span>
+                    </ContextMenuItem>
+                ))}
+            </ContextMenuContent>
+        </ContextMenu>
+    );
         },
     ),
 );


### PR DESCRIPTION


## Description
 Allow users to right-click elements in the layers panel and open code

## Related Issues

Fixes #2575
<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds right-click context menu to `TreeNode` for viewing code, with `viewSource()` function, and minor `CONTRIBUTING.md` update.
> 
>   - **Feature**:
>     - Adds right-click context menu to `TreeNode` in `tree-node.tsx` for viewing code.
>     - `viewSource()` function added to open code block using `oid`.
>     - Context menu disabled for window elements.
>   - **Misc**:
>     - Adds newline to `CONTRIBUTING.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for f753565f9c944669dc37013f6c61cfb098cc2c33. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->