### PR TITLE
Upgrade Vercel AI SDK to V5

### DIFF
--- a/apps/web/client/package.json
+++ b/apps/web/client/package.json
@@ -28,7 +28,7 @@
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-        "@ai-sdk/react": "^1.2.9",
+        "@ai-sdk/react": "^2.0.8",
         "@codemirror/lang-css": "^6.2.0",
         "@codemirror/lang-html": "^6.4.7",
         "@codemirror/lang-javascript": "^6.2.3",
@@ -58,7 +58,7 @@
         "@uiw/react-codemirror": "^4.23.10",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
-        "ai": "^4.3.10",
+        "ai": "^5.0.0",
         "blob-util": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/message-content/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/message-content/index.tsx
@@ -1,4 +1,4 @@
-import type { Message } from 'ai';
+import type { UIMessage } from 'ai';
 import { observer } from 'mobx-react-lite';
 import { MarkdownRenderer } from '../markdown-renderer';
 import { ToolCallDisplay } from './tool-call-display';
@@ -11,7 +11,7 @@ export const MessageContent = observer(
         isStream,
     }: {
         messageId: string;
-        parts: Message['parts'];
+        parts: UIMessage['parts'];
         applied: boolean;
         isStream: boolean;
     }) => {

--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
@@ -4,16 +4,16 @@ import { useEditorEngine } from '@/components/store/editor';
 import { handleToolCall } from '@/components/tools';
 import { useChat, type UseChatHelpers } from '@ai-sdk/react';
 import { ChatType } from '@onlook/models';
-import type { Message } from 'ai';
+import type { UIMessage } from 'ai';
 import { usePostHog } from 'posthog-js/react';
 import { createContext, useContext, useRef } from 'react';
 
-type ExtendedUseChatHelpers = UseChatHelpers & { sendMessages: (messages: Message[], type: ChatType) => Promise<string | null | undefined> };
+type ExtendedUseChatHelpers = UseChatHelpers & { sendMessages: (messages: UIMessage[], type: ChatType) => Promise<string | null | undefined> };
 const ChatContext = createContext<ExtendedUseChatHelpers | null>(null);
 
 export function ChatProvider({ children }: { children: React.ReactNode }) {
     const editorEngine = useEditorEngine();
-    const lastMessageRef = useRef<Message | null>(null);
+    const lastMessageRef = useRef<UIMessage | null>(null);
     const posthog = usePostHog();
 
     const chat = useChat({
@@ -51,7 +51,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         },
     });
 
-    const sendMessages = async (messages: Message[], type: ChatType = ChatType.EDIT) => {
+    const sendMessages = async (messages: UIMessage[], type: ChatType = ChatType.EDIT) => {
         lastMessageRef.current = null;
         editorEngine.chat.error.clear();
         chat.setMessages(messages);

--- a/apps/web/client/src/components/store/editor/chat/conversation/conversation.ts
+++ b/apps/web/client/src/components/store/editor/chat/conversation/conversation.ts
@@ -8,7 +8,6 @@ import {
     type ChatSuggestion,
     type UserChatMessage
 } from '@onlook/models/chat';
-import type { Message } from 'ai';
 import { makeAutoObservable } from 'mobx';
 import { AssistantChatMessageImpl } from '../message/assistant';
 import { UserChatMessageImpl } from '../message/user';
@@ -61,7 +60,7 @@ export class ChatConversationImpl implements ChatConversation {
     }
 
 
-    getMessagesForStream(): Message[] {
+    getMessagesForStream() {
         const lastUserMessageIndex = this.messages.findLastIndex((m) => m.role === ChatMessageRole.USER);
         return this.messages.map((m, index) =>
             m.toStreamMessage({

--- a/apps/web/client/src/components/store/editor/chat/conversation/index.ts
+++ b/apps/web/client/src/components/store/editor/chat/conversation/index.ts
@@ -2,7 +2,7 @@
 import { api } from '@/trpc/client';
 import type { GitCommit } from '@onlook/git';
 import { ChatMessageRole, type ChatConversation, type ChatMessageContext } from '@onlook/models';
-import type { Message } from 'ai';
+import type { UIMessage } from 'ai';
 import { makeAutoObservable } from 'mobx';
 import { toast } from 'sonner';
 import type { EditorEngine } from '../../engine';
@@ -137,7 +137,7 @@ export class ConversationManager {
         this.current?.updateMessage(message);
     }
 
-    async addAssistantMessage(message: Message): Promise<AssistantChatMessageImpl | undefined> {
+    async addAssistantMessage(message: UIMessage): Promise<AssistantChatMessageImpl | undefined> {
         if (!this.current) {
             console.error('No conversation found');
             return;

--- a/apps/web/client/src/components/store/editor/chat/index.ts
+++ b/apps/web/client/src/components/store/editor/chat/index.ts
@@ -1,6 +1,6 @@
 import type { GitCommit } from '@onlook/git';
 import { ChatMessageRole, type ChatMessageContext } from '@onlook/models/chat';
-import type { Message } from 'ai';
+import type { UIMessage } from 'ai';
 import { makeAutoObservable } from 'mobx';
 import type { EditorEngine } from '../engine';
 import { ChatContext } from './context';
@@ -30,7 +30,7 @@ export class ChatManager {
         window.dispatchEvent(new Event(FOCUS_CHAT_INPUT_EVENT));
     }
 
-    async getEditMessages(content: string, contextOverride?: ChatMessageContext[]): Promise<Message[] | null> {
+    async getEditMessages(content: string, contextOverride?: ChatMessageContext[]): Promise<UIMessage[] | null> {
         if (!this.conversation.current) {
             console.error('No conversation found');
             return null;
@@ -52,7 +52,7 @@ export class ChatManager {
         return this.generateStreamMessages();
     }
 
-    async getAskMessages(content: string, contextOverride?: ChatMessageContext[]): Promise<Message[] | null> {
+    async getAskMessages(content: string, contextOverride?: ChatMessageContext[]): Promise<UIMessage[] | null> {
         if (!this.conversation.current) {
             console.error('No conversation found');
             return null;
@@ -69,7 +69,7 @@ export class ChatManager {
         return this.generateStreamMessages();
     }
 
-    async getFixErrorMessages(): Promise<Message[] | null> {
+    async getFixErrorMessages(): Promise<UIMessage[] | null> {
         const errors = this.editorEngine.error.errors;
         if (!this.conversation.current) {
             console.error('No conversation found');
@@ -119,12 +119,12 @@ export class ChatManager {
         return this.generateStreamMessages();
     }
 
-    private async generateStreamMessages(): Promise<Message[] | null> {
+    private async generateStreamMessages(): Promise<UIMessage[] | null> {
         if (!this.conversation.current) {
             console.error('No conversation found');
             return null;
         }
-        return this.conversation.current.getMessagesForStream();
+        return this.conversation.current.getMessagesForStream() as unknown as UIMessage[];
     }
 
     async createCommit(userPrompt: string): Promise<GitCommit | null> {

--- a/apps/web/client/src/components/store/editor/chat/message/assistant.ts
+++ b/apps/web/client/src/components/store/editor/chat/message/assistant.ts
@@ -1,6 +1,6 @@
 import { type AssistantChatMessage, ChatMessageRole } from '@onlook/models/chat';
 import type { CodeDiff } from '@onlook/models/code';
-import type { Message } from 'ai';
+import type { UIMessage } from 'ai';
 import { v4 as uuidv4 } from 'uuid';
 
 export class AssistantChatMessageImpl implements AssistantChatMessage {
@@ -9,30 +9,30 @@ export class AssistantChatMessageImpl implements AssistantChatMessage {
     content: string;
     applied: boolean = false;
     snapshots: Record<string, CodeDiff> = {};
-    parts: Message['parts'] = [];
+    parts: UIMessage['parts'] = [];
     aiSdkId: string | undefined;
 
-    private constructor(message: Message) {
+    private constructor(message: UIMessage) {
         this.id = uuidv4();
         this.aiSdkId = message.id;
         this.content = message.content;
         this.parts = message.parts;
     }
 
-    static fromMessage(message: Message): AssistantChatMessageImpl {
+    static fromMessage(message: UIMessage): AssistantChatMessageImpl {
         return new AssistantChatMessageImpl(message);
     }
 
-    toStreamMessage(): Message {
+    toStreamMessage(): UIMessage {
         return {
             ...this,
             content: this.content,
             parts: this.parts,
-        };
+        } as unknown as UIMessage;
     }
 
     static fromJSON(data: AssistantChatMessage): AssistantChatMessageImpl {
-        const message = new AssistantChatMessageImpl(data);
+        const message = new AssistantChatMessageImpl(data as unknown as UIMessage);
         message.id = data.id;
         message.applied = data.applied;
         message.snapshots = data.snapshots || {};

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -38,7 +38,7 @@
         "@ai-sdk/openai": "^1.3.22",
         "@mendable/firecrawl-js": "^1.29.1",
         "@openrouter/ai-sdk-provider": "^0.7.3",
-        "ai": "^4.3.10",
+        "ai": "^5.0.0",
         "exa-js": "^1.8.26",
         "fg": "^0.0.3",
         "marked": "^15.0.7",

--- a/packages/ai/src/tools/cli.ts
+++ b/packages/ai/src/tools/cli.ts
@@ -7,7 +7,7 @@ export const TERMINAL_COMMAND_TOOL_PARAMETERS = z.object({
 });
 export const terminalCommandTool = tool({
     description: 'Run any generic Linux Bash command in the terminal',
-    parameters: TERMINAL_COMMAND_TOOL_PARAMETERS,
+    inputSchema: TERMINAL_COMMAND_TOOL_PARAMETERS,
 });
 
 export const ALLOWED_BASH_READ_COMMANDS = z.enum([
@@ -39,7 +39,7 @@ export const BASH_READ_TOOL_PARAMETERS = z.object({
 });
 export const bashReadTool = tool({
     description: 'Execute read-only bash commands for exploration and analysis',
-    parameters: BASH_READ_TOOL_PARAMETERS,
+    inputSchema: BASH_READ_TOOL_PARAMETERS,
 });
 
 export const ALLOWED_BASH_EDIT_COMMANDS = z.enum([
@@ -66,7 +66,7 @@ export const BASH_EDIT_TOOL_PARAMETERS = z.object({
 });
 export const bashEditTool = tool({
     description: 'Execute file modification commands in a persistent shell session',
-    parameters: BASH_EDIT_TOOL_PARAMETERS,
+    inputSchema: BASH_EDIT_TOOL_PARAMETERS,
 });
 
 export const GLOB_TOOL_NAME = 'glob';
@@ -76,7 +76,7 @@ export const GLOB_TOOL_PARAMETERS = z.object({
 });
 export const globTool = tool({
     description: 'Fast file pattern matching tool that works with any codebase size',
-    parameters: GLOB_TOOL_PARAMETERS,
+    inputSchema: GLOB_TOOL_PARAMETERS,
 });
 
 export const GREP_TOOL_NAME = 'grep';
@@ -99,5 +99,5 @@ export const GREP_TOOL_PARAMETERS = z.object({
 });
 export const grepTool = tool({
     description: 'Powerful search tool built on ripgrep with full regex syntax support',
-    parameters: GREP_TOOL_PARAMETERS,
+    inputSchema: GREP_TOOL_PARAMETERS,
 });

--- a/packages/ai/src/tools/edit.ts
+++ b/packages/ai/src/tools/edit.ts
@@ -10,7 +10,7 @@ export const SEARCH_REPLACE_EDIT_FILE_TOOL_PARAMETERS = z.object({
 });
 export const searchReplaceEditFileTool = tool({
     description: 'Make exact string replacements in files with precise matching',
-    parameters: SEARCH_REPLACE_EDIT_FILE_TOOL_PARAMETERS,
+    inputSchema: SEARCH_REPLACE_EDIT_FILE_TOOL_PARAMETERS,
 });
 
 export const SEARCH_REPLACE_MULTI_EDIT_FILE_TOOL_NAME = 'search_replace_multi_edit_file';
@@ -32,7 +32,7 @@ export const SEARCH_REPLACE_MULTI_EDIT_FILE_TOOL_PARAMETERS = z.object({
 });
 export const searchReplaceMultiEditFileTool = tool({
     description: 'Make multiple edits to a single file in one atomic operation',
-    parameters: SEARCH_REPLACE_MULTI_EDIT_FILE_TOOL_PARAMETERS,
+    inputSchema: SEARCH_REPLACE_MULTI_EDIT_FILE_TOOL_PARAMETERS,
 });
 
 export const WRITE_FILE_TOOL_NAME = 'write_file';
@@ -42,7 +42,7 @@ export const WRITE_FILE_TOOL_PARAMETERS = z.object({
 });
 export const writeFileTool = tool({
     description: 'Write or overwrite file contents completely',
-    parameters: WRITE_FILE_TOOL_PARAMETERS,
+    inputSchema: WRITE_FILE_TOOL_PARAMETERS,
 });
 
 export const FUZZY_EDIT_FILE_TOOL_NAME = 'fuzzy_edit_file';
@@ -63,5 +63,5 @@ Make sure there's enough context for the other model to understand where the cha
 export const fuzzyEditFileTool = tool({
     description:
         'Edit the contents of a file with fuzzy matching instead of search and replace. This should be used as a fallback when the search and replace tool fails. It calls another agent to do the actual editing.',
-    parameters: FUZZY_EDIT_FILE_TOOL_PARAMETERS,
+    inputSchema: FUZZY_EDIT_FILE_TOOL_PARAMETERS,
 });

--- a/packages/ai/src/tools/guides.ts
+++ b/packages/ai/src/tools/guides.ts
@@ -4,11 +4,11 @@ import { z } from 'zod';
 export const ONLOOK_INSTRUCTIONS_TOOL_NAME = 'onlook_instructions';
 export const onlookInstructionsTool = tool({
     description: 'Get the instructions for the Onlook AI',
-    parameters: z.object({}),
+    inputSchema: z.object({}),
 });
 
 export const READ_STYLE_GUIDE_TOOL_NAME = 'read_style_guide';
 export const readStyleGuideTool = tool({
     description: 'Read the Tailwind config and global CSS file if available for the style guide',
-    parameters: z.object({}),
+    inputSchema: z.object({}),
 });

--- a/packages/ai/src/tools/plan.ts
+++ b/packages/ai/src/tools/plan.ts
@@ -10,7 +10,7 @@ const TASK_TOOL_PARAMETERS = z.object({
 });
 const taskTool = tool({
     description: 'Launch specialized agents for analysis tasks',
-    parameters: TASK_TOOL_PARAMETERS,
+    inputSchema: TASK_TOOL_PARAMETERS,
 });
 
 export const TODO_WRITE_TOOL_NAME = 'todo_write';
@@ -28,7 +28,7 @@ export const TODO_WRITE_TOOL_PARAMETERS = z.object({
 });
 export const todoWriteTool = tool({
     description: 'Create and manage structured task lists for coding sessions',
-    parameters: TODO_WRITE_TOOL_PARAMETERS,
+    inputSchema: TODO_WRITE_TOOL_PARAMETERS,
 });
 
 export const EXIT_PLAN_MODE_TOOL_NAME = 'exit_plan_mode';
@@ -37,5 +37,5 @@ export const EXIT_PLAN_MODE_TOOL_PARAMETERS = z.object({
 });
 export const exitPlanModeTool = tool({
     description: 'Exit planning mode when ready to implement code',
-    parameters: EXIT_PLAN_MODE_TOOL_PARAMETERS,
+    inputSchema: EXIT_PLAN_MODE_TOOL_PARAMETERS,
 });

--- a/packages/ai/src/tools/read.ts
+++ b/packages/ai/src/tools/read.ts
@@ -9,7 +9,7 @@ export const READ_FILE_TOOL_PARAMETERS = z.object({
 });
 export const readFileTool = tool({
     description: 'Read file contents with line numbers and range support',
-    parameters: READ_FILE_TOOL_PARAMETERS,
+    inputSchema: READ_FILE_TOOL_PARAMETERS,
 });
 
 export const LIST_FILES_TOOL_NAME = 'list_files';
@@ -19,5 +19,5 @@ export const LIST_FILES_TOOL_PARAMETERS = z.object({
 });
 export const listFilesTool = tool({
     description: 'List all files in the current directory, including subdirectories',
-    parameters: LIST_FILES_TOOL_PARAMETERS,
+    inputSchema: LIST_FILES_TOOL_PARAMETERS,
 });

--- a/packages/ai/src/tools/sandbox.ts
+++ b/packages/ai/src/tools/sandbox.ts
@@ -9,5 +9,5 @@ export const SANDBOX_TOOL_PARAMETERS = z.object({
 export const sandboxTool = tool({
     description:
         'Restart the development server. This should only be used if absolutely necessary such as if updating dependencies, clearing next cache, or if the server is not responding.',
-    parameters: SANDBOX_TOOL_PARAMETERS,
+    inputSchema: SANDBOX_TOOL_PARAMETERS,
 });

--- a/packages/ai/src/tools/web.ts
+++ b/packages/ai/src/tools/web.ts
@@ -31,7 +31,7 @@ export const SCRAPE_URL_TOOL_PARAMETERS = z.object({
 export const scrapeUrlTool = tool({
     description:
         'Scrape a URL and extract its content in various formats (markdown, HTML, JSON). Can extract clean, LLM-ready content from any website, handling dynamic content and anti-bot mechanisms.',
-    parameters: SCRAPE_URL_TOOL_PARAMETERS,
+    inputSchema: SCRAPE_URL_TOOL_PARAMETERS,
 });
 
 export const WEB_SEARCH_TOOL_NAME = 'web_search';
@@ -42,5 +42,5 @@ export const WEB_SEARCH_TOOL_PARAMETERS = z.object({
 });
 export const webSearchTool = tool({
     description: 'Search the web for up-to-date information',
-    parameters: WEB_SEARCH_TOOL_PARAMETERS,
+    inputSchema: WEB_SEARCH_TOOL_PARAMETERS,
 });

--- a/packages/ai/test/tools/web-search.test.ts
+++ b/packages/ai/test/tools/web-search.test.ts
@@ -64,8 +64,8 @@ describe('Web Search Tool', () => {
             expect(webSearchTool.description).toContain('up-to-date information');
         });
 
-        it('should use the correct parameters schema', () => {
-            expect(webSearchTool.parameters).toBe(WEB_SEARCH_TOOL_PARAMETERS);
+        it('should use the correct input schema', () => {
+            expect(webSearchTool.inputSchema).toBe(WEB_SEARCH_TOOL_PARAMETERS);
         });
     });
 

--- a/packages/mastra/package.json
+++ b/packages/mastra/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@ai-sdk/anthropic": "^1.2.10",
         "@mastra/core": "^0.9.0",
-        "ai": "^4.2.6",
+        "ai": "^5.0.0",
         "fg": "^0.0.3",
         "marked": "^15.0.7"
     }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@onlook/typescript": "*",
         "typescript": "^5.5.4",
-        "ai": "^4.2.6"
+        "ai": "^5.0.0"
     },
     "dependencies": {
         "zod": "^3.23.8"

--- a/packages/models/src/chat/message/message.ts
+++ b/packages/models/src/chat/message/message.ts
@@ -1,5 +1,5 @@
-import type { Message } from '@ai-sdk/react';
-import type { TextPart } from 'ai';
+import type { Message as ReactMessage } from '@ai-sdk/react';
+import type { UIMessage } from 'ai';
 import type { CodeDiff } from '../../code/index.ts';
 import { type ChatMessageContext } from './context.ts';
 
@@ -9,25 +9,25 @@ export enum ChatMessageRole {
     SYSTEM = 'system',
 }
 
-export interface UserChatMessage extends Message {
+export interface UserChatMessage extends ReactMessage {
     role: ChatMessageRole.USER;
     context: ChatMessageContext[];
-    parts: TextPart[];
+    parts: UIMessage['parts'];
     content: string;
     commitOid: string | null;
 }
 
-export interface AssistantChatMessage extends Message {
+export interface AssistantChatMessage extends ReactMessage {
     role: ChatMessageRole.ASSISTANT;
     applied: boolean;
     snapshots: ChatSnapshot;
-    parts: Message['parts'];
+    parts: UIMessage['parts'];
     content: string;
 }
 
 export type ChatSnapshot = Record<string, CodeDiff>;
 
-export interface SystemChatMessage extends Message {
+export interface SystemChatMessage extends ReactMessage {
     role: ChatMessageRole.SYSTEM;
 }
 


### PR DESCRIPTION
## Description

Upgrades the Vercel AI SDK to version 5. This involved migrating:
*   Tool definitions from `parameters` to `inputSchema`.
*   The server chat route to use V5 UI messages and `toUIMessageStreamResponse`.
*   Client-side chat hooks and internal store types to align with the new `UIMessage` structure.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [x] Refactor
- [ ] Other (please describe):

## Testing

1.  Run `bun install` at the repo root to install updated dependencies.
2.  Run `bun run typecheck` to ensure type compatibility.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

The client UI currently renders old `tool-invocation` parts. A follow-up task could involve migrating rendering to use v5's typed `tool-<name>` and `dynamic-tool` parts once the server begins emitting them.

---
<a href="https://cursor.com/background-agent?bcId=bc-6be88b1d-103f-4093-929a-f00b37bc837b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6be88b1d-103f-4093-929a-f00b37bc837b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade Vercel AI SDK to v5, updating tool definitions, server chat routes, and client-side chat hooks to align with the new SDK structure.
> 
>   - **SDK Upgrade**:
>     - Upgrade Vercel AI SDK to version 5 in `package.json` files.
>     - Update dependencies in `apps/web/client/package.json`, `packages/ai/package.json`, `packages/mastra/package.json`, and `packages/models/package.json`.
>   - **Tool Definitions**:
>     - Migrate tool definitions from `parameters` to `inputSchema` in `cli.ts`, `edit.ts`, `guides.ts`, `plan.ts`, `read.ts`, `sandbox.ts`, and `web.ts`.
>   - **Server Chat Route**:
>     - Update `streamResponse` in `route.ts` to use `toUIMessageStreamResponse` and convert messages using `convertToModelMessages`.
>   - **Client-Side Changes**:
>     - Update chat hooks and internal store types to use `UIMessage` in `use-chat.tsx`, `conversation.ts`, `index.ts`, `assistant.ts`, and `user.ts`.
>   - **Testing**:
>     - Update test in `web-search.test.ts` to validate `inputSchema` instead of `parameters`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for e6d36bbb3933f77913c4ce5c181ef8602fac6f1b. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->