### PR TITLE
fix: Next.js hydration warning in layout component

### DIFF
--- a/apps/web/client/src/app/layout.tsx
+++ b/apps/web/client/src/app/layout.tsx
@@ -71,7 +71,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                     dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
                 />
             </head>
-            <body>
+            <body suppressHydrationWarning>
                 {isProduction && (
                     <>
                         <Script src="https://z.onlook.com/cdn-cgi/zaraz/i.js" strategy="lazyOnload" />


### PR DESCRIPTION
### Description

- Fixed a hydration mismatch warning that was appearing in the browser console when loading new blank projects. The issue was caused by browser extensions adding attributes to the body element during development, which caused Next.js to detect a mismatch between server-rendered and client-side HTML.

- Added `suppressHydrationWarning` to the body element in the layout component to resolve this warning while maintaining all existing functionality.

## Related Issues
Fixes the reported hydration warning issue with blank projects

## Type of Change
- [x] Bug fix