### PR TITLE
bugs: branch connection timeout in frame

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/frame/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/frame/index.tsx
@@ -30,20 +30,19 @@ export const FrameView = observer(({ frame }: { frame: Frame }) => {
         }
 
         const timeoutId = setTimeout(() => {
-            // Check if still connecting when timeout fires
             const currentBranchData = editorEngine.branches.getBranchDataById(frame.branchId);
             const stillConnecting = currentBranchData?.sandbox?.session?.isConnecting || currentBranchData?.sandbox?.isIndexing || false;
 
             if (stillConnecting) {
                 setHasTimedOut(true);
                 toast.error('Connection timeout', {
-                    description: `Failed to connect to the branch ${branchData?.branch?.name}. Please try reloading.`,
+                    description: `Failed to connect to the branch ${currentBranchData?.branch?.name}. Please try reloading.`,
                 });
             }
-        }, 10000); // 10 second timeout
+        }, 30000);
 
         return () => clearTimeout(timeoutId);
-    }, [isConnecting, frame.branchId, editorEngine.branches]);
+    }, [isConnecting, frame.branchId]);
 
     const undebouncedReloadIframe = () => {
         setReloadKey(prev => prev + 1);


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase connection timeout in `FrameView` to 30 seconds to handle longer connection times.
> 
>   - **Behavior**:
>     - Increase connection timeout from 10 seconds to 30 seconds in `FrameView` in `index.tsx`.
>     - Adjusts error message to use `currentBranchData` for branch name.
>   - **Effects**:
>     - Handles longer connection times without premature timeout errors.
>     - Ensures accurate branch name in timeout error message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 39869497a1700b200a44dd5e6e3fd32e08bb427c. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->