### PR TITLE
fix: hide code block when streaming

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/assistant-message.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/assistant-message.tsx
@@ -1,14 +1,14 @@
 import type { ChatMessage } from '@onlook/models';
 import { MessageContent } from './message-content';
 
-export const AssistantMessage = ({ message }: { message: ChatMessage }) => {
+export const AssistantMessage = ({ message, isStreaming }: { message: ChatMessage, isStreaming: boolean }) => {
     return (
         <div className="px-4 py-2 text-small content-start flex flex-col text-wrap gap-2">
             <MessageContent
                 messageId={message.id}
                 parts={message.parts}
                 applied={false}
-                isStream={false}
+                isStream={isStreaming}
             />
         </div>
     );

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/index.tsx
@@ -51,7 +51,7 @@ export const ChatMessages = observer(({
             let messageNode;
             switch (message.role) {
                 case 'assistant':
-                    messageNode = <AssistantMessage key={message.id} message={message} />;
+                    messageNode = <AssistantMessage key={message.id} message={message} isStreaming={isStreaming} />;
                     break;
                 case 'user':
                     messageNode = (

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/index.tsx
@@ -93,6 +93,10 @@ export const ChatMessages = observer(({
             {messages.map((message, index) => renderMessage(message, index))}
             {streamedMessage && <StreamMessage message={streamedMessage} />}
             {error && <ErrorMessage error={error} />}
+            {isStreaming && <div className="flex w-full h-full flex-row items-center gap-2 px-4 my-2 text-small content-start text-foreground-secondary">
+                <Icons.LoadingSpinner className="animate-spin" />
+                <p>Thinking ...</p>
+            </div>}
         </ChatMessageList>
     );
 },

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/message-content/tool-call-display.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/message-content/tool-call-display.tsx
@@ -39,7 +39,7 @@ export const ToolCallDisplay = ({
     const toolName = toolPart.type.split('-')[1];
     const loading = isStream && isLastPart;
 
-    if (isStream && toolPart.state !== 'output-available' && toolPart.state !== 'input-available') {
+    if (isStream || (toolPart.state !== 'output-available' && toolPart.state !== 'input-available')) {
         return (
             <ToolCallSimple
                 toolPart={toolPart}

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/stream-message.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/stream-message.tsx
@@ -2,7 +2,7 @@ import { type ChatMessage } from '@onlook/models';
 import { MessageContent } from './message-content';
 
 export const StreamMessage = ({ message }: { message: ChatMessage }) => {
-    return message && (
+    return (
         <div className="px-4 pt-2 text-small content-start flex flex-col text-wrap gap-2">
             <MessageContent
                 messageId={message.id}

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/stream-message.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-messages/stream-message.tsx
@@ -1,27 +1,15 @@
 import { type ChatMessage } from '@onlook/models';
-import { Icons } from '@onlook/ui/icons';
-import { useMemo } from 'react';
 import { MessageContent } from './message-content';
 
 export const StreamMessage = ({ message }: { message: ChatMessage }) => {
-    const isAssistantStreamMessage = useMemo(() => message?.role === 'assistant', [message?.role]);
-
-    return (
-        <>
-            {message && isAssistantStreamMessage && (
-                <div className="px-4 pt-2 text-small content-start flex flex-col text-wrap gap-2">
-                    <MessageContent
-                        messageId={message.id}
-                        parts={message.parts}
-                        applied={false}
-                        isStream={true}
-                    />
-                </div>
-            )}
-            <div className="flex w-full h-full flex-row items-center gap-2 px-4 my-2 text-small content-start text-foreground-secondary">
-                <Icons.LoadingSpinner className="animate-spin" />
-                <p>Thinking ...</p>
-            </div>
-        </>
+    return message && (
+        <div className="px-4 pt-2 text-small content-start flex flex-col text-wrap gap-2">
+            <MessageContent
+                messageId={message.id}
+                parts={message.parts}
+                applied={false}
+                isStream={true}
+            />
+        </div>
     );
 };

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/code-display/collapsible-code-block.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/code-display/collapsible-code-block.tsx
@@ -1,5 +1,5 @@
-import { api } from '@/trpc/react';
 import { useEditorEngine } from '@/components/store/editor';
+import { api } from '@/trpc/react';
 import { Button } from '@onlook/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@onlook/ui/collapsible';
 import { Icons } from '@onlook/ui/icons';
@@ -49,7 +49,6 @@ export const CollapsibleCodeBlock = observer(({
 
     return (
         <div className="group relative">
-
             <Collapsible open={isOpen} onOpenChange={setIsOpen}>
                 <div
                     className={cn(
@@ -83,16 +82,13 @@ export const CollapsibleCodeBlock = observer(({
                                 >
                                     <span className="truncate flex-1 min-w-0">{getTruncatedFileName(path)}</span>
                                     {(() => {
-                                        const branch = branchId 
+                                        const branch = branchId
                                             ? editorEngine.branches.allBranches.find(b => b.id === branchId)
                                             : editorEngine.branches.activeBranch;
                                         return branch && (
-                                            <>
-                                                
-                                                 <span className="text-foreground-tertiary group-hover:text-foreground-secondary text-mini ml-0.5 flex-shrink-0 truncate max-w-24">
-                                                     {' • '}{branch.name}
-                                                 </span>
-                                            </>
+                                            <span className="text-foreground-tertiary group-hover:text-foreground-secondary text-mini ml-0.5 flex-shrink-0 truncate max-w-24">
+                                                {' • '}{branch.name}
+                                            </span>
                                         );
                                     })()}
                                 </div>


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug by hiding code blocks during streaming in chat components using `isStreaming` prop.
> 
>   - **Behavior**:
>     - Add `isStreaming` prop to `AssistantMessage` and `ChatMessages` to control UI during streaming.
>     - Modify `ToolCallDisplay` to hide code blocks when `isStream` is true or tool state is not 'output-available' or 'input-available'.
>     - Update `CollapsibleCodeBlock` to adjust animation based on `isStream` and user settings.
>   - **Components**:
>     - `StreamMessage` simplified by removing unnecessary elements.
>     - `ChatMessages` shows a loading spinner and "Thinking ..." text when `isStreaming` is true.
>   - **Misc**:
>     - Minor import reordering in `collapsible-code-block.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 8024fbcc9433776058d9ed9013cc58af6f83b47d. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->