### PR TITLE
fix: drop over images

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/left-panel/design-panel/image-tab/image-item.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/design-panel/image-tab/image-item.tsx
@@ -173,6 +173,13 @@ export const ImageItem = ({ image, projectId, branchId, onImageDragStart, onImag
                 className="aspect-square bg-background-secondary rounded-md border border-border-primary overflow-hidden cursor-pointer hover:border-border-onlook transition-colors relative"
                 onDragStart={handleDragStart}
                 onDragEnd={onImageDragEnd}
+                onDragOver={(e) => {
+                    // Allow external file drops by preventing default but not stopping propagation
+                    const isExternalDrag = e.dataTransfer.types.includes('Files') && !e.dataTransfer.types.includes('application/json');
+                    if (isExternalDrag) {
+                        e.preventDefault();
+                    }
+                }}
                 onMouseDown={onImageMouseDown}
                 onMouseUp={onImageMouseUp}
             >


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow external file drops on `ImageItem` by preventing default drag-over behavior for non-JSON files in `image-item.tsx`.
> 
>   - **Behavior**:
>     - In `image-item.tsx`, added `onDragOver` event to `ImageItem` to allow external file drops by preventing default behavior for files not of type `application/json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 735b05784dedc1c9a8fc4171f4c302ea0f013fe7. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled dropping external image files onto the design panel’s image items by improving drag-over handling. This allows smoother import of files dragged from the desktop or other apps without interfering with existing drag interactions.
* **Bug Fixes**
  * Ensures external file drags are recognized while preserving in-app drag-and-drop behavior and preventing unintended blocking of other drag types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->