### PR TITLE
fix: correct server.js path in Dockerfile CMD for standalone build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD bun -e "fetch('http://localhost:3000').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"
 
 # Start the Next.js server
-CMD ["bun", "apps/web/client/server.js"]
+CMD ["bun", "apps/web/client/.next/standalone/apps/web/client/server.js"]


### PR DESCRIPTION
Fixes #3046

## Problem

The Dockerfile `CMD` instruction referenced `apps/web/client/server.js`, which does not exist after a Next.js standalone build. When running the Docker image, bun throws:

```
error: Module not found "apps/web/client/server.js"
```

## Solution

Updated the `CMD` path to match the actual standalone build output location:
```
apps/web/client/.next/standalone/apps/web/client/server.js
```

This matches what the `start:standalone` script in `apps/web/client/package.json` already uses:
```json
"start:standalone": "bun .next/standalone/apps/web/client/server.js"
```

The `build:standalone` script copies assets into `.next/standalone/apps/web/client/`, so the server entry point is always at that path when building from the monorepo root.

## Testing

The fix aligns the Dockerfile CMD with the existing `start:standalone` npm script, which is the canonical way to start the standalone server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container startup configuration to reference the optimized standalone build output location, ensuring proper application initialization and consistent deployment behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->