### PR TITLE
fix: remove trailing whitespace from fonts.ts

### DIFF
--- a/apps/web/client/src/app/fonts.ts
+++ b/apps/web/client/src/app/fonts.ts
@@ -4,4 +4,4 @@ export const vujahdayScript = Vujahday_Script({
   weight: '400',
   subsets: ['latin'],
   display: 'swap',
-}); 
+});


### PR DESCRIPTION
Remove trailing whitespace for code hygiene.

Fixes #3081

## Description

### Problem
Line 6 of `apps/web/client/src/app/fonts.ts` had a trailing whitespace character, which triggers warnings in editors and CI linting tools that flag trailing spaces.

### Fix
Removed the trailing whitespace on line 6 of `apps/web/client/src/app/fonts.ts`.

### Testing
- No functional change — this is a code hygiene / whitespace cleanup only
- Verified the file renders identically; no runtime behavior is affected

Fixes #3081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed minor formatting in font configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/onlook-dev/onlook/pull/3112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->