### PR TITLE
feat: Add conversation memory for chat context continuity

### DIFF
--- a/apps/web/client/src/app/api/chat/route.ts
+++ b/apps/web/client/src/app/api/chat/route.ts
@@ -123,7 +123,9 @@ export const streamResponse = async (req: NextRequest, userId: string) => {
                     // Run in background to not block the response
                     void api.chat.conversation.updateSummary({
                         conversationId,
-                        messages: finalMessages,
+                        // Cast required because tRPC infers a stricter type from Zod schema
+                        // while ChatMessage is based on UIMessage from 'ai' package
+                        messages: finalMessages as unknown as Parameters<typeof api.chat.conversation.updateSummary>[0]['messages'],
                     }).catch((error) => {
                         console.warn('Failed to update conversation summary:', error);
                     });

--- a/apps/web/client/src/app/api/chat/route.ts
+++ b/apps/web/client/src/app/api/chat/route.ts
@@ -123,9 +123,7 @@ export const streamResponse = async (req: NextRequest, userId: string) => {
                     // Run in background to not block the response
                     void api.chat.conversation.updateSummary({
                         conversationId,
-                        // Cast required because tRPC infers a stricter type from Zod schema
-                        // while ChatMessage is based on UIMessage from 'ai' package
-                        messages: finalMessages as unknown as Parameters<typeof api.chat.conversation.updateSummary>[0]['messages'],
+                        messages: finalMessages,
                     }).catch((error) => {
                         console.warn('Failed to update conversation summary:', error);
                     });

--- a/packages/ai/src/chat/index.ts
+++ b/packages/ai/src/chat/index.ts
@@ -1,1 +1,2 @@
 export * from './providers';
+export * from './summarize';

--- a/packages/ai/src/chat/summarize.ts
+++ b/packages/ai/src/chat/summarize.ts
@@ -1,0 +1,123 @@
+import { LLMProvider, OPENROUTER_MODELS, type ChatMessage, type ChatSummary } from '@onlook/models';
+import { ChatSummarySchema } from '@onlook/models';
+import { generateObject } from 'ai';
+import { initModel } from './providers';
+
+/**
+ * Generates a summary of the conversation to maintain context across turns.
+ * This summary is stored in the database and injected into the system prompt
+ * to help the AI remember what was discussed and done in the conversation.
+ */
+export async function generateConversationSummary({
+    messages,
+    existingSummary,
+    conversationId,
+}: {
+    messages: ChatMessage[];
+    existingSummary: ChatSummary | null;
+    conversationId: string;
+}): Promise<ChatSummary> {
+    const { model, headers } = initModel({
+        provider: LLMProvider.OPENROUTER,
+        model: OPENROUTER_MODELS.CLAUDE_3_5_HAIKU, // Use a fast, cheap model for summarization
+    });
+
+    // Build context from recent messages (last 10 to avoid token limits)
+    const recentMessages = messages.slice(-10);
+    const messageContext = recentMessages
+        .map((msg) => {
+            const role = msg.role === 'user' ? 'User' : 'Assistant';
+            const content = msg.parts
+                .map((p) => {
+                    if (p.type === 'text') return p.text;
+                    // Tool invocation types start with 'tool-' (e.g., 'tool-read_file')
+                    if (p.type.startsWith('tool-')) {
+                        const toolName = p.type.replace('tool-', '');
+                        return `[Tool: ${toolName}]`;
+                    }
+                    return '';
+                })
+                .join(' ');
+            return `${role}: ${content}`;
+        })
+        .join('\n\n');
+
+    const existingSummaryContext = existingSummary
+        ? `
+Previous Summary:
+- Files discussed: ${existingSummary.filesDiscussed.join(', ') || 'None'}
+- Project context: ${existingSummary.projectContext}
+- Implementation details: ${existingSummary.implementationDetails}
+- User preferences: ${existingSummary.userPreferences}
+- Current status: ${existingSummary.currentStatus}
+`
+        : '';
+
+    const { object: summary } = await generateObject({
+        model,
+        headers,
+        schema: ChatSummarySchema,
+        prompt: `You are a summarization assistant. Analyze the conversation and create/update a summary that captures the key information needed for context continuity.
+
+${existingSummaryContext}
+
+Recent Conversation:
+${messageContext}
+
+Generate a comprehensive summary that:
+1. Lists all files that were discussed or modified
+2. Captures the user's overall project goals and what they're building
+3. Notes important implementation decisions and code patterns used
+4. Records any preferences the user has expressed
+5. Describes the current state and any pending work
+
+Keep each field concise but informative. Focus on information that would help continue the conversation in a future session.`,
+        maxOutputTokens: 500,
+    });
+
+    return summary;
+}
+
+/**
+ * Formats the conversation summary for injection into the system prompt.
+ */
+export function formatSummaryForPrompt(summary: ChatSummary | null): string {
+    if (!summary) {
+        return '';
+    }
+
+    const sections: string[] = [];
+
+    if (summary.filesDiscussed.length > 0) {
+        sections.push(`Files worked on: ${summary.filesDiscussed.join(', ')}`);
+    }
+
+    if (summary.projectContext) {
+        sections.push(`Project context: ${summary.projectContext}`);
+    }
+
+    if (summary.implementationDetails) {
+        sections.push(`Implementation notes: ${summary.implementationDetails}`);
+    }
+
+    if (summary.userPreferences) {
+        sections.push(`User preferences: ${summary.userPreferences}`);
+    }
+
+    if (summary.currentStatus) {
+        sections.push(`Current status: ${summary.currentStatus}`);
+    }
+
+    if (sections.length === 0) {
+        return '';
+    }
+
+    return `
+## CONVERSATION MEMORY
+The following is a summary of previous work in this conversation. Use this to maintain context and avoid redoing work:
+
+${sections.join('\n')}
+
+---
+`;
+}

--- a/packages/ai/src/chat/summarize.ts
+++ b/packages/ai/src/chat/summarize.ts
@@ -1,6 +1,7 @@
 import { LLMProvider, OPENROUTER_MODELS, type ChatMessage, type ChatSummary } from '@onlook/models';
 import { ChatSummarySchema } from '@onlook/models';
 import { generateObject } from 'ai';
+import { v4 as uuidv4 } from 'uuid';
 import { initModel } from './providers';
 
 /**
@@ -12,10 +13,12 @@ export async function generateConversationSummary({
     messages,
     existingSummary,
     conversationId,
+    userId,
 }: {
     messages: ChatMessage[];
     existingSummary: ChatSummary | null;
     conversationId: string;
+    userId: string;
 }): Promise<ChatSummary> {
     const { model, headers } = initModel({
         provider: LLMProvider.OPENROUTER,
@@ -73,6 +76,16 @@ Generate a comprehensive summary that:
 
 Keep each field concise but informative. Focus on information that would help continue the conversation in a future session.`,
         maxOutputTokens: 500,
+        experimental_telemetry: {
+            isEnabled: true,
+            metadata: {
+                conversationId,
+                userId,
+                tags: ['conversation-summary-generation'],
+                sessionId: conversationId,
+                langfuseTraceId: uuidv4(),
+            },
+        },
     });
 
     return summary;

--- a/packages/ai/test/chat/summarize.test.ts
+++ b/packages/ai/test/chat/summarize.test.ts
@@ -1,0 +1,277 @@
+import type { ChatMessage, ChatSummary } from '@onlook/models';
+import { describe, expect, test } from 'bun:test';
+import {
+    buildMessageContext,
+    extractMessageContent,
+    formatExistingSummaryContext,
+    formatSummaryForPrompt,
+    getRoleLabel,
+    SUMMARY_MESSAGE_LIMIT,
+} from '../../src/chat/summarize';
+
+function createMessage(
+    parts: ChatMessage['parts'],
+    role: 'user' | 'assistant' | 'system' = 'user'
+): ChatMessage {
+    return {
+        id: 'test-id',
+        createdAt: new Date(),
+        role,
+        threadId: 'test-thread',
+        parts,
+        metadata: { context: [], checkpoints: [] },
+    } as unknown as ChatMessage;
+}
+
+function createSummary(overrides: Partial<ChatSummary> = {}): ChatSummary {
+    return {
+        filesDiscussed: [],
+        projectContext: '',
+        implementationDetails: '',
+        userPreferences: '',
+        currentStatus: '',
+        ...overrides,
+    };
+}
+
+describe('SUMMARY_MESSAGE_LIMIT', () => {
+    test('is set to 10', () => {
+        expect(SUMMARY_MESSAGE_LIMIT).toBe(10);
+    });
+});
+
+describe('extractMessageContent', () => {
+    test('extracts text from text parts', () => {
+        const parts = [{ type: 'text', text: 'hello world' }] as ChatMessage['parts'];
+        expect(extractMessageContent(parts)).toBe('hello world');
+    });
+
+    test('extracts multiple text parts joined by space', () => {
+        const parts = [
+            { type: 'text', text: 'hello' },
+            { type: 'text', text: 'world' },
+        ] as ChatMessage['parts'];
+        expect(extractMessageContent(parts)).toBe('hello world');
+    });
+
+    test('formats tool invocations with tool name', () => {
+        // Create a minimal tool part - use unknown first to avoid strict type checking
+        const parts = [{ type: 'tool-read_file', toolCallId: 'test', state: 'output', input: { path: '/test' }, output: {} }] as unknown as ChatMessage['parts'];
+        expect(extractMessageContent(parts)).toBe('[Tool: read_file]');
+    });
+
+    test('handles mixed text and tool parts', () => {
+        const parts = [
+            { type: 'text', text: 'Reading file:' },
+            { type: 'tool-read_file', toolCallId: 'test', state: 'output', input: { path: '/test' }, output: {} },
+        ] as unknown as ChatMessage['parts'];
+        expect(extractMessageContent(parts)).toBe('Reading file: [Tool: read_file]');
+    });
+
+    test('ignores unknown part types', () => {
+        const parts = [
+            { type: 'text', text: 'visible' },
+            { type: 'unknown', data: 'ignored' },
+        ] as unknown as ChatMessage['parts'];
+        expect(extractMessageContent(parts)).toBe('visible ');
+    });
+
+    test('handles empty parts array', () => {
+        expect(extractMessageContent([])).toBe('');
+    });
+
+    test('handles undefined parts', () => {
+        expect(extractMessageContent(undefined)).toBe('');
+    });
+
+    test('handles null parts', () => {
+        expect(extractMessageContent(null)).toBe('');
+    });
+});
+
+describe('getRoleLabel', () => {
+    test('returns User for user role', () => {
+        expect(getRoleLabel('user')).toBe('User');
+    });
+
+    test('returns System for system role', () => {
+        expect(getRoleLabel('system')).toBe('System');
+    });
+
+    test('returns Assistant for assistant role', () => {
+        expect(getRoleLabel('assistant')).toBe('Assistant');
+    });
+});
+
+describe('buildMessageContext', () => {
+    test('builds context from single message', () => {
+        const messages = [createMessage([{ type: 'text', text: 'hello' }], 'user')];
+        expect(buildMessageContext(messages)).toBe('User: hello');
+    });
+
+    test('builds context from multiple messages', () => {
+        const messages = [
+            createMessage([{ type: 'text', text: 'hello' }], 'user'),
+            createMessage([{ type: 'text', text: 'hi there' }], 'assistant'),
+        ];
+        expect(buildMessageContext(messages)).toBe('User: hello\n\nAssistant: hi there');
+    });
+
+    test('includes system messages with correct label', () => {
+        const messages = [
+            createMessage([{ type: 'text', text: 'system instructions' }], 'system'),
+            createMessage([{ type: 'text', text: 'user input' }], 'user'),
+        ];
+        expect(buildMessageContext(messages)).toBe('System: system instructions\n\nUser: user input');
+    });
+
+    test('limits messages to SUMMARY_MESSAGE_LIMIT', () => {
+        const messages = Array.from({ length: 15 }, (_, i) =>
+            createMessage([{ type: 'text', text: `message ${i}` }], 'user')
+        );
+        const context = buildMessageContext(messages);
+        // Should only include last 10 messages (5-14)
+        expect(context).toContain('message 5');
+        expect(context).toContain('message 14');
+        expect(context).not.toContain('message 4');
+    });
+
+    test('accepts custom limit', () => {
+        const messages = Array.from({ length: 10 }, (_, i) =>
+            createMessage([{ type: 'text', text: `message ${i}` }], 'user')
+        );
+        const context = buildMessageContext(messages, 3);
+        // Should only include last 3 messages (7-9)
+        expect(context).toContain('message 7');
+        expect(context).toContain('message 9');
+        expect(context).not.toContain('message 6');
+    });
+
+    test('handles empty messages array', () => {
+        expect(buildMessageContext([])).toBe('');
+    });
+
+    test('handles messages with only tool invocations', () => {
+        const messages = [
+            createMessage([{ type: 'tool-read_file', input: {} }] as unknown as ChatMessage['parts'], 'assistant'),
+        ];
+        expect(buildMessageContext(messages)).toBe('Assistant: [Tool: read_file]');
+    });
+});
+
+describe('formatExistingSummaryContext', () => {
+    test('returns empty string for null summary', () => {
+        expect(formatExistingSummaryContext(null)).toBe('');
+    });
+
+    test('formats summary with all fields', () => {
+        const summary = createSummary({
+            filesDiscussed: ['src/index.ts', 'src/utils.ts'],
+            projectContext: 'Building a CLI tool',
+            implementationDetails: 'Using TypeScript with strict mode',
+            userPreferences: 'Prefer functional style',
+            currentStatus: 'Working on parsing logic',
+        });
+        const result = formatExistingSummaryContext(summary);
+        expect(result).toContain('Files discussed: src/index.ts, src/utils.ts');
+        expect(result).toContain('Project context: Building a CLI tool');
+        expect(result).toContain('Implementation details: Using TypeScript with strict mode');
+        expect(result).toContain('User preferences: Prefer functional style');
+        expect(result).toContain('Current status: Working on parsing logic');
+    });
+
+    test('shows None for empty filesDiscussed', () => {
+        const summary = createSummary({ filesDiscussed: [] });
+        const result = formatExistingSummaryContext(summary);
+        expect(result).toContain('Files discussed: None');
+    });
+});
+
+describe('formatSummaryForPrompt', () => {
+    test('returns empty string for null summary', () => {
+        expect(formatSummaryForPrompt(null)).toBe('');
+    });
+
+    test('returns empty string for summary with all empty fields', () => {
+        const summary = createSummary();
+        expect(formatSummaryForPrompt(summary)).toBe('');
+    });
+
+    test('includes CONVERSATION MEMORY header', () => {
+        const summary = createSummary({ projectContext: 'Test project' });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('## CONVERSATION MEMORY');
+    });
+
+    test('includes files worked on section', () => {
+        const summary = createSummary({
+            filesDiscussed: ['src/index.ts', 'src/utils.ts'],
+        });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('Files worked on: src/index.ts, src/utils.ts');
+    });
+
+    test('includes project context section', () => {
+        const summary = createSummary({
+            projectContext: 'Building a CLI tool',
+        });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('Project context: Building a CLI tool');
+    });
+
+    test('includes implementation notes section', () => {
+        const summary = createSummary({
+            implementationDetails: 'Using TypeScript',
+        });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('Implementation notes: Using TypeScript');
+    });
+
+    test('includes user preferences section', () => {
+        const summary = createSummary({
+            userPreferences: 'Prefer functional style',
+        });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('User preferences: Prefer functional style');
+    });
+
+    test('includes current status section', () => {
+        const summary = createSummary({
+            currentStatus: 'Working on feature X',
+        });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('Current status: Working on feature X');
+    });
+
+    test('only includes non-empty sections', () => {
+        const summary = createSummary({
+            projectContext: 'Test project',
+            currentStatus: 'In progress',
+            // other fields empty
+        });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('Project context: Test project');
+        expect(result).toContain('Current status: In progress');
+        expect(result).not.toContain('Files worked on:');
+        expect(result).not.toContain('Implementation notes:');
+        expect(result).not.toContain('User preferences:');
+    });
+
+    test('formats all sections correctly', () => {
+        const summary = createSummary({
+            filesDiscussed: ['file1.ts'],
+            projectContext: 'Project',
+            implementationDetails: 'Details',
+            userPreferences: 'Prefs',
+            currentStatus: 'Status',
+        });
+        const result = formatSummaryForPrompt(summary);
+        expect(result).toContain('## CONVERSATION MEMORY');
+        expect(result).toContain('---');
+        expect(result).toContain('Files worked on: file1.ts');
+        expect(result).toContain('Project context: Project');
+        expect(result).toContain('Implementation notes: Details');
+        expect(result).toContain('User preferences: Prefs');
+        expect(result).toContain('Current status: Status');
+    });
+});

--- a/packages/db/src/defaults/conversation.ts
+++ b/packages/db/src/defaults/conversation.ts
@@ -11,5 +11,6 @@ export const createDefaultConversation = (projectId: string): DbConversation => 
         displayName: 'New Conversation',
         suggestions: [],
         agentType: AgentType.ROOT,
+        summary: null,
     };
 };

--- a/packages/db/src/mappers/chat/conversation.ts
+++ b/packages/db/src/mappers/chat/conversation.ts
@@ -7,6 +7,7 @@ export const fromDbConversation = (conversation: DbConversation): ChatConversati
         title: conversation.displayName || null,
         agentType: conversation.agentType || AgentType.ROOT,
         suggestions: conversation.suggestions || [],
+        summary: conversation.summary || null,
     }
 }
 
@@ -17,5 +18,6 @@ export const toDbConversation = (conversation: ChatConversation): DbConversation
         displayName: conversation.title || null,
         agentType: conversation.agentType,
         suggestions: conversation.suggestions || [],
+        summary: conversation.summary || null,
     }
 }

--- a/packages/db/src/schema/chat/conversation.ts
+++ b/packages/db/src/schema/chat/conversation.ts
@@ -1,6 +1,6 @@
 import { AgentType, type ChatSuggestion, type ChatSummary } from "@onlook/models";
 import { relations } from "drizzle-orm";
-import { jsonb, pgEnum, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { jsonb, pgEnum, pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 import { createInsertSchema, createUpdateSchema } from "drizzle-zod";
 import { z } from "zod";
 import { projects } from "../project";

--- a/packages/db/src/schema/chat/conversation.ts
+++ b/packages/db/src/schema/chat/conversation.ts
@@ -1,6 +1,6 @@
-import { AgentType, type ChatSuggestion } from "@onlook/models";
+import { AgentType, type ChatSuggestion, type ChatSummary } from "@onlook/models";
 import { relations } from "drizzle-orm";
-import { jsonb, pgEnum, pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { jsonb, pgEnum, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 import { createInsertSchema, createUpdateSchema } from "drizzle-zod";
 import { z } from "zod";
 import { projects } from "../project";
@@ -20,6 +20,8 @@ export const conversations = pgTable("conversations", {
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
     suggestions: jsonb("suggestions").$type<ChatSuggestion[]>().default([]),
+    // Memory feature: stores a rolling summary of the conversation for context continuity
+    summary: jsonb("summary").$type<ChatSummary>(),
 }).enableRLS();
 
 export const conversationInsertSchema = createInsertSchema(conversations, {

--- a/packages/db/src/seed/db.ts
+++ b/packages/db/src/seed/db.ts
@@ -135,6 +135,8 @@ const conversation0 = {
     displayName: 'Test Conversation',
     createdAt: new Date(),
     updatedAt: new Date(),
+    agentType: null,
+    summary: null,
     suggestions: [
         {
             title: 'Test Suggestion',

--- a/packages/models/src/chat/conversation/index.ts
+++ b/packages/models/src/chat/conversation/index.ts
@@ -1,4 +1,5 @@
 import type { ChatSuggestion } from '../suggestion';
+import type { ChatSummary } from '../summary';
 
 export enum AgentType {
     ROOT = "root",
@@ -13,4 +14,6 @@ export interface ChatConversation {
     createdAt: Date;
     updatedAt: Date;
     suggestions: ChatSuggestion[];
+    // Memory feature: rolling summary of conversation for context continuity
+    summary: ChatSummary | null;
 }

--- a/packages/models/src/chat/summary.ts
+++ b/packages/models/src/chat/summary.ts
@@ -15,3 +15,5 @@ export const ChatSummarySchema = z.object({
         .describe('Specific preferences the user has expressed about implementation, design, etc.'),
     currentStatus: z.string().describe('Current state of the project and any pending work'),
 });
+
+export type ChatSummary = z.infer<typeof ChatSummarySchema>;


### PR DESCRIPTION
## Summary

Implements issue #2898 - Allow the chat to have memory.

This PR adds a **rolling summary system** that maintains conversation context across turns, preventing the AI from redoing work and ensuring coherent long-running conversations.

## Changes

### Database Schema (`packages/db`)
- Added `summary` field (JSONB) to `conversations` table storing structured `ChatSummary`
- Updated mappers, defaults, and seed data

### AI Package (`packages/ai`)
- **New**: `packages/ai/src/chat/summarize.ts` - Core summarization logic
  - `generateConversationSummary()` - Uses Claude 3.5 Haiku for efficient summarization
  - `formatSummaryForPrompt()` - Formats summary for system prompt injection
- Updated `createRootAgentStream()` to accept and inject `conversationSummary`

### Models (`packages/models`)
- Added `ChatSummary` type export from existing `ChatSummarySchema`
- Added `summary` field to `ChatConversation` interface

### Web Client (`apps/web/client`)
- Chat route fetches existing summary before streaming
- After AI response completes, triggers background summary update
- New `updateSummary` tRPC endpoint generates/stores summaries

## How It Works

1. **On chat start**: Existing conversation summary is fetched and injected into system prompt
2. **During chat**: AI sees "CONVERSATION MEMORY" section with context about previous work
3. **After response**: Background job generates updated summary capturing new information
4. **Next turn**: Updated summary ensures continuity

## Summary Structure

```typescript
interface ChatSummary {
  filesDiscussed: string[];        // Files worked on
  projectContext: string;          // What user is building
  implementationDetails: string;   // Key code decisions
  userPreferences: string;         // User's expressed preferences
  currentStatus: string;           // Current state & pending work
}
```

## Testing

- Ran typechecks on modified packages - no new errors introduced
- Pre-existing type errors in web-client unrelated to these changes

## Related Issues

Fixes #2898

## Type of Change

- [x] New feature
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds conversation memory feature to maintain chat context continuity by storing and utilizing conversation summaries.
> 
>   - **Behavior**:
>     - Adds conversation memory feature to maintain chat context across turns.
>     - `generateConversationSummary()` in `summarize.ts` creates summaries using Claude 3.5 Haiku.
>     - `formatSummaryForPrompt()` formats summaries for system prompt injection.
>     - `createRootAgentStream()` in `root.ts` injects summaries into system prompts.
>   - **Database**:
>     - Adds `summary` field to `conversations` table in `conversation.ts` schema.
>     - Updates `createDefaultConversation()` and mappers in `conversation.ts` to handle summaries.
>     - Seed data in `db.ts` includes conversation summaries.
>   - **API**:
>     - `streamResponse()` in `route.ts` fetches and updates conversation summaries.
>     - `updateSummary` endpoint in `conversation.ts` generates and stores summaries.
>   - **Models**:
>     - Defines `ChatSummary` type and schema in `summary.ts`.
>     - Updates `ChatConversation` interface in `conversation/index.ts` to include `summary`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for d9c44364b58eeb6b3c4cbf8d202e04ceb13ffb15. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations now maintain a rolling summary so the AI retains relevant context across messages.
  * AI responses use this conversation memory for more coherent, context-aware assistance.

* **Chores**
  * Conversation storage and data shapes updated to persist summaries across sessions.

* **Tests**
  * Added comprehensive unit tests for the conversation summarization utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->