### PR TITLE
Fix: Disable isolated installs for bun v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
   #     - uses: oven-sh/setup-bun@v1
   #       with:
-  #         bun-version: 1.2.21
+  #         bun-version: 1.3.1
   #     - name: Cache dependencies
   #       uses: actions/cache@v4
   #       with:
@@ -40,7 +40,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.21
+          bun-version: 1.3.1
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -64,7 +64,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.21
+          bun-version: 1.3.1
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/bun.lock
+++ b/bun.lock
@@ -7,10 +7,6 @@
         "@onlook/eslint": "*",
       },
     },
-    "apps/admin": {
-      "name": "admin",
-      "version": "0.0.0",
-    },
     "apps/backend": {
       "name": "@onlook/backend",
       "devDependencies": {
@@ -1975,8 +1971,6 @@
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
-
-    "admin": ["admin@workspace:apps/admin"],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+linker = "hoisted"

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
     "devDependencies": {
         "@onlook/eslint": "*"
     },
-    "packageManager": "bun@1.2.21"
+    "packageManager": "bun@1.3.1"
 }


### PR DESCRIPTION
## Description

Vercel started using bun 1.3 under the hood - there's no known way to pin the version of bun for now to avoid CI crashing. Logs from Vercel: 
```
13:32:08.564 Running build in Washington, D.C., USA (East) – iad1
13:32:08.565 Build machine configuration: 4 cores, 8 GB
13:32:08.580 Cloning [github.com/onlook-dev/onlook](http://github.com/onlook-dev/onlook) (Branch: fix-chat-scroll, Commit: f1d8881)
13:32:09.838 Warning: Failed to fetch one or more git submodules
13:32:09.838 Cloning completed: 1.258s
13:32:15.909 Restored build cache from previous deployment (7sWccrXMxhxSFnE49dRDBDp3MHk7)
13:32:19.881 Running “vercel build”
13:32:20.301 Vercel CLI 48.2.9
13:32:20.447 Detected OpenTelemetry dependency: @vercel/otel@1.13.0, which meets the minimum version requirement of 1.11.0
13:32:20.682 Running “install” command: bun install...
13:32:20.726 bun install v1.3.0 (b0a6feca)
...
```

https://bun.com/blog/bun-v1.3#isolated-installs-are-now-the-default-for-workspaces <- this shows how to avoid the breaking changes that are now the default for us.

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Bun version to 1.3.1 and adjust configuration for Vercel compatibility.
> 
>   - **Chores**:
>     - Update Bun version to `1.3.1` in `.github/workflows/ci.yml` and `package.json` to ensure compatibility with Vercel's environment.
>     - Remove unused `apps/admin` entry from `bun.lock`.
>     - Add `bunfig.toml` with `linker = "hoisted"` for package manager configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 597901deca6a46d036abb2e435e2cb72f082f09d. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded project runtime and package manager from Bun 1.2.21 to 1.3.1 for enhanced performance and stability
  * Updated all continuous integration workflows to consistently use Bun 1.3.1 across environments
  * Implemented build configuration settings to optimize dependency installation and management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->