### PR TITLE
[codex] Fix font panel globals CSS setup

### DIFF
--- a/apps/web/client/src/components/store/editor/font/css-theme.ts
+++ b/apps/web/client/src/components/store/editor/font/css-theme.ts
@@ -1,0 +1,107 @@
+import { addFontToCssTheme, removeFontFromCssTheme } from '@onlook/fonts';
+import type { Font, RouterConfig } from '@onlook/models';
+import type { EditorEngine } from '../engine';
+import type { SandboxManager } from '../sandbox';
+import { normalizePath } from '../sandbox/helpers';
+
+const GLOBAL_CSS_FILE = 'globals.css';
+
+function rankGlobalCssPath(path: string, routerConfig: RouterConfig): number {
+    const normalizedPath = normalizePath(path);
+
+    if (normalizedPath === normalizePath(`${routerConfig.basePath}/${GLOBAL_CSS_FILE}`)) {
+        return 0;
+    }
+
+    if (
+        routerConfig.basePath.startsWith('src/') &&
+        normalizedPath === normalizePath(`src/${GLOBAL_CSS_FILE}`)
+    ) {
+        return 1;
+    }
+
+    if (normalizedPath === GLOBAL_CSS_FILE) {
+        return 2;
+    }
+
+    return 3;
+}
+
+export const getGlobalCssPath = async (sandbox: SandboxManager): Promise<string | null> => {
+    const routerConfig = await sandbox.getRouterConfig();
+    if (!routerConfig) {
+        return null;
+    }
+
+    const files = await sandbox.listAllFiles();
+    const globalCssFiles = files
+        .filter(
+            (file) =>
+                file.type === 'file' &&
+                (file.path === GLOBAL_CSS_FILE || file.path.endsWith(`/${GLOBAL_CSS_FILE}`)),
+        )
+        .sort(
+            (a, b) =>
+                rankGlobalCssPath(a.path, routerConfig) - rankGlobalCssPath(b.path, routerConfig),
+        );
+
+    return globalCssFiles[0]?.path ?? null;
+};
+
+export const addFontToGlobalCss = async (
+    font: Font,
+    editorEngine: EditorEngine,
+): Promise<boolean> => {
+    try {
+        const sandbox = editorEngine.activeSandbox;
+        const cssPath = await getGlobalCssPath(sandbox);
+        if (!cssPath) {
+            return false;
+        }
+
+        const file = await sandbox.readFile(cssPath);
+        if (typeof file !== 'string') {
+            return false;
+        }
+
+        const result = addFontToCssTheme(font, file);
+        if (result === file) {
+            return true;
+        }
+
+        await sandbox.writeFile(cssPath, result);
+        return true;
+    } catch (error) {
+        console.error('Error adding font to global CSS:', error);
+        return false;
+    }
+};
+
+export const removeFontFromGlobalCss = async (
+    fontId: string,
+    editorEngine: EditorEngine,
+): Promise<boolean> => {
+    try {
+        const sandbox = editorEngine.activeSandbox;
+        const cssPath = await getGlobalCssPath(sandbox);
+        if (!cssPath) {
+            return false;
+        }
+
+        const file = await sandbox.readFile(cssPath);
+        if (typeof file !== 'string') {
+            return false;
+        }
+
+        const result = removeFontFromCssTheme(fontId, file);
+        if (result === file) {
+            return true;
+        }
+
+        await sandbox.writeFile(cssPath, result);
+        return true;
+    } catch (error) {
+        console.error('Error removing font from global CSS:', error);
+        return false;
+    }
+};

--- a/apps/web/client/src/components/store/editor/font/css-theme.ts
+++ b/apps/web/client/src/components/store/editor/font/css-theme.ts
@@ -1,8 +1,8 @@
 import { addFontToCssTheme, removeFontFromCssTheme } from '@onlook/fonts';
 import type { Font, RouterConfig } from '@onlook/models';
-import type { EditorEngine } from '../engine';
-import type { SandboxManager } from '../sandbox';
-import { normalizePath } from '../sandbox/helpers';
+import type { EditorEngine } from '@/components/store/editor/engine';
+import type { SandboxManager } from '@/components/store/editor/sandbox';
+import { normalizePath } from '@/components/store/editor/sandbox/helpers';
 
 const GLOBAL_CSS_FILE = 'globals.css';
 
@@ -13,10 +13,7 @@ function rankGlobalCssPath(path: string, routerConfig: RouterConfig): number {
         return 0;
     }
 
-    if (
-        routerConfig.basePath.startsWith('src/') &&
-        normalizedPath === normalizePath(`src/${GLOBAL_CSS_FILE}`)
-    ) {
+    if (normalizedPath === normalizePath(`src/${GLOBAL_CSS_FILE}`)) {
         return 1;
     }
 
@@ -48,9 +45,10 @@ export const getGlobalCssPath = async (sandbox: SandboxManager): Promise<string 
     return globalCssFiles[0]?.path ?? null;
 };
 
-export const addFontToGlobalCss = async (
-    font: Font,
+const updateGlobalCss = async (
     editorEngine: EditorEngine,
+    transform: (css: string) => string,
+    errorLabel: string,
 ): Promise<boolean> => {
     try {
         const sandbox = editorEngine.activeSandbox;
@@ -64,7 +62,7 @@ export const addFontToGlobalCss = async (
             return false;
         }
 
-        const result = addFontToCssTheme(font, file);
+        const result = transform(file);
         if (result === file) {
             return true;
         }
@@ -72,36 +70,29 @@ export const addFontToGlobalCss = async (
         await sandbox.writeFile(cssPath, result);
         return true;
     } catch (error) {
-        console.error('Error adding font to global CSS:', error);
+        console.error(errorLabel, error);
         return false;
     }
+};
+
+export const addFontToGlobalCss = async (
+    font: Font,
+    editorEngine: EditorEngine,
+): Promise<boolean> => {
+    return updateGlobalCss(
+        editorEngine,
+        (css) => addFontToCssTheme(font, css),
+        'Error adding font to global CSS:',
+    );
 };
 
 export const removeFontFromGlobalCss = async (
     fontId: string,
     editorEngine: EditorEngine,
 ): Promise<boolean> => {
-    try {
-        const sandbox = editorEngine.activeSandbox;
-        const cssPath = await getGlobalCssPath(sandbox);
-        if (!cssPath) {
-            return false;
-        }
-
-        const file = await sandbox.readFile(cssPath);
-        if (typeof file !== 'string') {
-            return false;
-        }
-
-        const result = removeFontFromCssTheme(fontId, file);
-        if (result === file) {
-            return true;
-        }
-
-        await sandbox.writeFile(cssPath, result);
-        return true;
-    } catch (error) {
-        console.error('Error removing font from global CSS:', error);
-        return false;
-    }
+    return updateGlobalCss(
+        editorEngine,
+        (css) => removeFontFromCssTheme(fontId, css),
+        'Error removing font from global CSS:',
+    );
 };

--- a/apps/web/client/src/components/store/editor/font/index.ts
+++ b/apps/web/client/src/components/store/editor/font/index.ts
@@ -6,6 +6,7 @@ import { generate } from '@onlook/parser';
 import { makeAutoObservable } from 'mobx';
 import type { EditorEngine } from '../engine';
 import { addFontToConfig, ensureFontConfigFileExists, getFontConfigPath, readFontConfigFile, removeFontFromConfig, scanExistingFonts, scanFontConfig } from './font-config';
+import { addFontToGlobalCss, removeFontFromGlobalCss } from './css-theme';
 import { FontSearchManager } from './font-search-manager';
 import { uploadFonts } from './font-upload-manager';
 import { addFontVariableToRootLayout, clearDefaultFontFromRootLayout, getCurrentDefaultFont, removeFontVariableFromRootLayout, updateDefaultFontInRootLayout, } from './layout-manager';
@@ -101,8 +102,15 @@ export class FontManager {
                 console.error('No font config path found');
                 return false;
             }
+            await this.ensureConfigFilesExist();
             const success = await addFontToConfig(font, fontConfigPath, this.editorEngine);
             if (success) {
+                await Promise.all([
+                    addFontToTailwindConfig(font, this.editorEngine.activeSandbox),
+                    addFontVariableToRootLayout(font.id, this.editorEngine),
+                    addFontToGlobalCss(font, this.editorEngine),
+                ]);
+
                 // Update the fonts array
                 this._fonts.push(font);
 
@@ -152,6 +160,7 @@ export class FontManager {
 
                 // Remove font from Tailwind config
                 await removeFontFromTailwindConfig(font, this.editorEngine.activeSandbox);
+                await removeFontFromGlobalCss(font.id, this.editorEngine);
 
                 return result;
             }
@@ -247,6 +256,7 @@ export class FontManager {
                     fontConfigPath,
                     code,
                 );
+                await this.syncFontsWithConfigs();
             }
 
             return result.success;
@@ -355,6 +365,7 @@ export class FontManager {
                 for (const font of addedFonts) {
                     await addFontToTailwindConfig(font, sandbox);
                     await addFontVariableToRootLayout(font.id, this.editorEngine);
+                    await addFontToGlobalCss(font, this.editorEngine);
                 }
             }
 

--- a/apps/web/client/src/components/store/editor/font/index.ts
+++ b/apps/web/client/src/components/store/editor/font/index.ts
@@ -4,9 +4,9 @@ import { type CodeDiff, type FontUploadFile } from '@onlook/models';
 import type { Font } from '@onlook/models/assets';
 import { generate } from '@onlook/parser';
 import { makeAutoObservable } from 'mobx';
+import { addFontToGlobalCss, removeFontFromGlobalCss } from '@/components/store/editor/font/css-theme';
 import type { EditorEngine } from '../engine';
 import { addFontToConfig, ensureFontConfigFileExists, getFontConfigPath, readFontConfigFile, removeFontFromConfig, scanExistingFonts, scanFontConfig } from './font-config';
-import { addFontToGlobalCss, removeFontFromGlobalCss } from './css-theme';
 import { FontSearchManager } from './font-search-manager';
 import { uploadFonts } from './font-upload-manager';
 import { addFontVariableToRootLayout, clearDefaultFontFromRootLayout, getCurrentDefaultFont, removeFontVariableFromRootLayout, updateDefaultFontInRootLayout, } from './layout-manager';
@@ -105,11 +105,16 @@ export class FontManager {
             await this.ensureConfigFilesExist();
             const success = await addFontToConfig(font, fontConfigPath, this.editorEngine);
             if (success) {
-                await Promise.all([
+                const [tailwindUpdated, layoutUpdated, globalCssUpdated] = await Promise.all([
                     addFontToTailwindConfig(font, this.editorEngine.activeSandbox),
                     addFontVariableToRootLayout(font.id, this.editorEngine),
                     addFontToGlobalCss(font, this.editorEngine),
                 ]);
+
+                if (!tailwindUpdated || !layoutUpdated || !globalCssUpdated) {
+                    console.error('Failed to apply font to one or more project config files');
+                    return false;
+                }
 
                 // Update the fonts array
                 this._fonts.push(font);
@@ -145,6 +150,17 @@ export class FontManager {
             const result = await removeFontFromConfig(font, fontConfigPath, this.editorEngine);
 
             if (result) {
+                const [layoutUpdated, tailwindUpdated, globalCssUpdated] = await Promise.all([
+                    removeFontVariableFromRootLayout(font.id, this.editorEngine),
+                    removeFontFromTailwindConfig(font, this.editorEngine.activeSandbox),
+                    removeFontFromGlobalCss(font.id, this.editorEngine),
+                ]);
+
+                if (!layoutUpdated || !tailwindUpdated || !globalCssUpdated) {
+                    console.error('Failed to remove font from one or more project config files');
+                    return false;
+                }
+
                 // Remove from fonts array
                 this._fonts = this._fonts.filter((f) => f.id !== font.id);
 
@@ -154,13 +170,6 @@ export class FontManager {
                 if (font.id === this._defaultFont) {
                     this._defaultFont = null;
                 }
-
-                // Remove font variable and font class from layout file
-                await removeFontVariableFromRootLayout(font.id, this.editorEngine);
-
-                // Remove font from Tailwind config
-                await removeFontFromTailwindConfig(font, this.editorEngine.activeSandbox);
-                await removeFontFromGlobalCss(font.id, this.editorEngine);
 
                 return result;
             }
@@ -358,6 +367,7 @@ export class FontManager {
                 for (const font of removedFonts) {
                     await removeFontFromTailwindConfig(font, sandbox);
                     await removeFontVariableFromRootLayout(font.id, this.editorEngine);
+                    await removeFontFromGlobalCss(font.id, this.editorEngine);
                 }
             }
 

--- a/apps/web/client/src/components/store/editor/font/layout-manager.ts
+++ b/apps/web/client/src/components/store/editor/font/layout-manager.ts
@@ -109,7 +109,7 @@ export const removeFontVariableFromRootLayout = async (
             await editorEngine.activeSandbox.writeFile(layoutPath, newContent);
             return true;
         }
-        return false;
+        return true;
     } catch (error) {
         console.error(`Error removing font variable`, error);
         return false;

--- a/packages/fonts/src/helpers/css-theme.ts
+++ b/packages/fonts/src/helpers/css-theme.ts
@@ -2,7 +2,7 @@ import type { Font } from '@onlook/models';
 
 const THEME_BLOCK_REGEX = /@theme(?:\s+inline)?\s*\{/g;
 
-function findThemeBlock(content: string): { start: number; bodyStart: number; end: number } | null {
+function findThemeBlock(content: string): { bodyStart: number; bodyEnd: number } | null {
     const match = THEME_BLOCK_REGEX.exec(content);
     THEME_BLOCK_REGEX.lastIndex = 0;
 
@@ -21,15 +21,18 @@ function findThemeBlock(content: string): { start: number; bodyStart: number; en
             depth--;
             if (depth === 0) {
                 return {
-                    start: match.index,
                     bodyStart,
-                    end: index,
+                    bodyEnd: index,
                 };
             }
         }
     }
 
     return null;
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function getThemeFontVariableName(fontId: string): string {
@@ -43,14 +46,12 @@ function getFontThemeDeclaration(font: Font): string {
     return `${themeVariable}: var(${fontVariable});`;
 }
 
+/**
+ * Adds or updates a Tailwind CSS `@theme` font token for an Onlook-managed font.
+ */
 export function addFontToCssTheme(font: Font, content: string): string {
     const declaration = getFontThemeDeclaration(font);
     const themeVariable = getThemeFontVariableName(font.id);
-    const existingDeclarationRegex = new RegExp(`(^\\s*)${themeVariable}\\s*:[^;]+;`, 'm');
-
-    if (existingDeclarationRegex.test(content)) {
-        return content.replace(existingDeclarationRegex, `$1${declaration}`);
-    }
 
     const block = findThemeBlock(content);
     if (!block) {
@@ -58,15 +59,35 @@ export function addFontToCssTheme(font: Font, content: string): string {
         return `${content}${separator}@theme inline {\n    ${declaration}\n}\n`;
     }
 
-    const beforeClose = content.slice(0, block.end).replace(/\s*$/, '');
-    const afterClose = content.slice(block.end);
+    const beforeBody = content.slice(0, block.bodyStart);
+    const body = content.slice(block.bodyStart, block.bodyEnd);
+    const afterBody = content.slice(block.bodyEnd);
+    const escapedThemeVariable = escapeRegExp(themeVariable);
+    const existingDeclarationRegex = new RegExp(`(^\\s*)${escapedThemeVariable}\\s*:[^;]+;`, 'm');
 
-    return `${beforeClose}\n    ${declaration}\n${afterClose}`;
+    if (existingDeclarationRegex.test(body)) {
+        return `${beforeBody}${body.replace(existingDeclarationRegex, `$1${declaration}`)}${afterBody}`;
+    }
+
+    const trimmedBody = body.replace(/\s*$/, '');
+    return `${beforeBody}${trimmedBody}\n    ${declaration}\n${afterBody}`;
 }
 
+/**
+ * Removes a Tailwind CSS `@theme` font token for an Onlook-managed font.
+ */
 export function removeFontFromCssTheme(fontId: string, content: string): string {
-    const themeVariable = getThemeFontVariableName(fontId);
-    const declarationRegex = new RegExp(`\\n?\\s*${themeVariable}\\s*:[^;]+;`, 'g');
+    const block = findThemeBlock(content);
+    if (!block) {
+        return content;
+    }
 
-    return content.replace(declarationRegex, '');
+    const themeVariable = getThemeFontVariableName(fontId);
+    const escapedThemeVariable = escapeRegExp(themeVariable);
+    const declarationRegex = new RegExp(`\\n?\\s*${escapedThemeVariable}\\s*:[^;]+;`, 'g');
+    const beforeBody = content.slice(0, block.bodyStart);
+    const body = content.slice(block.bodyStart, block.bodyEnd);
+    const afterBody = content.slice(block.bodyEnd);
+
+    return `${beforeBody}${body.replace(declarationRegex, '')}${afterBody}`;
 }

--- a/packages/fonts/src/helpers/css-theme.ts
+++ b/packages/fonts/src/helpers/css-theme.ts
@@ -1,0 +1,72 @@
+import type { Font } from '@onlook/models';
+
+const THEME_BLOCK_REGEX = /@theme(?:\s+inline)?\s*\{/g;
+
+function findThemeBlock(content: string): { start: number; bodyStart: number; end: number } | null {
+    const match = THEME_BLOCK_REGEX.exec(content);
+    THEME_BLOCK_REGEX.lastIndex = 0;
+
+    if (!match) {
+        return null;
+    }
+
+    const bodyStart = match.index + match[0].length;
+    let depth = 1;
+
+    for (let index = bodyStart; index < content.length; index++) {
+        const char = content[index];
+        if (char === '{') {
+            depth++;
+        } else if (char === '}') {
+            depth--;
+            if (depth === 0) {
+                return {
+                    start: match.index,
+                    bodyStart,
+                    end: index,
+                };
+            }
+        }
+    }
+
+    return null;
+}
+
+function getThemeFontVariableName(fontId: string): string {
+    return `--font-${fontId}`;
+}
+
+function getFontThemeDeclaration(font: Font): string {
+    const themeVariable = getThemeFontVariableName(font.id);
+    const fontVariable = font.variable || themeVariable;
+
+    return `${themeVariable}: var(${fontVariable});`;
+}
+
+export function addFontToCssTheme(font: Font, content: string): string {
+    const declaration = getFontThemeDeclaration(font);
+    const themeVariable = getThemeFontVariableName(font.id);
+    const existingDeclarationRegex = new RegExp(`(^\\s*)${themeVariable}\\s*:[^;]+;`, 'm');
+
+    if (existingDeclarationRegex.test(content)) {
+        return content.replace(existingDeclarationRegex, `$1${declaration}`);
+    }
+
+    const block = findThemeBlock(content);
+    if (!block) {
+        const separator = content.endsWith('\n') ? '\n' : '\n\n';
+        return `${content}${separator}@theme inline {\n    ${declaration}\n}\n`;
+    }
+
+    const beforeClose = content.slice(0, block.end).replace(/\s*$/, '');
+    const afterClose = content.slice(block.end);
+
+    return `${beforeClose}\n    ${declaration}\n${afterClose}`;
+}
+
+export function removeFontFromCssTheme(fontId: string, content: string): string {
+    const themeVariable = getThemeFontVariableName(fontId);
+    const declarationRegex = new RegExp(`\\n?\\s*${themeVariable}\\s*:[^;]+;`, 'g');
+
+    return content.replace(declarationRegex, '');
+}

--- a/packages/fonts/src/helpers/index.ts
+++ b/packages/fonts/src/helpers/index.ts
@@ -1,6 +1,7 @@
 export * from './class-utils';
 export * from './ast-generators';
 export * from './ast-manipulators';
+export * from './css-theme';
 export * from './font-extractors';
 export * from './validators';
 export * from './import-export-manager';

--- a/packages/fonts/test/css-theme.test.ts
+++ b/packages/fonts/test/css-theme.test.ts
@@ -1,0 +1,47 @@
+import { describe } from 'bun:test';
+import type { Font } from '@onlook/models';
+import { addFontToCssTheme, removeFontFromCssTheme } from '../src/helpers/css-theme';
+import { runDataDrivenTests } from './test-utils';
+import path from 'path';
+
+const __dirname = import.meta.dir;
+
+describe('addFontToCssTheme', () => {
+    runDataDrivenTests(
+        {
+            casesDir: path.resolve(__dirname, 'data/css-theme/add-font-to-css-theme'),
+            inputFileName: 'config',
+            expectedFileName: 'expected',
+        },
+        async (input: { font: Font; content: string }) => {
+            return addFontToCssTheme(input.font, input.content);
+        },
+        async (content: string, filePath?: string) => {
+            const config = JSON.parse(content);
+            const inputContent = await Bun.file(
+                path.resolve(path.dirname(filePath || ''), 'input.css'),
+            ).text();
+            return { font: config.font, content: inputContent };
+        },
+    );
+});
+
+describe('removeFontFromCssTheme', () => {
+    runDataDrivenTests(
+        {
+            casesDir: path.resolve(__dirname, 'data/css-theme/remove-font-from-css-theme'),
+            inputFileName: 'config',
+            expectedFileName: 'expected',
+        },
+        async (input: { fontId: string; content: string }) => {
+            return removeFontFromCssTheme(input.fontId, input.content);
+        },
+        async (content: string, filePath?: string) => {
+            const config = JSON.parse(content);
+            const inputContent = await Bun.file(
+                path.resolve(path.dirname(filePath || ''), 'input.css'),
+            ).text();
+            return { fontId: config.fontId, content: inputContent };
+        },
+    );
+});

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/existing-theme/config.json
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/existing-theme/config.json
@@ -1,0 +1,11 @@
+{
+    "font": {
+        "id": "inter",
+        "family": "Inter",
+        "variable": "--font-inter",
+        "subsets": ["latin"],
+        "weight": ["400"],
+        "styles": ["normal"],
+        "type": "google"
+    }
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/existing-theme/expected.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/existing-theme/expected.css
@@ -1,0 +1,6 @@
+@import 'tailwindcss';
+
+@theme {
+    --color-background: #ffffff;
+    --font-inter: var(--font-inter);
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/existing-theme/input.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/existing-theme/input.css
@@ -1,0 +1,5 @@
+@import 'tailwindcss';
+
+@theme {
+    --color-background: #ffffff;
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/no-theme/config.json
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/no-theme/config.json
@@ -1,0 +1,11 @@
+{
+    "font": {
+        "id": "open-sans",
+        "family": "Open Sans",
+        "variable": "--font-open-sans",
+        "subsets": ["latin"],
+        "weight": ["400"],
+        "styles": ["normal"],
+        "type": "google"
+    }
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/no-theme/expected.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/no-theme/expected.css
@@ -1,0 +1,9 @@
+@import 'tailwindcss';
+
+body {
+    margin: 0;
+}
+
+@theme inline {
+    --font-open-sans: var(--font-open-sans);
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/no-theme/input.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/no-theme/input.css
@@ -1,0 +1,5 @@
+@import 'tailwindcss';
+
+body {
+    margin: 0;
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/outside-theme-token/config.json
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/outside-theme-token/config.json
@@ -1,0 +1,11 @@
+{
+    "font": {
+        "id": "inter",
+        "family": "Inter",
+        "variable": "--font-inter",
+        "subsets": ["latin"],
+        "weight": ["400"],
+        "styles": ["normal"],
+        "type": "google"
+    }
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/outside-theme-token/expected.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/outside-theme-token/expected.css
@@ -1,0 +1,8 @@
+:root {
+    --font-inter: system-ui;
+}
+
+@theme inline {
+    --color-background: #ffffff;
+    --font-inter: var(--font-inter);
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/outside-theme-token/input.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/outside-theme-token/input.css
@@ -1,0 +1,7 @@
+:root {
+    --font-inter: system-ui;
+}
+
+@theme inline {
+    --color-background: #ffffff;
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/regex-font-id/config.json
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/regex-font-id/config.json
@@ -1,0 +1,11 @@
+{
+    "font": {
+        "id": "font.test",
+        "family": "Font Test",
+        "variable": "--font-font-test",
+        "subsets": ["latin"],
+        "weight": ["400"],
+        "styles": ["normal"],
+        "type": "google"
+    }
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/regex-font-id/expected.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/regex-font-id/expected.css
@@ -1,0 +1,4 @@
+@theme inline {
+    --font-font-test: var(--font-old);
+    --font-font.test: var(--font-font-test);
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/regex-font-id/input.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/regex-font-id/input.css
@@ -1,0 +1,4 @@
+@theme inline {
+    --font-font-test: var(--font-old);
+    --font-font.test: var(--font-old);
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/updates-existing/config.json
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/updates-existing/config.json
@@ -1,0 +1,11 @@
+{
+    "font": {
+        "id": "inter",
+        "family": "Inter",
+        "variable": "--font-inter-display",
+        "subsets": ["latin"],
+        "weight": ["400"],
+        "styles": ["normal"],
+        "type": "google"
+    }
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/updates-existing/expected.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/updates-existing/expected.css
@@ -1,0 +1,3 @@
+@theme inline {
+    --font-inter: var(--font-inter-display);
+}

--- a/packages/fonts/test/data/css-theme/add-font-to-css-theme/updates-existing/input.css
+++ b/packages/fonts/test/data/css-theme/add-font-to-css-theme/updates-existing/input.css
@@ -1,0 +1,3 @@
+@theme inline {
+    --font-inter: var(--font-old);
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/outside-theme-token/config.json
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/outside-theme-token/config.json
@@ -1,0 +1,3 @@
+{
+    "fontId": "inter"
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/outside-theme-token/expected.css
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/outside-theme-token/expected.css
@@ -1,0 +1,7 @@
+:root {
+    --font-inter: system-ui;
+}
+
+@theme inline {
+    --color-background: #ffffff;
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/outside-theme-token/input.css
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/outside-theme-token/input.css
@@ -1,0 +1,8 @@
+:root {
+    --font-inter: system-ui;
+}
+
+@theme inline {
+    --font-inter: var(--font-inter);
+    --color-background: #ffffff;
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/regex-font-id/config.json
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/regex-font-id/config.json
@@ -1,0 +1,3 @@
+{
+    "fontId": "font.test"
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/regex-font-id/expected.css
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/regex-font-id/expected.css
@@ -1,0 +1,3 @@
+@theme inline {
+    --font-font-test: var(--font-old);
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/regex-font-id/input.css
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/regex-font-id/input.css
@@ -1,0 +1,4 @@
+@theme inline {
+    --font-font-test: var(--font-old);
+    --font-font.test: var(--font-font-test);
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/removes-font/config.json
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/removes-font/config.json
@@ -1,0 +1,3 @@
+{
+    "fontId": "inter"
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/removes-font/expected.css
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/removes-font/expected.css
@@ -1,0 +1,3 @@
+@theme inline {
+    --color-background: #ffffff;
+}

--- a/packages/fonts/test/data/css-theme/remove-font-from-css-theme/removes-font/input.css
+++ b/packages/fonts/test/data/css-theme/remove-font-from-css-theme/removes-font/input.css
@@ -1,0 +1,4 @@
+@theme inline {
+    --font-inter: var(--font-inter);
+    --color-background: #ffffff;
+}


### PR DESCRIPTION
## Summary
- wire font panel adds/removes through globals.css Tailwind v4 theme tokens
- apply Tailwind config, root layout variable imports, and globals CSS immediately after font additions
- add data-driven coverage for CSS theme token insertion, updates, and removal

Fixes #2912

## Validation
- git diff --check
- bun test packages/fonts/test/css-theme.test.ts packages/fonts/test/ast-manipulators.test.ts (not run: bun is not installed in this shell)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global CSS theme now updates when fonts are added or removed from the editor; font changes are synchronized with layout and theme settings for consistent styling

* **Tests**
  * Added data-driven tests covering adding and removing fonts in CSS theme scenarios (multiple fixtures and edge cases)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->