### PR TITLE
fix: correct server.js path in Dockerfile for standalone build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD bun -e "fetch('http://localhost:3000').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"
 
-# Start the Next.js server
-CMD ["bun", "apps/web/client/server.js"]
+# Start the Next.js server (standalone build output)
+CMD ["bun", ".next/standalone/apps/web/client/server.js"]


### PR DESCRIPTION
The Dockerfile was pointing to apps/web/client/server.js which doesn't exist. The standalone build outputs to .next/standalone/apps/web/client/server.js.

Fixes #3046

## Description

The Dockerfile was incorrectly pointing to `apps/web/client/server.js` which doesn't exist in the repository. When using standalone build output (`STANDALONE_BUILD=true`), Next.js outputs the server file to `.next/standalone/apps/web/client/server.js`.

This caused Docker builds to fail with error: "Module not found 'apps/web/client/server.js'"

### Related Issues

Fixes #3046

### Type of Change

- [x] Bug fix

### Testing

1. Build Docker image with the fixed Dockerfile
2. Run the container
3. Verify the application starts correctly on port 3000

### Additional Notes

The `start:standalone` script in package.json already correctly references `.next/standalone/apps/web/client/server.js`, but the Dockerfile was using the wrong path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated containerized application startup configuration to use an optimized server build output. Build steps, environment variables, port configuration, and health checks remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/onlook-dev/onlook/pull/3107)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->