### PR TITLE
fix: detect Next.js route groups as valid project structure

### DIFF
--- a/packages/utility/src/path.ts
+++ b/packages/utility/src/path.ts
@@ -84,7 +84,15 @@ export const isTargetFile = (
     }
 
     const dirName = normalize(path.dirname(targetFile));
-    return potentialPaths.some((p) => normalize(p) === dirName);
+    return potentialPaths.some((p) => {
+        const normalizedP = normalize(p);
+        if (normalizedP === dirName) return true;
+        // Support Next.js route groups: match files inside (group) subdirectories
+        // e.g., app/(marketing)/layout.tsx should match potentialPath 'app'
+        const parentDir = normalize(path.dirname(dirName));
+        const groupDir = path.basename(dirName);
+        return parentDir === normalizedP && /^\([^)]+\)$/.test(groupDir);
+    });
 };
 
 export const isRootLayoutFile = (

--- a/packages/utility/test/path.test.ts
+++ b/packages/utility/test/path.test.ts
@@ -190,4 +190,24 @@ describe('isTargetFile', () => {
         const targetFile = 'src/components/layout.tsx';
         expect(isRootLayoutFile(targetFile)).toBe(false);
     });
+
+    test('returns true for layout in a Next.js route group under app/', () => {
+        expect(isRootLayoutFile('app/(marketing)/layout.tsx')).toBe(true);
+    });
+
+    test('returns true for layout in a Next.js route group under src/app/', () => {
+        expect(isRootLayoutFile('src/app/(dashboard)/layout.tsx')).toBe(true);
+    });
+
+    test('returns true for layout in route group with jsx extension', () => {
+        expect(isRootLayoutFile('app/(app)/layout.jsx')).toBe(true);
+    });
+
+    test('returns false for layout nested deeper than one route group level', () => {
+        expect(isRootLayoutFile('app/(app)/nested/layout.tsx')).toBe(false);
+    });
+
+    test('returns false for layout in directory that looks like route group but is not', () => {
+        expect(isRootLayoutFile('app/marketing/layout.tsx')).toBe(false);
+    });
 });


### PR DESCRIPTION
## Summary

Next.js projects using route groups (parenthesized directories like `(app)`, `(dashboard)`) were rejected during project import because the validator only checked for layout files at the exact `app/` or `src/app/` path level.

## Changes

Modified `isTargetFile` in `packages/utility/src/path.ts` to also match files inside Next.js route group subdirectories. A route group directory matches the `(name)` pattern per the Next.js App Router spec.

For example, `app/(marketing)/layout.tsx` now correctly matches the potential path `app`.

Added 5 test cases covering route group paths, including edge cases for nested directories and non-group directories.

## Testing

- All 36 existing + new tests pass (`bun test packages/utility/test/path.test.ts`)
- Typecheck passes (`bun run typecheck`)
- Verified that non-route-group subdirectories (e.g., `app/marketing/layout.tsx`) are still correctly rejected

Fixes #2936

This contribution was developed with AI assistance (Claude Code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition of Next.js route group subdirectories in file path handling.

* **Tests**
  * Added test coverage for layout files within route groups, including edge cases and nested scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->