### PR TITLE
fix: sanitize null providerExecuted in tool-call parts to prevent ModelMessage validation error

### DIFF
--- a/packages/ai/src/stream/index.ts
+++ b/packages/ai/src/stream/index.ts
@@ -66,22 +66,35 @@ export const ensureToolCallResults = (parts: ChatMessage['parts']): ChatMessage[
         }
     });
 
-    // Second pass: update parts that need stub results
+    // Second pass: update parts that need stub results and sanitize null fields
     return parts.map((part) => {
         if (part.type?.startsWith('tool-')) {
             const toolPart = part as ToolUIPart;
+
+            // Sanitize providerExecuted: DB JSONB can store JSON null, but the AI SDK's
+            // Zod schema uses z.boolean().optional() which accepts undefined but rejects null,
+            // causing standardizePrompt to throw "The messages must be a ModelMessage[]".
+            const rawProviderExecuted = (toolPart as { providerExecuted?: boolean | null })
+                .providerExecuted;
+            const sanitizedPart =
+                rawProviderExecuted === null
+                    ? ({ ...toolPart, providerExecuted: undefined } as ToolUIPart)
+                    : toolPart;
+
             if (
-                toolPart.toolCallId &&
-                (toolPart.state === 'input-available' || toolPart.state === 'input-streaming') &&
-                !toolResultIds.has(toolPart.toolCallId)
+                sanitizedPart.toolCallId &&
+                (sanitizedPart.state === 'input-available' ||
+                    sanitizedPart.state === 'input-streaming') &&
+                !toolResultIds.has(sanitizedPart.toolCallId)
             ) {
                 // Update existing part to have stub result
                 return {
-                    ...toolPart,
+                    ...sanitizedPart,
                     state: 'output-available',
                     output: 'No tool result returned',
                 };
             }
+            return sanitizedPart;
         }
         return part;
     });


### PR DESCRIPTION
## Problem

Closes #2888

When a conversation with tool calls is loaded from the database and the AI stream resumes, the app throws:

```
Invalid prompt: The messages must be a ModelMessage[]. If you have passed a UIMessage[], you can use convertToModelMessages to convert them.
```

## Root Cause

Tool-call parts are stored as JSONB in the database. JSONB permits JSON `null` as a valid value for any field — so `providerExecuted` can be stored as `null` when it wasn't explicitly set (e.g. from older records or a race during streaming).

In `convertToModelMessages` (AI SDK v5, `src/ui/convert-to-model-messages.ts`, line ~5915), the function passes `providerExecuted` directly from the UIMessage part into the ModelMessage content:

```ts
content.push({
  type: "tool-call",
  toolCallId: part.toolCallId,
  toolName,
  input: ...,
  providerExecuted: part.providerExecuted,  // null from DB passes through here
});
```

`standardizePrompt` then validates this against `modelMessageSchema` using Zod v4's `z.boolean().optional()`. In Zod v4, `.optional()` allows `undefined` but **rejects `null`** — causing the crash.

## Fix

`ensureToolCallResults` (in `packages/ai/src/stream/index.ts`) already processes all tool-call parts on every assistant message before `convertToModelMessages` runs. The fix adds a null-to-undefined sanitization step there:

```ts
// DB JSONB can store JSON null; z.boolean().optional() rejects null
const rawProviderExecuted = (toolPart as { providerExecuted?: boolean | null }).providerExecuted;
const sanitizedPart =
  rawProviderExecuted === null
    ? ({ ...toolPart, providerExecuted: undefined } as ToolUIPart)
    : toolPart;
```

This converts `null → undefined` for `providerExecuted` on every tool-call part before the AI SDK validates it, fixing the crash without affecting any other behavior.

## Test plan

- [ ] Start a conversation that uses tool calls (e.g. code actions)
- [ ] Close and reopen the project to reload the conversation from DB
- [ ] Verify the chat resumes and `streamText` is called without the "Invalid prompt" error
- [ ] Confirm existing tool call behavior (inline diffs, apply changes) still works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool call execution states to ensure consistent data processing and prevent validation errors during tool result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->