### PR TITLE
Simulating Onlook -> Agent implementation

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/left-panel/design-panel/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/design-panel/index.tsx
@@ -1,6 +1,7 @@
 import { useEditorEngine } from '@/components/store/editor';
 import { transKeys } from '@/i18n/keys';
 import { LeftPanelTabValue } from '@onlook/models';
+import { Button } from '@onlook/ui/button';
 import { Icons } from '@onlook/ui/icons';
 import { cn } from '@onlook/ui/utils';
 import { observer } from 'mobx-react-lite';
@@ -47,11 +48,16 @@ const tabs: {
         },
     ];
 
-export const DesignPanel = observer(() => {
+interface DesignPanelProps {
+    onClose?: () => void;
+    activeSection?: string | null;
+}
+
+export const DesignPanel = observer(({ onClose, activeSection }: DesignPanelProps) => {
     const editorEngine = useEditorEngine();
     const t = useTranslations();
     const isLocked = editorEngine.state.leftPanelLocked;
-    const selectedTab = editorEngine.state.leftPanelTab;
+    const selectedTab = (activeSection as LeftPanelTabValue) || editorEngine.state.leftPanelTab;
 
     const handleMouseEnter = (tab: LeftPanelTabValue) => {
         if (isLocked) {
@@ -102,8 +108,8 @@ export const DesignPanel = observer(() => {
             className="flex h-full overflow-auto"
             onMouseLeave={handleMouseLeave}
         >
-            {/* Left sidebar with tabs */}
-            <div className="w-20 flex flex-col items-center py-0.5 gap-2 bg-background-onlook/60 backdrop-blur-xl">
+            {/* Left sidebar with tabs - HIDDEN */}
+            {/* <div className="w-20 flex flex-col items-center py-0.5 gap-2 bg-background-onlook/60 backdrop-blur-xl">
                 {tabs.map((tab) => (
                     <button
                         key={tab.value}
@@ -127,18 +133,47 @@ export const DesignPanel = observer(() => {
                     <ZoomControls />
                     <HelpButton />
                 </div>
-            </div>
+            </div> */}
 
             {/* Content panel */}
-            {editorEngine.state.leftPanelTab && (
+            {selectedTab && (
                 <>
                     <div className="flex-1 w-[280px] bg-background/95 rounded-xl">
-                        <div className="border backdrop-blur-xl h-full shadow overflow-auto p-0 rounded-xl">
-                            {selectedTab === LeftPanelTabValue.LAYERS && <LayersTab />}
-                            {selectedTab === LeftPanelTabValue.BRAND && <BrandTab />}
-                            {selectedTab === LeftPanelTabValue.PAGES && <PagesTab />}
-                            {selectedTab === LeftPanelTabValue.IMAGES && <ImagesTab />}
-                            {selectedTab === LeftPanelTabValue.BRANCHES && <BranchesTab />}
+                        <div className="border backdrop-blur-xl h-full shadow overflow-auto p-0 rounded-xl flex flex-col">
+                            {/* Panel header with close button */}
+                            <div className="flex items-center justify-between p-3 border-b border-border/50">
+                                <div className="flex items-center gap-2">
+                                    {selectedTab === LeftPanelTabValue.LAYERS && <Icons.Layers className="w-4 h-4" />}
+                                    {selectedTab === LeftPanelTabValue.BRAND && <Icons.Brand className="w-4 h-4" />}
+                                    {selectedTab === LeftPanelTabValue.PAGES && <Icons.File className="w-4 h-4" />}
+                                    {selectedTab === LeftPanelTabValue.IMAGES && <Icons.Image className="w-4 h-4" />}
+                                    {selectedTab === LeftPanelTabValue.BRANCHES && <Icons.Branch className="w-4 h-4" />}
+                                    <span className="text-sm font-medium">
+                                        {selectedTab === LeftPanelTabValue.LAYERS && t(transKeys.editor.panels.layers.tabs.layers)}
+                                        {selectedTab === LeftPanelTabValue.BRAND && t(transKeys.editor.panels.layers.tabs.brand)}
+                                        {selectedTab === LeftPanelTabValue.PAGES && t(transKeys.editor.panels.layers.tabs.pages)}
+                                        {selectedTab === LeftPanelTabValue.IMAGES && t(transKeys.editor.panels.layers.tabs.images)}
+                                        {selectedTab === LeftPanelTabValue.BRANCHES && t(transKeys.editor.panels.layers.tabs.branches)}
+                                    </span>
+                                </div>
+                                {onClose && (
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-6 w-6"
+                                        onClick={onClose}
+                                    >
+                                        <Icons.CrossS className="h-4 w-4" />
+                                    </Button>
+                                )}
+                            </div>
+                            <div className="flex-1 overflow-auto">
+                                {selectedTab === LeftPanelTabValue.LAYERS && <LayersTab />}
+                                {selectedTab === LeftPanelTabValue.BRAND && <BrandTab />}
+                                {selectedTab === LeftPanelTabValue.PAGES && <PagesTab />}
+                                {selectedTab === LeftPanelTabValue.IMAGES && <ImagesTab />}
+                                {selectedTab === LeftPanelTabValue.BRANCHES && <BranchesTab />}
+                            </div>
                         </div>
                     </div>
 

--- a/apps/web/client/src/app/project/[id]/_components/left-panel/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/left-panel/index.tsx
@@ -5,11 +5,16 @@ import { observer } from "mobx-react-lite";
 import { CodePanel } from "./code-panel";
 import { DesignPanel } from "./design-panel";
 
-export const LeftPanel = observer(() => {
+interface LeftPanelProps {
+    onClose?: () => void;
+    activeSection?: string | null;
+}
+
+export const LeftPanel = observer(({ onClose, activeSection }: LeftPanelProps) => {
     const editorEngine = useEditorEngine();
     return <>
         <div className={cn('size-full', editorEngine.state.editorMode !== EditorMode.DESIGN && editorEngine.state.editorMode !== EditorMode.PAN && 'hidden')}>
-            <DesignPanel />
+            <DesignPanel onClose={onClose} activeSection={activeSection} />
         </div>
         <div className={cn('size-full', editorEngine.state.editorMode !== EditorMode.CODE && 'hidden')}>
             <CodePanel />

--- a/apps/web/client/src/app/project/[id]/_components/main.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/main.tsx
@@ -4,14 +4,14 @@ import { useEditorEngine } from '@/components/store/editor';
 import { SubscriptionModal } from '@/components/ui/pricing-modal';
 import { SettingsModalWithProjects } from '@/components/ui/settings-modal/with-project';
 import { EditorAttributes } from '@onlook/constants';
-import { EditorMode } from '@onlook/models';
+import { EditorMode, LeftPanelTabValue } from '@onlook/models';
 import { Button } from '@onlook/ui/button';
 import { Icons } from '@onlook/ui/icons';
 import { TooltipProvider } from '@onlook/ui/tooltip';
 import { cn } from '@onlook/ui/utils';
 import { observer } from 'mobx-react-lite';
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { usePanelMeasurements } from '../_hooks/use-panel-measure';
 import { useStartProject } from '../_hooks/use-start-project';
 import { BottomBar } from './bottom-bar';
@@ -31,6 +31,19 @@ export const Main = observer(() => {
         leftPanelRef,
         rightPanelRef,
     );
+    const [activeSection, setActiveSection] = useState<string | null>(null);
+
+    const handleSidebarClick = (tab: LeftPanelTabValue) => {
+        editorEngine.state.leftPanelTab = tab;
+        editorEngine.state.leftPanelLocked = true;
+        setActiveSection(tab);
+    };
+
+    const handleClosePanel = () => {
+        editorEngine.state.leftPanelTab = null;
+        editorEngine.state.leftPanelLocked = false;
+        setActiveSection(null);
+    };
 
     useEffect(() => {
         function handleGlobalWheel(event: WheelEvent) {
@@ -82,7 +95,7 @@ export const Main = observer(() => {
     return (
         <TooltipProvider>
             <div className="h-screen w-screen flex flex-row select-none relative overflow-hidden">
-                <Canvas />
+                <Canvas onSidebarClick={handleSidebarClick} />
 
                 <div className="absolute top-0 w-full">
                     <TopBar />
@@ -91,9 +104,9 @@ export const Main = observer(() => {
                 {/* Left Panel */}
                 <div
                     ref={leftPanelRef}
-                    className="absolute top-10 left-0 h-[calc(100%-40px)] z-50"
+                    className="absolute top-10 left-2 h-[calc(100%-40px)] z-50"
                 >
-                    <LeftPanel />
+                    <LeftPanel onClose={handleClosePanel} activeSection={activeSection} />
                 </div>
                 {/* EditorBar anchored between panels */}
                 <div


### PR DESCRIPTION
## Description

Checking if Cursor was able to implement the following summary of changes from a mockup of the Onlook Canvas. 

"I need to implement a right-click context menu system for the canvas with the following requirements:

Hide the left sidebar buttons - Comment out or hide the Sidebar component that contains the vertical button panel on the left side

Install and configure context menu if it's not already in there. If IT IS, then don't replace it. - Add @radix-ui/react-context-menu package and create a reusable context menu component at /src/components/ui/context-menu.tsx with these exports:

ContextMenu, ContextMenuTrigger, ContextMenuContent
ContextMenuItem, ContextMenuSeparator
ContextMenuSub, ContextMenuSubTrigger, ContextMenuSubContent
Style with dark theme 
SubTrigger should have a right arrow icon indicator
Wrap Canvas in context menu if not already there - Update the Canvas right click to:

Accept an onSidebarClick prop
Add a context menu with this structure:
"Add Element" (with PlusIcon)
"Add Component" (with ComponentInstanceIcon)
Separator
"Panels" submenu (with grid icon) that expands to show:
Layers
Brand
Pages
Images
Separator
Branches
Separator
"Copy" (with ⌘ C shortcut text)
"Paste" (with ⌘ V shortcut text)
Update LeftPanel - Add:

onClose prop to LeftPanel component
X button (Cross2Icon from Radix) in the upper right corner of the panel header
Support nullable activeSection prop (string | null)
Update page.tsx - Modify to:

Pass onSidebarClick to Canvas component
Hide/comment out the Sidebar component
Reposition LeftPanel from left-20 to left-2 (since sidebar is hidden)
Pass onClose handler to LeftPanel that closes the panel

The end result should allow users to right-click the canvas, see a professional context menu with a "Panels" submenu option that opens the various side panels, and close panels with an X button in the upper-right corner

"

## Related Issues

<!-- Link any related issues using GitHub keywords (e.g., "closes #123", "fixes #456", "related to #789") -->

## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran or the steps to verify your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements a context menu for the canvas, updates the left panel with close functionality, and modifies the main component to integrate these changes.
> 
>   - **Canvas**:
>     - Adds a context menu to `Canvas` in `index.tsx` with options like "Add Element", "Add Component", and a "Panels" submenu.
>     - Integrates `ContextMenu` components from `@onlook/ui/context-menu`.
>     - Handles `onSidebarClick` prop to open specific panels.
>   - **Left Panel**:
>     - Updates `DesignPanel` and `LeftPanel` to support `onClose` and `activeSection` props.
>     - Hides the left sidebar buttons in `DesignPanel`.
>     - Adds close button to panel header in `DesignPanel`.
>   - **Main Component**:
>     - Modifies `Main` to pass `onSidebarClick` to `Canvas` and `onClose` to `LeftPanel`.
>     - Adjusts `LeftPanel` position to `left-2` in `main.tsx`.
>   - **Misc**:
>     - Installs `@radix-ui/react-context-menu` package for context menu functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 0811c8f8da6c57e930d36ba94f7022abf5728a0b. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a context menu on the canvas with options to add elements, manage panels, and perform copy/paste operations.
  * Left panel can now be opened/closed directly from the canvas context menu and displays the active tab with icons and labels.
  * Close button added to the left panel for easier dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->