### PR TITLE
fix(ui): navbar responsiveness 

### DIFF
--- a/apps/web/client/src/app/_components/top-bar/github.tsx
+++ b/apps/web/client/src/app/_components/top-bar/github.tsx
@@ -57,9 +57,9 @@ export function useGitHubStats() {
 export function GitHubButton() {
     const { formatted } = useGitHubStats();
     return (
-        <a href="https://github.com/onlook-dev/onlook" className="flex items-center gap-1.5 text-small hover:opacity-80" target="_blank" rel="noopener noreferrer">
+        <a href="https://github.com/onlook-dev/onlook" className="flex items-center gap-1.5 text-small hover:opacity-80 " target="_blank" rel="noopener noreferrer">
             <Icons.GitHubLogo className="h-5 w-5" />
-            <span className="transition-all duration-300">{formatted}</span>
+            <span className="transition-all duration-300 hidden md:block">{formatted}</span>
         </a>
     );
 }

--- a/apps/web/client/src/app/_components/top-bar/github.tsx
+++ b/apps/web/client/src/app/_components/top-bar/github.tsx
@@ -56,7 +56,7 @@ export function useGitHubStats() {
 export function GitHubButton() {
     const { formatted } = useGitHubStats();
     return (
-        <a href="https://github.com/onlook-dev/onlook" className="flex items-center gap-1.5 text-small hover:opacity-80 " target="_blank" rel="noopener noreferrer">
+        <a href="https://github.com/onlook-dev/onlook" className="flex items-center gap-1.5 text-small hover:opacity-80" target="_blank" rel="noopener noreferrer">
             <Icons.GitHubLogo className="h-5 w-5" />
             <span className="transition-all duration-300 hidden sm:block">{formatted}</span>
         </a>

--- a/apps/web/client/src/app/_components/top-bar/github.tsx
+++ b/apps/web/client/src/app/_components/top-bar/github.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Icons } from '@onlook/ui/icons';
-import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 const DEFAULT_STAR_COUNT = 20550;
@@ -59,7 +58,7 @@ export function GitHubButton() {
     return (
         <a href="https://github.com/onlook-dev/onlook" className="flex items-center gap-1.5 text-small hover:opacity-80 " target="_blank" rel="noopener noreferrer">
             <Icons.GitHubLogo className="h-5 w-5" />
-            <span className="transition-all duration-300 hidden md:block">{formatted}</span>
+            <span className="transition-all duration-300 hidden sm:block">{formatted}</span>
         </a>
     );
 }

--- a/apps/web/client/src/app/_components/top-bar/index.tsx
+++ b/apps/web/client/src/app/_components/top-bar/index.tsx
@@ -32,8 +32,8 @@ const LINKS = [
 export const TopBar = () => {
     const currentPath = usePathname();
     return (
-        <div className="w-full gap-2 max-w-6xl mx-auto flex items-center justify-between p-4 h-12 text-small text-foreground-secondary select-none">
-            <div className="flex items-center gap-4 mt-0 text-regular text-foreground-secondary">
+        <div className="w-full max-w-6xl mx-auto flex items-center justify-between p-4 h-12 text-small text-foreground-secondary select-none">
+            <div className="flex items-center gap-8 mt-0 text-regular text-foreground-secondary">
                 {LINKS.map((link) => (
                     <a href={link.href} key={link.href} className={cn(
                         'hover:opacity-80',

--- a/apps/web/client/src/app/_components/top-bar/index.tsx
+++ b/apps/web/client/src/app/_components/top-bar/index.tsx
@@ -32,8 +32,8 @@ const LINKS = [
 export const TopBar = () => {
     const currentPath = usePathname();
     return (
-        <div className="w-full max-w-6xl mx-auto flex items-center justify-between p-4 h-12 text-small text-foreground-secondary select-none">
-            <div className="flex items-center gap-8 mt-0 text-regular text-foreground-secondary">
+        <div className="w-full gap-2 max-w-6xl mx-auto flex items-center justify-between p-4 h-12 text-small text-foreground-secondary select-none">
+            <div className="flex items-center gap-4 mt-0 text-regular text-foreground-secondary">
                 {LINKS.map((link) => (
                     <a href={link.href} key={link.href} className={cn(
                         'hover:opacity-80',


### PR DESCRIPTION
## Description

Auth button and navbar used to overflow on smaller screens 


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [x] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

Existing
<img width="325" height="132" alt="Screenshot 2025-09-18 at 7 32 46 PM" src="https://github.com/user-attachments/assets/1f4dfd6c-7c4d-48e9-9683-0763488b3571" />

Fixed
<img width="400" height="90" alt="Screenshot 2025-09-18 at 7 33 21 PM" src="https://github.com/user-attachments/assets/cd40f821-3270-4945-8c0a-7102c806228c" />



## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve navbar responsiveness on small screens by adjusting element visibility and spacing in `github.tsx` and `index.tsx`.
> 
>   - **UI Changes**:
>     - In `github.tsx`, hide `formatted` text on small screens by adding `hidden md:block` class to the `span` element.
>     - In `index.tsx`, reduce `gap` in the `TopBar` component from `gap-8` to `gap-4` for better spacing on small screens.
>   - **Misc**:
>     - Remove extra space in `GitHubButton` class in `github.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for c6fd3a740bb502f70644de058c7a1aa9b7e439db. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * GitHub button in the top bar now adapts for small screens: star count is hidden on compact viewports and shown on larger screens to reduce clutter.
  * Minor visual polish with no functional impact.
  * Hover appearance remains the same; link behavior and data updates are unaffected.
  * No configuration or actions required; applies automatically after update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->