### PR TITLE
feat: add drag-to-select for multiple webframes

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/frame/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/frame/index.tsx
@@ -17,6 +17,7 @@ export const FrameView = observer(({ frame }: { frame: Frame }) => {
     const [isResizing, setIsResizing] = useState(false);
     const [reloadKey, setReloadKey] = useState(0);
     const [hasTimedOut, setHasTimedOut] = useState(false);
+    const isSelected = editorEngine.frames.isSelected(frame.id);
 
     // Check if sandbox is connecting for this frame's branch
     const branchData = editorEngine.branches.getBranchDataById(frame.branchId);
@@ -60,7 +61,10 @@ export const FrameView = observer(({ frame }: { frame: Frame }) => {
             <RightClickMenu>
                 <TopBar frame={frame} />
             </RightClickMenu>
-            <div className="relative">
+            <div className="relative" style={{
+                outline: isSelected ? '2px solid rgb(94, 234, 212)' : 'none',
+                borderRadius: '4px',
+            }}>
                 <ResizeHandles frame={frame} setIsResizing={setIsResizing} />
                 <FrameComponent key={reloadKey} frame={frame} reloadIframe={reloadIframe} ref={iFrameRef} />
                 <GestureScreen frame={frame} isResizing={isResizing} />

--- a/apps/web/client/src/app/project/[id]/_components/canvas/overlay/drag-select.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/overlay/drag-select.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { observer } from 'mobx-react-lite';
+
+interface DragSelectOverlayProps {
+    startX: number;
+    startY: number;
+    endX: number;
+    endY: number;
+    isSelecting: boolean;
+}
+
+export const DragSelectOverlay = observer(({ startX, startY, endX, endY, isSelecting }: DragSelectOverlayProps) => {
+    if (!isSelecting) {
+        return null;
+    }
+
+    const left = Math.min(startX, endX);
+    const top = Math.min(startY, endY);
+    const width = Math.abs(endX - startX);
+    const height = Math.abs(endY - startY);
+
+    return (
+        <div
+            className="absolute border-2 border-blue-500 bg-blue-500/10 pointer-events-none"
+            style={{
+                left: `${left}px`,
+                top: `${top}px`,
+                width: `${width}px`,
+                height: `${height}px`,
+            }}
+        />
+    );
+});


### PR DESCRIPTION
Implement drag selection functionality allowing users to select multiple webframes by clicking and dragging on the canvas, similar to Figma and tldraw.

- Add DragSelectOverlay component for visual selection rectangle
- Implement drag selection logic in Canvas component with proper coordinate transformation
- Add visual feedback with teal outline for selected frames
- Support multi-select with Shift key modifier
- Integrate with existing frame selection system for chat context

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
