### PR TITLE
feat: support custom OpenRouter base URL via OPENROUTER_BASE_URL 

### DIFF
--- a/apps/web/client/.env.example
+++ b/apps/web/client/.env.example
@@ -8,6 +8,9 @@ SUPABASE_SERVICE_ROLE_KEY="<Your Supabase service role key>"
 
 # OpenRouter - Enables AI chat. Other providers are optional below
 OPENROUTER_API_KEY="<Your api key from https://openrouter.ai/settings/keys>"
+# Optional: override the OpenRouter API base URL (e.g. for self-hosted proxies or custom endpoints)
+# Defaults to https://openrouter.ai/api/v1 when unset
+# OPENROUTER_BASE_URL="https://your-proxy.example.com/api/v1"
 
 # Codesandbox - Used to host user apps. Other providers may be supported in the future. May be optional in the future.
 CSB_API_KEY="<Your api key from https://codesandbox.io/t/api>"

--- a/packages/ai/src/chat/providers.ts
+++ b/packages/ai/src/chat/providers.ts
@@ -45,10 +45,28 @@ export function initModel({
     };
 }
 
+/**
+ * Returns the base URL for the OpenRouter provider.
+ *
+ * The lookup order is:
+ *   1. `OPENROUTER_BASE_URL` environment variable (explicit override)
+ *   2. The default OpenRouter API endpoint
+ *
+ * This allows self-hosted deployments and proxy setups to point Onlook at a
+ * custom endpoint without modifying source code.
+ */
+function getOpenRouterBaseUrl(): string | undefined {
+    return process.env.OPENROUTER_BASE_URL || undefined;
+}
+
 function getOpenRouterProvider(model: OPENROUTER_MODELS): LanguageModel {
     if (!process.env.OPENROUTER_API_KEY) {
         throw new Error('OPENROUTER_API_KEY must be set');
     }
-    const openrouter = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
+    const baseURL = getOpenRouterBaseUrl();
+    const openrouter = createOpenRouter({
+        apiKey: process.env.OPENROUTER_API_KEY,
+        ...(baseURL && { baseURL }),
+    });
     return openrouter(model);
 }


### PR DESCRIPTION
## Summary

Closes #3048

Adds support for a custom OpenRouter API base URL, making it easy to use Onlook 
with a proxy or self-hosted OpenAI-compatible backend without modifying source code.

## What changed

### `packages/ai/src/chat/providers.ts`
- Added `getOpenRouterBaseUrl()` helper that reads the optional `OPENROUTER_BASE_URL` env var
- Passed resolved base URL to `createOpenRouter({ baseURL })` when set
- Default behaviour is **unchanged** when env var is absent

### `apps/web/client/.env.example`
- Documented the new `OPENROUTER_BASE_URL` optional variable

## Why

Users running Onlook behind a proxy, in air-gapped environments, or with a 
self-hosted endpoint have no way to redirect OpenRouter calls without patching code.
A single env var covers all these scenarios.

<!-- Put an `x` in the boxes that apply -->
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing
1. No env var set — behaviour unchanged ✅
2. Set `OPENROUTER_BASE_URL=https://your-proxy.example.com/api/v1` — requests routed to custom URL ✅
3. `tsc --noEmit` in `packages/ai` should pass ✅

## Checklist
- [x] No breaking changes (env var is optional)
- [x] `.env.example` updated with documentation
- [x] No new dependencies added



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `OPENROUTER_BASE_URL` environment variable configuration, enabling users to override the default OpenRouter API base URL with a custom endpoint while maintaining full backward compatibility with existing setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->