### PR TITLE
fix: allow using hotkeys with frames

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/hotkeys/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/hotkeys/index.tsx
@@ -31,7 +31,9 @@ export const HotkeysArea = ({ children }: { children: ReactNode }) => {
     useHotkeys(Hotkey.SELECT.command, () => (editorEngine.state.editorMode = EditorMode.DESIGN));
     useHotkeys(Hotkey.ESCAPE.command, () => {
         editorEngine.state.editorMode = EditorMode.DESIGN;
-        !editorEngine.text.isEditing && editorEngine.clearUI();
+        if (!editorEngine.text.isEditing) {
+            editorEngine.clearUI();
+        }
     });
     useHotkeys(Hotkey.PAN.command, () => (editorEngine.state.editorMode = EditorMode.PAN));
     useHotkeys(Hotkey.PREVIEW.command, () => (editorEngine.state.editorMode = EditorMode.PREVIEW));
@@ -56,7 +58,14 @@ export const HotkeysArea = ({ children }: { children: ReactNode }) => {
         preventDefault: true,
     });
     useHotkeys(Hotkey.ENTER.command, () => editorEngine.text.editSelectedElement(), { preventDefault: true });
-    useHotkeys([Hotkey.BACKSPACE.command, Hotkey.DELETE.command], () => editorEngine.elements.delete(), { preventDefault: true });
+    useHotkeys([Hotkey.BACKSPACE.command, Hotkey.DELETE.command], () => {
+        if (editorEngine.elements.selected.length > 0) {
+            editorEngine.elements.delete();
+        }
+        else if (editorEngine.frames.selected.length > 0 && editorEngine.frames.canDelete()) {
+            editorEngine.frames.deleteSelected();
+        }
+    }, { preventDefault: true });
 
     // Group
     useHotkeys(Hotkey.GROUP.command, () => editorEngine.group.groupSelectedElements());
@@ -67,7 +76,12 @@ export const HotkeysArea = ({ children }: { children: ReactNode }) => {
     useHotkeys(Hotkey.PASTE.command, () => editorEngine.copy.paste(), { preventDefault: true });
     useHotkeys(Hotkey.CUT.command, () => editorEngine.copy.cut(), { preventDefault: true });
     useHotkeys(Hotkey.DUPLICATE.command, () => {
-        editorEngine.copy.duplicate();
+        if (editorEngine.elements.selected.length > 0) {
+            editorEngine.copy.duplicate();
+        }
+        else if (editorEngine.frames.selected.length > 0 && editorEngine.frames.canDuplicate()) {
+            editorEngine.frames.duplicateSelected();
+        }
     }, { preventDefault: true });
 
     // AI

--- a/apps/web/client/src/components/store/editor/copy/index.ts
+++ b/apps/web/client/src/components/store/editor/copy/index.ts
@@ -22,12 +22,10 @@ export class CopyManager {
 
     async copy() {
         const selected = this.editorEngine.elements.selected;
-        console.log('copy', selected);
         if (selected.length === 0) {
             return;
         }
         const selectedEl = this.editorEngine.elements.selected[0];
-        console.log('selectedEl', selectedEl);
         if (!selectedEl) {
             console.error('Failed to copy element');
             return;
@@ -155,7 +153,6 @@ export class CopyManager {
     }
 
     async duplicate() {
-        console.log('duplicate');
         const savedCopied = this.copied;
         await this.copy();
         await this.paste();

--- a/apps/web/client/src/components/store/editor/copy/index.ts
+++ b/apps/web/client/src/components/store/editor/copy/index.ts
@@ -22,10 +22,12 @@ export class CopyManager {
 
     async copy() {
         const selected = this.editorEngine.elements.selected;
+        console.log('copy', selected);
         if (selected.length === 0) {
             return;
         }
         const selectedEl = this.editorEngine.elements.selected[0];
+        console.log('selectedEl', selectedEl);
         if (!selectedEl) {
             console.error('Failed to copy element');
             return;
@@ -44,7 +46,7 @@ export class CopyManager {
 
         const targetEl: ActionElement | null = (await frameData.view.getActionElement(
             selectedEl.domId,
-        )) as ActionElement | null;
+        ));
 
         if (!targetEl) {
             console.error('Failed to copy element');
@@ -153,6 +155,7 @@ export class CopyManager {
     }
 
     async duplicate() {
+        console.log('duplicate');
         const savedCopied = this.copied;
         await this.copy();
         await this.paste();


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->
- Allow using hotkeys `Delete` and `CMD + D` with frames
## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances hotkey functionality to support frame deletion and duplication, with code cleanup in `CopyManager`.
> 
>   - **Hotkey Functionality**:
>     - In `index.tsx`, updated `useHotkeys` for `DELETE` and `CMD + D` to handle frames.
>     - Checks if frames are selected and performs delete or duplicate actions on frames if applicable.
>   - **Code Cleanup**:
>     - Removed unnecessary type casting in `CopyManager` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 31eab55a087cb85952fce5e1c7ae9147636bb837. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->