### PR TITLE
feat: improve project placeholder styling with gradient and faded border

### DIFF
--- a/apps/web/client/src/app/projects/_components/select/project-card.tsx
+++ b/apps/web/client/src/app/projects/_components/select/project-card.tsx
@@ -55,7 +55,7 @@ export function ProjectCard({
         <motion.div
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
-            whileHover={{ scale: 1.02, y: -4 }}
+            whileHover={{ y: -4 }}
             transition={{ type: 'spring', stiffness: 300, damping: 24 }}
             className="w-full break-inside-avoid cursor-pointer"
         >
@@ -63,7 +63,10 @@ export function ProjectCard({
                 {img ? (
                     <img src={img} alt={project.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" />
                 ) : (
-                    <div className="absolute inset-0 w-full h-full bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-blue-950/20 dark:to-indigo-950/20" />
+                    <>
+                        <div className="absolute inset-0 w-full h-full bg-gradient-to-t from-gray-800/40 via-gray-500/40 to-gray-400/40" />
+                        <div className="absolute inset-0 rounded-lg border-[0.5px] border-gray-500/70" style={{ maskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)' }} />
+                    </>
                 )}
 
                 <div className="absolute inset-0 bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />

--- a/apps/web/client/src/app/projects/_components/select/square-project-card.tsx
+++ b/apps/web/client/src/app/projects/_components/select/square-project-card.tsx
@@ -46,7 +46,7 @@ export function SquareProjectCard({
 
     return (
         <div
-            className="cursor-pointer transition-all duration-300 hover:scale-[1.02] hover:shadow-xl hover:shadow-black/20 group"
+            className="cursor-pointer transition-all duration-300 hover:shadow-xl hover:shadow-black/20 group"
             role="button"
             tabIndex={0}
             onKeyDown={(e) => {
@@ -56,11 +56,14 @@ export function SquareProjectCard({
                 }
             }}
         >
-            <div className="w-full aspect-[4/2.8] rounded-lg overflow-hidden relative shadow-sm transition-all duration-300">
+            <div className={`w-full aspect-[4/2.8] rounded-lg overflow-hidden relative shadow-sm transition-all duration-300`}>
                 {img ? (
                     <img src={img} alt={project.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" />
                 ) : (
-                    <div className="absolute inset-0 w-full h-full bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-blue-950/20 dark:to-indigo-950/20" />
+                    <>
+                        <div className="absolute inset-0 w-full h-full bg-gradient-to-t from-gray-800/40 via-gray-500/40 to-gray-400/40" />
+                        <div className="absolute inset-0 rounded-lg border-[0.5px] border-gray-500/70" style={{ maskImage: 'linear-gradient(to bottom, black 60%, transparent 100%)' }} />
+                    </>
                 )}
 
                 <div className="absolute inset-0 bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />


### PR DESCRIPTION
## Summary
- Replace blue gradient placeholders with gray gradient matching carousel style
- Remove hover scale effects from project cards for cleaner interaction
- Add fading border that matches gradient overlay pattern using CSS mask

## Changes Made
- **project-card.tsx** & **square-project-card.tsx**: Updated placeholder styling with consistent gray gradient
- Removed `scale` hover effects while keeping shadow and vertical movement
- Added CSS mask to border for smooth fade-out effect from 60% to transparent at bottom

## Test Plan
- [x] Verify gradient placeholders display correctly for projects without preview images  
- [x] Confirm border fading works properly with rounded corners
- [x] Test hover interactions still work smoothly without scaling
- [x] Check both masonry and grid layout modes

🤖 Generated with [Claude Code](https://claude.ai/code)