### PR TITLE
feat: add more context to chat

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
@@ -138,21 +138,21 @@ export const ChatInput = observer(({
         }
         
         const savedInput = inputValue.trim();
-        setInputValue('');
         
         try {
             if (isStreaming) {
-                // Queue the message if currently streaming
+                // Queue the message if streaming
                 const queuedMessage = editorEngine.chat.queue.enqueue(savedInput, chatMode);
                 console.log('Message queued:', queuedMessage);
             } else {
                 // Send immediately if not streaming
                 await onSendMessage(savedInput, chatMode);
             }
+            // Clear input
+            setInputValue('');
         } catch (error) {
             console.error('Error sending message', error);
             toast.error('Failed to send message. Please try again.');
-            setInputValue(savedInput);
         }
     }
 

--- a/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/right-panel/chat-tab/chat-input/index.tsx
@@ -144,7 +144,6 @@ export const ChatInput = observer(({
             if (isStreaming) {
                 // Queue the message if currently streaming
                 const queuedMessage = editorEngine.chat.queue.enqueue(savedInput, chatMode);
-                toast.success('Message queued - will send when current response finishes');
                 console.log('Message queued:', queuedMessage);
             } else {
                 // Send immediately if not streaming

--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat/index.tsx
@@ -208,15 +208,20 @@ export function useChat({ conversationId, projectId, initialMessages }: UseChatP
                 );
             };
 
-            const cleanupContext = async () => {
-                await editorEngine.chat.context.clearImagesFromContext();
+            const cleanupContext = () => {
+                editorEngine.chat.context.clearImagesFromContext();
             };
 
             void cleanupContext();
             void fetchSuggestions();
             void applyCommit();
+            
+            // Process any queued messages
+            setTimeout(() => {
+                void editorEngine.chat.queue.processNext();
+            }, 500);
         }
-    }, [finishReason, conversationId]);
+    }, [finishReason, conversationId, editorEngine.chat.queue, editorEngine.chat.context, editorEngine.versions, setMessages]);
 
     useEffect(() => {
         editorEngine.chat.conversation.setConversationLength(messages.length);

--- a/apps/web/client/src/components/store/editor/chat/index.ts
+++ b/apps/web/client/src/components/store/editor/chat/index.ts
@@ -4,11 +4,13 @@ import { makeAutoObservable } from 'mobx';
 import type { EditorEngine } from '../engine';
 import { ChatContext } from './context';
 import { ConversationManager } from './conversation';
+import { MessageQueue } from './queue';
 
 export const FOCUS_CHAT_INPUT_EVENT = 'focus-chat-input';
 export class ChatManager {
     conversation: ConversationManager;
     context: ChatContext;
+    queue: MessageQueue;
 
     // Content sent from useChat hook
     _sendMessageAction: SendMessage | null = null;
@@ -17,6 +19,7 @@ export class ChatManager {
     constructor(private editorEngine: EditorEngine) {
         this.context = new ChatContext(this.editorEngine);
         this.conversation = new ConversationManager(this.editorEngine);
+        this.queue = new MessageQueue(this.editorEngine);
         makeAutoObservable(this);
     }
 
@@ -51,5 +54,6 @@ export class ChatManager {
     clear() {
         this.context.clear();
         this.conversation.clear();
+        this.queue.clear();
     }
 }

--- a/apps/web/client/src/components/store/editor/chat/queue.ts
+++ b/apps/web/client/src/components/store/editor/chat/queue.ts
@@ -18,7 +18,7 @@ export class MessageQueue {
     }
 
     get queue(): QueuedMessage[] {
-        return this._queue;
+        return [...this._queue];
     }
 
     get length(): number {

--- a/apps/web/client/src/components/store/editor/chat/queue.ts
+++ b/apps/web/client/src/components/store/editor/chat/queue.ts
@@ -1,0 +1,92 @@
+import { type ChatType } from '@onlook/models';
+import { makeAutoObservable } from 'mobx';
+import type { EditorEngine } from '../engine';
+
+export interface QueuedMessage {
+    content: string;
+    type: ChatType;
+    id: string;
+    timestamp: number;
+}
+
+export class MessageQueue {
+    private _queue: QueuedMessage[] = [];
+    private _isProcessing = false;
+
+    constructor(private editorEngine: EditorEngine) {
+        makeAutoObservable(this);
+    }
+
+    get queue(): QueuedMessage[] {
+        return this._queue;
+    }
+
+    get length(): number {
+        return this._queue.length;
+    }
+
+    get isProcessing(): boolean {
+        return this._isProcessing;
+    }
+
+    get isEmpty(): boolean {
+        return this._queue.length === 0;
+    }
+
+    enqueue(content: string, type: ChatType): QueuedMessage {
+        const message: QueuedMessage = {
+            content: content.trim(),
+            type,
+            id: `queued_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+            timestamp: Date.now(),
+        };
+        
+        this._queue.push(message);
+        return message;
+    }
+
+    dequeue(): QueuedMessage | null {
+        return this._queue.shift() || null;
+    }
+
+    removeMessage(id: string): boolean {
+        const index = this._queue.findIndex(msg => msg.id === id);
+        if (index !== -1) {
+            this._queue.splice(index, 1);
+            return true;
+        }
+        return false;
+    }
+
+    clear(): void {
+        this._queue = [];
+        this._isProcessing = false;
+    }
+
+    async processNext(): Promise<void> {
+        if (this._isProcessing || this.isEmpty || this.editorEngine.chat.isStreaming) {
+            return;
+        }
+
+        const nextMessage = this.dequeue();
+        if (!nextMessage) {
+            return;
+        }
+
+        this._isProcessing = true;
+        
+        try {
+            await this.editorEngine.chat.sendMessage(nextMessage.content, nextMessage.type);
+        } catch (error) {
+            console.error('Error processing queued message:', error);
+        } finally {
+            this._isProcessing = false;
+        }
+    }
+
+    async processAll(): Promise<void> {
+        while (!this.isEmpty && !this.editorEngine.chat.isStreaming) {
+            await this.processNext();
+        }
+    }
+}

--- a/apps/web/client/src/components/store/editor/chat/queue.ts
+++ b/apps/web/client/src/components/store/editor/chat/queue.ts
@@ -68,12 +68,13 @@ export class MessageQueue {
             return;
         }
 
+        this._isProcessing = true;
+        
         const nextMessage = this.dequeue();
         if (!nextMessage) {
+            this._isProcessing = false;
             return;
         }
-
-        this._isProcessing = true;
         
         try {
             await this.editorEngine.chat.sendMessage(nextMessage.content, nextMessage.type);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Implemented a queue system that allows users to interrupt AI operations and add more context without losing the current request.
Related Issues
<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->
Closes #2866
Type of Change
<!-- Put an `x` in the boxes that apply -->

## Screenshots (if applicable)

<img width="1700" height="741" alt="Screenshot 2025-09-22 at 9 48 21 AM" src="https://github.com/user-attachments/assets/ef2e8e7e-98ad-43f4-b48c-0724dba3fcd1" />


<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces a message queue system for chat, allowing users to queue messages during AI streaming and process them post-streaming.
> 
>   - **New Features**:
>     - Implemented `MessageQueue` class in `queue.ts` to handle queuing of chat messages.
>     - Updated `ChatManager` in `index.ts` to include `MessageQueue` and manage message queuing.
>     - Modified `ChatInput` in `index.tsx` to allow message queuing during AI streaming.
>   - **Behavior Changes**:
>     - `sendMessage` in `ChatInput` now queues messages if `isStreaming` is true.
>     - Placeholder in `ChatInput` shows number of queued messages during streaming.
>     - `useChat` hook processes queued messages after streaming ends.
>   - **UI Updates**:
>     - Send button in `ChatInput` changes icon and title during streaming to indicate queuing.
>     - Input is cleared on send and restored if sending fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 939cd08d18b56eb6d11cc3a5ca9429e54f2597a5. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now keep typing and queue messages while the assistant is streaming.
  - Send button adapts during streaming (queue indicator, updated icon/title) and only disables when the input is empty.
  - Placeholder shows the number of queued messages during streaming.

- Bug Fixes
  - Improved reliability so queued messages are automatically sent after streaming ends.
  - Input is cleared on send and restored if sending fails, preventing accidental text loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->