### PR TITLE
Double-click elements to open in code, click in blank canvas area to close code panel.

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/frame/gesture.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/frame/gesture.tsx
@@ -75,11 +75,14 @@ export const GestureScreen = observer(({ frame, isResizing }: { frame: Frame, is
                             editorEngine.elements.shiftClick(el);
                         } else {
                             editorEngine.elements.click([el]);
-                            editorEngine.move.startDragPreparation(el, pos, frameData);
+                            // Disabled: editorEngine.move.startDragPreparation(el, pos, frameData);
                         }
                         break;
                     case MouseAction.DOUBLE_CLICK:
-                        editorEngine.text.start(el, frameData.view);
+                        // Open element location in code panel instead of text editing
+                        if (el.oid) {
+                            editorEngine.ide.openCodeBlock(el.oid);
+                        }
                         break;
                 }
             } catch (error) {
@@ -98,8 +101,8 @@ export const GestureScreen = observer(({ frame, isResizing }: { frame: Frame, is
                     return;
                 }
 
-                if (editorEngine.move.shouldDrag) {
-                    await editorEngine.move.drag(e, getRelativeMousePosition);
+                if (false) { // Disabled: editorEngine.move.shouldDrag
+                    // Disabled: await editorEngine.move.drag(e, getRelativeMousePosition);
                 } else if (
                     editorEngine.state.editorMode === EditorMode.DESIGN ||
                     ((editorEngine.state.editorMode === EditorMode.INSERT_DIV ||
@@ -213,15 +216,22 @@ export const GestureScreen = observer(({ frame, isResizing }: { frame: Frame, is
     }
 
     const handleDragOver = async (e: React.DragEvent<HTMLDivElement>) => {
+        // Disabled drag and drop functionality
         e.preventDefault();
         e.stopPropagation();
-        await handleMouseEvent(e, MouseAction.MOVE);
+        // Disabled: await handleMouseEvent(e, MouseAction.MOVE);
     };
 
     const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+        // Disabled drag and drop functionality
         e.preventDefault();
         e.stopPropagation();
-
+        
+        toast.error("Drag and drop is disabled", {
+            description: "Element dragging has been disabled on this canvas",
+        });
+        
+        /* Disabled: Original drop functionality
         try {
             const propertiesData = e.dataTransfer.getData('application/json');
             if (!propertiesData) {
@@ -253,6 +263,7 @@ export const GestureScreen = observer(({ frame, isResizing }: { frame: Frame, is
                 description: error instanceof Error ? error.message : 'Unknown error',
             });
         }
+        */
     };
 
     const gestureScreenClassName = useMemo(() => {

--- a/apps/web/client/src/app/project/[id]/_components/canvas/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/index.tsx
@@ -2,7 +2,7 @@
 
 import { useEditorEngine } from '@/components/store/editor';
 import { EditorAttributes } from '@onlook/constants';
-import { EditorMode } from '@onlook/models';
+import { EditorMode, EditorTabValue } from '@onlook/models';
 import { throttle } from 'lodash';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -57,9 +57,23 @@ export const Canvas = observer(() => {
                 editorEngine.clearUI();
                 editorEngine.frames.deselectAll();
             }
+            
+            // Switch to chat mode when clicking on empty canvas space during code editing
+            console.log('Canvas click detected in design mode, current tab:', editorEngine.state.rightPanelTab);
+            if (editorEngine.state.rightPanelTab === EditorTabValue.DEV) {
+                console.log('Switching from DEV to CHAT mode');
+                editorEngine.state.rightPanelTab = EditorTabValue.CHAT;
+            }
         } else if (event.button === 0) {
             // Only clear UI for left clicks that don't start drag selection
             editorEngine.clearUI();
+            
+            // Switch to chat mode when clicking on empty canvas space during code editing
+            console.log('Canvas click detected, current tab:', editorEngine.state.rightPanelTab);
+            if (editorEngine.state.rightPanelTab === EditorTabValue.DEV) {
+                console.log('Switching from DEV to CHAT mode');
+                editorEngine.state.rightPanelTab = EditorTabValue.CHAT;
+            }
         }
     };
 

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/code-tab/code-controls.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/code-tab/code-controls.tsx
@@ -33,7 +33,7 @@ export const CodeControls = observer(() => {
 
     return (
         <>
-            <div className="flex flex-row opacity-50 transition-opacity duration-200 group-hover/panel:opacity-100">
+            <div className="flex flex-row items-center transition-opacity duration-200">
                 <Tooltip>
                     <DropdownMenu>
                         <TooltipTrigger asChild>
@@ -66,7 +66,6 @@ export const CodeControls = observer(() => {
                     </DropdownMenu>
                     <TooltipContent side="bottom" hideArrow>
                         <p>Create or Upload File</p>
-                        <TooltipArrow className="fill-foreground" />
                     </TooltipContent>
                 </Tooltip>
                 <Tooltip>
@@ -82,20 +81,19 @@ export const CodeControls = observer(() => {
                     </TooltipTrigger>
                     <TooltipContent side="bottom" hideArrow>
                         <p>New Folder</p>
-                        <TooltipArrow className="fill-foreground" />
                     </TooltipContent>
                 </Tooltip>
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <Button
-                            variant="ghost"
+                            variant="secondary"
                             size="icon"
                             onClick={saveFile}
                             disabled={!isDirty}
                             className={cn(
-                                "p-2 w-fit h-fit cursor-pointer",
+                                "px-1.5 py-0.75 w-fit h-fit cursor-pointer mr-0.5 ml-1",
                                 isDirty
-                                    ? "text-teal-200 hover:text-teal-100 hover:bg-teal-500"
+                                    ? "text-background-primary hover:text-teal-100 hover:bg-teal-500 bg-foreground-primary"
                                     : "hover:bg-background-onlook hover:text-teal-200"
                             )}
                         >
@@ -103,11 +101,11 @@ export const CodeControls = observer(() => {
                                 "h-4 w-4",
                                 isDirty && "text-teal-200 group-hover:text-teal-100"
                             )} />
+                            <span className="text-small">Save</span>
                         </Button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom" hideArrow>
                         <p>Save changes</p>
-                        <TooltipArrow className="fill-foreground" />
                     </TooltipContent>
                 </Tooltip>
             </div>

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/code-tab/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/code-tab/index.tsx
@@ -161,11 +161,13 @@ export const CodeTab = observer(() => {
 
             // Create the selection and apply it in a single transaction
             const selection = EditorSelection.create([EditorSelection.range(startPos, endPos)]);
+            
             editorView.dispatch({
                 selection,
                 effects: [
-                    EditorView.scrollIntoView(selection.main, {
-                        y: 'start'
+                    EditorView.scrollIntoView(startPos, {
+                        y: 'start',
+                        yMargin: 48 
                     })
                 ],
                 userEvent: 'select.element'


### PR DESCRIPTION
## Description
Double-click elements to open in code, click in blank canvas area to close code panel.

- removes ability to edit text in the canvas

## Related Issues

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
