### PR TITLE
fix: add tool result non-blocking

### DIFF
--- a/apps/web/client/src/app/api/chat/helpers/stream.ts
+++ b/apps/web/client/src/app/api/chat/helpers/stream.ts
@@ -25,7 +25,7 @@ export async function getModelFromType(chatType: ChatType) {
     return model;
 }
 
-export async function getToolSetFromType(chatType: ChatType) {
+export function getToolSetFromType(chatType: ChatType) {
     return chatType === ChatType.ASK ? ASK_TOOL_SET : BUILD_TOOL_SET;
 }
 

--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat.tsx
@@ -30,15 +30,7 @@ export const ChatProvider = observer(({ children }: { children: React.ReactNode 
                 projectId: editorEngine.projectId,
             },
         }),
-        onToolCall: async (toolCall) => {
-            const result = await handleToolCall(toolCall.toolCall, editorEngine);
-
-            chat.addToolResult({
-                tool: toolCall.toolCall.toolName,
-                toolCallId: toolCall.toolCall.toolCallId,
-                output: result,
-            });
-        },
+        onToolCall: (toolCall) => { handleToolCall(toolCall.toolCall, editorEngine, chat.addToolResult) },
         onFinish: ({ message }) => {
             if (!message.metadata) {
                 return;


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make tool result handling non-blocking by restructuring `handleToolCall` and removing `async` from `getToolSetFromType`.
> 
>   - **Behavior**:
>     - `getToolSetFromType` in `stream.ts` is no longer `async`, making tool set retrieval synchronous.
>     - `handleToolCall` in `tools.ts` now uses a nested async function `runTool` to handle tool calls non-blockingly.
>     - `onToolCall` in `use-chat.tsx` updated to use the new `handleToolCall` signature.
>   - **Error Handling**:
>     - Errors in `handleToolCall` are now caught and logged as tool results with error messages.
>   - **Misc**:
>     - Removed `async` from `getToolSetFromType` in `stream.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for d5c4a45b0c24fc038e14551c32290e1d01c08ec6. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->