### PR TITLE
fix(ide): show toast errors when code view cannot open element

### DIFF
--- a/apps/web/client/src/components/store/editor/ide/index.ts
+++ b/apps/web/client/src/components/store/editor/ide/index.ts
@@ -1,4 +1,5 @@
 import { EditorMode, type CodeNavigationTarget } from "@onlook/models";
+import { toast } from "@onlook/ui/sonner";
 import { makeAutoObservable } from "mobx";
 import type { EditorEngine } from "../engine";
 
@@ -19,12 +20,14 @@ export class IdeManager {
             const activeBranchId = this.editorEngine.branches.activeBranch?.id;
             if (!activeBranchId) {
                 console.warn('[IdeManager] No active branch found');
+                toast.error('Cannot open code view — no active branch is loaded yet.');
                 return;
             }
 
             const branchData = this.editorEngine.branches.getBranchDataById(activeBranchId);
             if (!branchData) {
                 console.warn(`[IdeManager] No branch data found for branchId: ${activeBranchId}`);
+                toast.error('Cannot open code view — branch data is unavailable.');
                 return;
             }
 
@@ -32,6 +35,7 @@ export class IdeManager {
             const metadata = await branchData.codeEditor.getJsxElementMetadata(oid);
             if (!metadata) {
                 console.warn(`[IdeManager] No metadata found for OID: ${oid}`);
+                toast.error('Cannot open code view — element metadata not found. The project may still be indexing; try again in a moment.');
                 return;
             }
 


### PR DESCRIPTION
When 'View in Code' was clicked and the underlying metadata lookup failed (no active branch, missing branch data, or element metadata not yet indexed), the IdeManager silently logged console warnings and returned with no user feedback — leaving users confused about why nothing happened.

Add actionable toast.error() messages for each early-return path so users receive clear feedback:
- 'no active branch' → prompt to wait for project load
- 'no branch data' → prompt branch data unavailable
- 'no element metadata' → prompt project may still be indexing

Fixes #318

## Description

When users click the **"View in Code"** button (or right-click → "View instance code") and the underlying
metadata lookup fails, `IdeManager.openCodeBlock()` silently logs a `console.warn` and returns — 
leaving users with zero feedback about why nothing happened. This is the core of the UX problem
reported in #318 (originally about detecting missing VS Code / Cursor; the equivalent silent-failure
issue in the current web-based code panel is metadata being unavailable).

### Changes

**`apps/web/client/src/components/store/editor/ide/index.ts`**

- Import `toast` from `@onlook/ui/sonner`
- Replace the three silent `return` early-exits with `toast.error(…)` messages:
  - No active branch → `"Cannot open code view — no active branch is loaded yet."`
  - No branch data → `"Cannot open code view — branch data is unavailable."`
  - No element metadata → `"Cannot open code view — element metadata not found. The project may still be indexing; try again in a moment."`

### Why this matters

Users coming from component selection to code navigation have no indication when the code view
fails silently. The toast gives actionable context ("project may still be indexing") and matches
the UX pattern already used elsewhere in the store layer (e.g., `branch/manager.ts`).

## Related Issues

Fixes #318

## Type of Change

- [x] Bug fix

## Testing

1. Open a project where indexing hasn't completed yet (e.g., right after import).
2. Select any element on the canvas and click the code icon (top-right of the element overlay).
3. A toast should now appear: **"Cannot open code view — element metadata not found. The project may still be indexing; try again in a moment."**
4. Once the project is fully indexed, the same click opens the code panel normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added user-facing error notifications for code editor operations that fail due to missing branch data, unavailable project information, or indexing issues. Users now receive clear feedback when these conditions occur instead of experiencing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->