### PR TITLE
fix: add optionalAuthProcedure to prevent UNAUTHORIZED errors on public pages (#3051)

### DIFF
--- a/apps/web/client/src/server/api/routers/subscription/subscription.ts
+++ b/apps/web/client/src/server/api/routers/subscription/subscription.ts
@@ -4,7 +4,7 @@ import { createBillingPortalSession, createCheckoutSession, createCustomer, isTi
 import { and, eq, isNull } from 'drizzle-orm';
 import { headers } from 'next/headers';
 import { z } from 'zod';
-import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { createTRPCRouter, optionalAuthProcedure, protectedProcedure } from '../../trpc';
 
 export const subscriptionRouter = createTRPCRouter({
     getLegacySubscriptions: protectedProcedure.query(async ({ ctx }) => {
@@ -36,6 +36,34 @@ export const subscriptionRouter = createTRPCRouter({
         }
 
         // If there is a scheduled price, we need to fetch it from the database.
+        let scheduledPrice = null;
+        if (subscription.scheduledPriceId) {
+            scheduledPrice = await ctx.db.query.prices.findFirst({
+                where: eq(prices.id, subscription.scheduledPriceId),
+            }) ?? null;
+        }
+
+        return fromDbSubscription(subscription, scheduledPrice);
+    }),
+    getOptional: optionalAuthProcedure.query(async ({ ctx }) => {
+        if (!ctx.user) {
+            return null;
+        }
+        const subscription = await ctx.db.query.subscriptions.findFirst({
+            where: and(
+                eq(subscriptions.userId, ctx.user.id),
+                eq(subscriptions.status, SubscriptionStatus.ACTIVE),
+            ),
+            with: {
+                product: true,
+                price: true,
+            },
+        });
+
+        if (!subscription) {
+            return null;
+        }
+
         let scheduledPrice = null;
         if (subscription.scheduledPriceId) {
             scheduledPrice = await ctx.db.query.prices.findFirst({

--- a/apps/web/client/src/server/api/routers/user/user.ts
+++ b/apps/web/client/src/server/api/routers/user/user.ts
@@ -5,11 +5,31 @@ import { extractNames } from '@onlook/utility';
 import type { User as SupabaseUser } from "@supabase/supabase-js";
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { createTRPCRouter, optionalAuthProcedure, protectedProcedure } from '../../trpc';
 import { userSettingsRouter } from './user-settings';
 
 export const userRouter = createTRPCRouter({
     get: protectedProcedure.query(async ({ ctx }) => {
+        const authUser = ctx.user;
+        const user = await ctx.db.query.users.findFirst({
+            where: eq(users.id, authUser.id),
+        });
+
+        const { displayName, firstName, lastName } = getUserName(authUser);
+        const userData = user ? fromDbUser({
+            ...user,
+            firstName: user.firstName ?? firstName,
+            lastName: user.lastName ?? lastName,
+            displayName: user.displayName ?? displayName,
+            email: user.email ?? authUser.email,
+            avatarUrl: user.avatarUrl ?? authUser.user_metadata.avatarUrl,
+        }) : null;
+        return userData;
+    }),
+    getOptional: optionalAuthProcedure.query(async ({ ctx }) => {
+        if (!ctx.user) {
+            return null;
+        }
         const authUser = ctx.user;
         const user = await ctx.db.query.users.findFirst({
             where: eq(users.id, authUser.id),

--- a/apps/web/client/src/server/api/trpc.ts
+++ b/apps/web/client/src/server/api/trpc.ts
@@ -30,13 +30,14 @@ import { ZodError } from 'zod';
  */
 export const createTRPCContext = async (opts: { headers: Headers }) => {
     const supabase = await createClient();
-    const {
-        data: { user },
-        error,
-    } = await supabase.auth.getUser();
 
-    if (error) {
-        throw new TRPCError({ code: 'UNAUTHORIZED', message: error.message });
+    // Attempt to get the user, but don't throw on auth errors.
+    // Unauthenticated visitors (e.g., marketing pages) should still get a valid
+    // context with user set to null. Protected procedures validate auth separately.
+    let user: User | null = null;
+    const { data, error } = await supabase.auth.getUser();
+    if (!error && data.user) {
+        user = data.user;
     }
 
     return {
@@ -144,6 +145,25 @@ export const protectedProcedure = t.procedure.use(timingMiddleware).use(({ ctx, 
         ctx: {
             // infers the `session` as non-nullable
             user: ctx.user as SetRequiredDeep<User, 'email'>,
+            db: ctx.db,
+        },
+    });
+});
+
+/**
+ * Optional auth procedure
+ *
+ * Use this for endpoints where authentication is optional. The user context is
+ * passed through as-is (may be null for unauthenticated visitors). Components
+ * like telemetry providers, pricing tables, and auth buttons on marketing pages
+ * should use this instead of protectedProcedure.
+ *
+ * @see https://trpc.io/docs/procedures
+ */
+export const optionalAuthProcedure = t.procedure.use(timingMiddleware).use(({ ctx, next }) => {
+    return next({
+        ctx: {
+            user: ctx.user ?? null,
             db: ctx.db,
         },
     });


### PR DESCRIPTION
## Summary

Fixes #3051.

**Root cause:** `createTRPCContext()` throws `TRPCError({ code: 'UNAUTHORIZED' })` when `supabase.auth.getUser()` returns an error, which happens for ALL unauthenticated visitors. This means even `publicProcedure` endpoints fail for visitors on marketing pages. Components like the telemetry provider, top bar auth button, and pricing table call `user.get` and `subscription.get` (protected endpoints), generating cascading UNAUTHORIZED errors and retries.

**Fix:** Three changes:

1. **`trpc.ts` — `createTRPCContext()`:** Don't throw on auth errors. Instead, set `user` to `null` for unauthenticated visitors. `protectedProcedure` still validates auth via its middleware, so existing protected endpoints are unaffected.

2. **`trpc.ts` — new `optionalAuthProcedure`:** A new procedure type that passes through the user context as-is (may be `null`). Use this for endpoints where authentication is optional.

3. **`user/user.ts` and `subscription/subscription.ts`:** Added `getOptional` endpoints using `optionalAuthProcedure` that return `null` for unauthenticated users instead of throwing. Components on marketing/public pages should use `user.getOptional` and `subscription.getOptional` instead of the protected variants.

## Changes

- `apps/web/client/src/server/api/trpc.ts`:
  - `createTRPCContext()`: Catch auth errors gracefully, set `user` to `null` instead of throwing.
  - New `optionalAuthProcedure` export for auth-optional endpoints.
- `apps/web/client/src/server/api/routers/user/user.ts`:
  - New `getOptional` query that returns user data if authenticated, `null` otherwise.
- `apps/web/client/src/server/api/routers/subscription/subscription.ts`:
  - New `getOptional` query that returns subscription data if authenticated, `null` otherwise.

## Migration Guide

Components that currently call `user.get` or `subscription.get` on pages accessible to unauthenticated visitors should switch to `user.getOptional` / `subscription.getOptional`:

```diff
- const user = api.user.get.useQuery();
+ const user = api.user.getOptional.useQuery();
```

## Root Cause Analysis

The tRPC context creation was designed assuming all API requests come from authenticated users. When the app expanded to include marketing pages with shared components (telemetry, auth button, pricing), these components' tRPC calls failed at the context level before reaching any procedure middleware. The `protectedProcedure` middleware was correctly checking auth, but the context creation was throwing first.

## Risk Assessment

- **Low risk for existing endpoints:** `protectedProcedure` still enforces auth via its own middleware. Existing protected endpoints continue to reject unauthenticated requests.
- **`publicProcedure` now works for unauthenticated users:** This is the correct behavior — public procedures should not require auth.
- **Component changes needed:** Frontend components on marketing pages need to be updated to use `getOptional` instead of `get`. This PR provides the backend support; frontend migration can be done incrementally.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `optionalAuthProcedure` to handle unauthenticated users gracefully and adds optional auth endpoints in user and subscription routers.
> 
>   - **Behavior**:
>     - `createTRPCContext()` in `trpc.ts`: Sets `user` to `null` for unauthenticated users instead of throwing an error.
>     - Introduces `optionalAuthProcedure` in `trpc.ts` for endpoints where authentication is optional.
>   - **Routers**:
>     - `user.ts`: Adds `getOptional` endpoint using `optionalAuthProcedure` to return user data or `null`.
>     - `subscription.ts`: Adds `getOptional` endpoint using `optionalAuthProcedure` to return subscription data or `null`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onlook-dev%2Fonlook&utm_source=github&utm_medium=referral)<sup> for 1dad7977a859796a2234c230feb0fd4c8903f524. You can [customize](https://app.ellipsis.dev/onlook-dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional authentication support to subscription and user information endpoints, allowing both authenticated and unauthenticated users to access certain data.
  * Enhanced request handling to gracefully support visitors without forcing authentication, while maintaining security for protected features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->