### PR TITLE
fix: re-add bash command tool

### DIFF
--- a/packages/ai/src/tools/toolset.ts
+++ b/packages/ai/src/tools/toolset.ts
@@ -8,6 +8,8 @@ import {
     globTool,
     GREP_TOOL_NAME,
     grepTool,
+    TERMINAL_COMMAND_TOOL_NAME,
+    terminalCommandTool,
 } from './cli';
 import {
     FUZZY_EDIT_FILE_TOOL_NAME,
@@ -57,4 +59,5 @@ export const BUILD_TOOL_SET: ToolSet = {
     [WRITE_FILE_TOOL_NAME]: writeFileTool,
     [BASH_EDIT_TOOL_NAME]: bashEditTool,
     [SANDBOX_TOOL_NAME]: sandboxTool,
+    [TERMINAL_COMMAND_TOOL_NAME]: terminalCommandTool,
 };


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds `terminalCommandTool` to `BUILD_TOOL_SET` in `toolset.ts`.
> 
>   - **Behavior**:
>     - Re-adds `TERMINAL_COMMAND_TOOL_NAME` and `terminalCommandTool` to `BUILD_TOOL_SET` in `toolset.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 67415ec64b404f892a926cb2295606de8757f79e. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->