### PR TITLE
fix: The CLI and Server window gets cleared when switching to Preview …

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/bottom-bar/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/bottom-bar/index.tsx
@@ -72,7 +72,7 @@ export const BottomBar = observer(() => {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ 
                         opacity: editorEngine.state.editorMode !== EditorMode.PREVIEW  ? 1 : 0, 
-                        y: editorEngine.state.editorMode !== EditorMode.PREVIEW  ? 20 : 0, 
+                        y: editorEngine.state.editorMode !== EditorMode.PREVIEW  ? 0 : 20, 
                     }}
                     className="absolute left-1/2 -translate-x-1/2 bottom-4 flex flex-col border-[0.5px] border-border p-1 px-1 bg-background rounded-lg backdrop-blur drop-shadow-xl overflow-hidden"
                     transition={{

--- a/apps/web/client/src/app/project/[id]/_components/bottom-bar/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/bottom-bar/index.tsx
@@ -68,11 +68,12 @@ export const BottomBar = observer(() => {
 
     return (
         <AnimatePresence mode="wait">
-            {editorEngine.state.editorMode !== EditorMode.PREVIEW && (
-                <motion.div
+            <motion.div
                     initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 20 }}
+                    animate={{ 
+                        opacity: editorEngine.state.editorMode !== EditorMode.PREVIEW  ? 1 : 0, 
+                        y: editorEngine.state.editorMode !== EditorMode.PREVIEW  ? 20 : 0, 
+                    }}
                     className="absolute left-1/2 -translate-x-1/2 bottom-4 flex flex-col border-[0.5px] border-border p-1 px-1 bg-background rounded-lg backdrop-blur drop-shadow-xl overflow-hidden"
                     transition={{
                         type: 'spring',
@@ -80,6 +81,10 @@ export const BottomBar = observer(() => {
                         duration: 0.4,
                         stiffness: 200,
                         damping: 25,
+                    }}
+                    style={{
+                        pointerEvents: editorEngine.state.editorMode !== EditorMode.PREVIEW ? 'auto' : 'none',
+                        visibility: editorEngine.state.editorMode !== EditorMode.PREVIEW ? 'visible' : 'hidden'
                     }}
                 >
                     <TerminalArea>
@@ -119,7 +124,6 @@ export const BottomBar = observer(() => {
                         </ToggleGroup>
                     </TerminalArea>
                 </motion.div>
-            )}
         </AnimatePresence>
     );
 });


### PR DESCRIPTION

## Description
fixed The CLI and Server window gets cleared when switching to Preview mode 

The TerminalArea component (which contains the Terminal components) was being completely unmounted from the DOM when switching to PREVIEW mode because of this condition:
```{editorEngine.state.editorMode !== EditorMode.PREVIEW && ()}```

the approach to:
Always render the TerminalArea component (never unmount it)
Hide it visually when in PREVIEW mode

## Related Issues

"fixes #2574"
<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

[<!-- Add screenshots to help explain your changes -->](https://github.com/user-attachments/assets/f26f4d31-0c83-4cff-8979-6541794b5f72)

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CLI and Server window clearing issue by always rendering `TerminalArea` and hiding it in PREVIEW mode in `index.tsx`.
> 
>   - **Behavior**:
>     - Fixes issue where CLI and Server window clears when switching to PREVIEW mode by always rendering `TerminalArea` in `index.tsx`.
>     - Uses `motion.div` to control visibility and pointer events based on `editorMode`.
>   - **UI Changes**:
>     - Adjusts `opacity`, `y`, `pointerEvents`, and `visibility` in `motion.div` to hide `TerminalArea` in PREVIEW mode without unmounting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 8b13c267e95807f2386f33dca76763456d2cd4db. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->