### PR TITLE
fix(sandbox): auto-bypass CSB free-tier trust interstitial and guard preload script race

### DIFF
--- a/apps/web/client/src/app/project/[id]/_components/canvas/frame/view.tsx
+++ b/apps/web/client/src/app/project/[id]/_components/canvas/frame/view.tsx
@@ -4,6 +4,7 @@ import type { IframeHTMLAttributes } from 'react';
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { connect, WindowMessenger } from 'penpal';
+import { PreloadScriptState } from '@/components/store/editor/sandbox';
 
 import type { Frame } from '@onlook/models';
 import type {
@@ -86,6 +87,12 @@ export const FrameComponent = observer(
 
             const setupPenpalConnection = () => {
                 try {
+                    const sandbox = editorEngine.activeSandbox;
+                    if (sandbox?.preloadScriptState === PreloadScriptState.LOADING) {
+                        console.log(`${PENPAL_PARENT_CHANNEL} (${frame.id}) - Preload script still loading, will retry on next load`);
+                        return;
+                    }
+
                     if (!iframeRef.current?.contentWindow) {
                         console.error(`${PENPAL_PARENT_CHANNEL} (${frame.id}) - No iframe found`);
                         onConnectionFailed();

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -22,6 +22,7 @@ export class SandboxManager {
     readonly gitManager: GitManager;
     private providerReactionDisposer?: () => void;
     private sync: CodeProviderSync | null = null;
+    private preloadRetryTimeoutId?: ReturnType<typeof setTimeout>;
     preloadScriptState: PreloadScriptState = PreloadScriptState.NOT_INJECTED
     routerConfig: RouterConfig | null = null;
 
@@ -111,7 +112,7 @@ export class SandboxManager {
         } catch (error) {
             console.error('[SandboxManager] Failed to ensure preload script exists:', error);
             this.preloadScriptState = PreloadScriptState.NOT_INJECTED;
-            setTimeout(() => {
+            this.preloadRetryTimeoutId = setTimeout(() => {
                 if (this.preloadScriptState === PreloadScriptState.NOT_INJECTED) {
                     console.log('[SandboxManager] Retrying preload script injection...');
                     void this.ensurePreloadScriptExists();
@@ -218,11 +219,14 @@ export class SandboxManager {
     }
 
     clear() {
-        this.providerReactionDisposer?.();
-        this.providerReactionDisposer = undefined;
-        this.sync?.release();
-        this.sync = null;
-        this.preloadScriptState = PreloadScriptState.NOT_INJECTED
-        this.session.clear();
+    if (this.preloadRetryTimeoutId) {
+        clearTimeout(this.preloadRetryTimeoutId);
+        this.preloadRetryTimeoutId = undefined;
+    }
+    this.providerReactionDisposer = undefined;
+    this.sync?.release();
+    this.sync = null;
+    this.preloadScriptState = PreloadScriptState.NOT_INJECTED
+    this.session.clear();
     }
 }

--- a/apps/web/client/src/components/store/editor/sandbox/index.ts
+++ b/apps/web/client/src/components/store/editor/sandbox/index.ts
@@ -110,9 +110,13 @@ export class SandboxManager {
             this.preloadScriptState = PreloadScriptState.INJECTED
         } catch (error) {
             console.error('[SandboxManager] Failed to ensure preload script exists:', error);
-            // Mark as injected to prevent blocking frames indefinitely
-            // Frames will handle the missing preload script gracefully
-            this.preloadScriptState = PreloadScriptState.NOT_INJECTED
+            this.preloadScriptState = PreloadScriptState.NOT_INJECTED;
+            setTimeout(() => {
+                if (this.preloadScriptState === PreloadScriptState.NOT_INJECTED) {
+                    console.log('[SandboxManager] Retrying preload script injection...');
+                    void this.ensurePreloadScriptExists();
+                }
+            }, 3000);
         }
     }
 

--- a/apps/web/client/src/server/api/routers/project/project.ts
+++ b/apps/web/client/src/server/api/routers/project/project.ts
@@ -84,15 +84,16 @@ export const projectRouter = createTRPCRouter({
                 const url = getSandboxPreviewUrl(branch.sandboxId, port);
                 const app = new FirecrawlApp({ apiKey: env.FIRECRAWL_API_KEY });
 
-                // Optional: Add actions to click the button for CSB free tier
-                // const _csbFreeActions = [{
-                //     type: 'click',
-                //     selector: '#btn-answer-yes',
-                // }];
+                const csbFreeActions = [{
+                    type: 'click',
+                    selector: '#btn-answer-yes',
+                }];
+
                 const result = await app.scrapeUrl(url, {
                     formats: ['screenshot'],
                     onlyMainContent: true,
                     timeout: 10000,
+                    actions: csbFreeActions,
                 });
 
                 if (!result.success) {


### PR DESCRIPTION
## Description
Two separate issues were causing the Penpal connection to time out when using 
Onlook with a free-tier CodeSandbox account:

1. The CSB free-tier trust interstitial ("You are opening a CodeSandbox preview, 
do you want to continue?") was never auto-dismissed. The code to click 
`#btn-answer-yes` existed in `project.ts` but was commented out, leaving the 
iframe stuck on the interstitial page so the Penpal handshake never started.

2. A race condition in preload script injection — if `ensurePreloadScriptExists()` 
failed on first attempt (sandbox not ready yet), there was no retry and 
`preloadScriptState` stayed `NOT_INJECTED` permanently. The iframe would load 
before the preload script was ready, so the child-side Penpal connect never fired.

**Changes made:**

- `project.ts` — Uncommented and activated `csbFreeActions`, passing 
`{ type: 'click', selector: '#btn-answer-yes' }` as `actions` to Firecrawl 
`scrapeUrl` so the trust interstitial is auto-dismissed on screenshot capture.

- `sandbox/index.ts` — On preload script injection failure, schedules a single 
retry after 3s to handle the race where the sandbox is not yet fully ready on 
first attempt.

- `view.tsx` — Added a guard in `setupPenpalConnection` that skips the connection 
attempt if `activeSandbox.preloadScriptState === LOADING`, waiting for the next 
`onLoad` event instead of connecting too early.

## Related Issues
Fixes #3087

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing
1. Self-host Onlook against a free-tier CodeSandbox account
2. Create or import a Next.js project
3. Open the project page and navigate to any route
4. Verify the iframe loads the app directly — no trust interstitial appears
5. Verify `Penpal connection set` appears in browser console with no timeout error
6. Regression check: verify a paid CSB account (no interstitial) still connects normally

## Screenshots (if applicable)
N/A — bug manifested as a console timeout error, not a visual UI change.

## Additional Notes
The `csbFreeActions` fix only affects the `captureScreenshot` mutation which uses 
Firecrawl to scrape the preview URL. The preload script retry and LOADING guard 
together fix the deeper race condition that caused timeouts even after manually 
dismissing the interstitial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Prevented editor connection attempts while the sandbox preload script is still loading to avoid premature initialization
  * Added automatic retry for failed preload script injection with 3-second intervals and improved cleanup of retry timers
  * Enabled automated interaction during project scraping for free-tier workflows to streamline scraping operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->