### PR TITLE
fix: disable drag absolute

### DIFF
--- a/apps/web/client/src/components/store/editor/move/index.ts
+++ b/apps/web/client/src/components/store/editor/move/index.ts
@@ -23,6 +23,12 @@ export class MoveManager {
             return;
         }
 
+        const positionType = el.styles?.computed?.position;
+        if (positionType === 'absolute') {
+            console.warn('Absolute mode dragging is disabled');
+            return;
+        }
+
         this.dragOrigin = position;
         this.dragTarget = el;
         this.isDragInProgress = true;
@@ -33,7 +39,7 @@ export class MoveManager {
                 return;
             }
 
-            const index = (await frameView.view.startDrag(el.domId)) as number;
+            const index = await frameView.view.startDrag(el.domId);
             if (index === null || index === -1) {
                 this.clear();
                 this.isDragInProgress = false;
@@ -189,19 +195,19 @@ export class MoveManager {
 
         try {
             // Get current index and parent
-            const currentIndex = (await frameData.view.getElementIndex(element.domId)) as number;
+            const currentIndex = await frameData.view.getElementIndex(element.domId);
 
             if (currentIndex === -1) {
                 return;
             }
 
-            const parent = (await frameData.view.getParentElement(element.domId)) as DomElement;
+            const parent = await frameData.view.getParentElement(element.domId);
             if (!parent) {
                 return;
             }
 
             // Get filtered children count for accurate index calculation
-            const childrenCount = (await frameData.view.getChildrenCount(parent.domId)) as number;
+            const childrenCount = await frameData.view.getChildrenCount(parent.domId);
 
             // Calculate new index based on direction and bounds
             const newIndex =


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Disable drag absolute until we have a better version
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables dragging for elements with `position: absolute` in `MoveManager` and removes unnecessary type assertions from async calls.
> 
>   - **Behavior**:
>     - Disables dragging for elements with `position: absolute` in `MoveManager` by checking `el.styles?.computed?.position` and returning early with a warning.
>   - **Code Simplification**:
>     - Removes unnecessary type assertions from `await` calls in `start()` and `shiftElement()` methods in `MoveManager`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 81ebd684074e1f350dda55b3bccf29db5587321c. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->