### PR TITLE
fix: handle breaks in tags

### DIFF
--- a/apps/web/preload/script/api/elements/text.ts
+++ b/apps/web/preload/script/api/elements/text.ts
@@ -96,7 +96,7 @@ function updateTextContent(el: HTMLElement, content: string): void {
 
 function extractTextContent(el: HTMLElement): string {
     let content = el.innerHTML;
-    content = content.replace(/<br\s*\/?>/gi, '\n');
+    content = content.replace(/<br[^>]*\/?>/gi, '\n');
     content = content.replace(/<[^>]*>/g, '');
     const textArea = document.createElement('textarea');
     textArea.innerHTML = content;


### PR DESCRIPTION
## Description

Update the preload script so it can detect <br> elements with attributes (e.g., <br data-oid="">).

Right now, it’s still buggy when adding multiple line breaks. From what I can tell, the issue happens during sandbox updates/refreshes. The data and file changes look correct, but when the sandbox refreshes, only the current frame you’re working on glitches—the other frames are fine. I couldn’t fully figure out why, so someone else might need to dig deeper.

## Related Issues

#2504 

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
