### PR TITLE
fix(template): suppress hydration mismatch

### DIFF
--- a/apps/web/template/app/layout.tsx
+++ b/apps/web/template/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
     return (
-        <html lang="en" data-oid="si2j4vl">
+        <html lang="en" data-oid="si2j4vl" suppressHydrationWarning>
             <body className={inter.className} data-oid="mwz9mme">
                 {children}
             </body>


### PR DESCRIPTION
## Description
Align Codesandbox preview with Next.js template and suppress false hydration warnings:
- Use port 8084 for `BLANK` and `EMPTY_NEXTJS` in `SandboxTemplates`.
- Add `suppressHydrationWarning` to template `html` to avoid extension-injected DOM attribute mismatches on first load.

## Related Issues
- Fixes #2652 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):


## Screenshots (if applicable)
N/A

## Additional Notes
- Port now matches `apps/web/template/package.json` (`PORT=8084`).
- Hydration mismatch was caused by extension-injected attributes; suppression prevents noisy first-load overlays.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Suppress false hydration warnings and align port configuration in Next.js template.
> 
>   - **Behavior**:
>     - Add `suppressHydrationWarning` to `<html>` in `layout.tsx` to suppress false hydration warnings due to extension-injected attributes.
>     - Change port to 8084 for `BLANK` and `EMPTY_NEXTJS` in `SandboxTemplates` to align with `apps/web/template/package.json`.
>   - **Related Issues**:
>     - Fixes #2652.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 25530ba4482368d20966aa7181298d54325deae5. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->