### PR TITLE
fix: push modified files back to sandbox

### DIFF
--- a/apps/web/client/src/services/sync-engine/sync-engine.ts
+++ b/apps/web/client/src/services/sync-engine/sync-engine.ts
@@ -157,6 +157,8 @@ export class CodeProviderSync {
         try {
             await this.pullFromSandbox();
             await this.setupWatching();
+            // Push any locally modified files (with OIDs) back to sandbox. This is required for the first time sync.
+            void this.pushModifiedFilesToSandbox();
         } catch (error) {
             this.isRunning = false;
             throw error;
@@ -306,6 +308,7 @@ export class CodeProviderSync {
             const localFiles = await this.fs.listFiles('/');
             const jsxFiles = localFiles.filter(path => /\.(jsx?|tsx?)$/i.test(path));
 
+            // TODO: Use available batch write API
             await Promise.all(
                 jsxFiles.map(async (filePath) => {
                     try {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `sync-engine.ts`, `start()` method now pushes modified files back to the sandbox during initial sync to ensure local changes are reflected.
> 
>   - **Behavior**:
>     - In `sync-engine.ts`, `start()` method of `CodeProviderSync` now calls `pushModifiedFilesToSandbox()` to push locally modified files back to the sandbox during initial sync.
>     - This ensures local changes are reflected in the sandbox from the start.
>   - **Misc**:
>     - Added a TODO comment to use batch write API in `pushModifiedFilesToSandbox()` for efficiency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 985b9aaa64c40e9e0baa2f48cde38693c9b590b7. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On startup, local changes to UI components are now automatically pushed to the sandbox during the initial sync, ensuring your latest edits appear immediately without waiting for subsequent saves or manual actions. This resolves cases where modified JSX/TSX files didn’t propagate until later, providing a more reliable, consistent first-run synchronization experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->