### PR TITLE
Report tool call failures as UI errors

### DIFF
--- a/apps/web/client/src/app/project/[id]/_hooks/use-chat/index.tsx
+++ b/apps/web/client/src/app/project/[id]/_hooks/use-chat/index.tsx
@@ -56,7 +56,7 @@ export function useChat({ conversationId, projectId, initialMessages }: UseChatP
             }),
             onToolCall: async (toolCall) => {
                 setIsExecutingToolCall(true);
-                void handleToolCall(toolCall.toolCall, editorEngine, addToolResult).then(() => {
+                void handleToolCall(toolCall.toolCall, editorEngine, addToolResult).finally(() => {
                     setIsExecutingToolCall(false);
                 });
             },

--- a/apps/web/client/src/components/tools/tools.ts
+++ b/apps/web/client/src/components/tools/tools.ts
@@ -1,13 +1,16 @@
 import type { EditorEngine } from '@/components/store/editor/engine';
 import type { ToolCall } from '@ai-sdk/provider-utils';
-import { getToolClassesFromType } from '@onlook/ai';
+import { type AddToolResult, createToolErrorResult, getToolClassesFromType } from '@onlook/ai';
 import { toast } from '@onlook/ui/sonner';
 
-export async function handleToolCall(toolCall: ToolCall<string, unknown>, editorEngine: EditorEngine, addToolResult: (toolResult: { tool: string, toolCallId: string, output: any }) => Promise<void>) {
+export async function handleToolCall(
+    toolCall: ToolCall<string, unknown>,
+    editorEngine: EditorEngine,
+    addToolResult: AddToolResult,
+) {
     const toolName = toolCall.toolName;
     const currentChatMode = editorEngine.state.chatMode;
     const availableTools = getToolClassesFromType(currentChatMode);
-    let output: unknown = null;
 
     try {
         const tool = availableTools.find(tool => tool.toolName === toolName);
@@ -23,15 +26,13 @@ export async function handleToolCall(toolCall: ToolCall<string, unknown>, editor
         const validatedInput = tool.parameters.parse(toolCall.input);
         const toolInstance = new tool();
         // Can force type with as any because we know the input is valid.
-        output = await toolInstance.handle(validatedInput as any, editorEngine);
-    } catch (error) {
-        output = 'error handling tool call ' + error;
-    } finally {
-        void addToolResult({
+        const output = await toolInstance.handle(validatedInput as any, editorEngine);
+        await addToolResult({
             tool: toolName,
             toolCallId: toolCall.toolCallId,
-            output: output,
+            output,
         });
+    } catch (error) {
+        await addToolResult(createToolErrorResult(toolName, toolCall.toolCallId, error));
     }
-
 }

--- a/packages/ai/src/tools/index.ts
+++ b/packages/ai/src/tools/index.ts
@@ -1,4 +1,4 @@
 export * from './classes';
 export * from './models';
+export * from './result';
 export * from './toolset';
-

--- a/packages/ai/src/tools/result.ts
+++ b/packages/ai/src/tools/result.ts
@@ -1,0 +1,46 @@
+type ToolOutputResult = {
+    state?: 'output-available';
+    tool: string;
+    toolCallId: string;
+    output: unknown;
+    errorText?: never;
+};
+
+type ToolErrorResult = {
+    state: 'output-error';
+    tool: string;
+    toolCallId: string;
+    output?: never;
+    errorText: string;
+};
+
+export type AddToolResult = (toolResult: ToolOutputResult | ToolErrorResult) => Promise<void>;
+
+export function formatToolCallError(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message || error.name || 'Unknown tool error';
+    }
+
+    if (typeof error === 'string') {
+        return error;
+    }
+
+    try {
+        return JSON.stringify(error) ?? String(error);
+    } catch {
+        return String(error);
+    }
+}
+
+export function createToolErrorResult(
+    tool: string,
+    toolCallId: string,
+    error: unknown,
+): ToolErrorResult {
+    return {
+        state: 'output-error',
+        tool,
+        toolCallId,
+        errorText: formatToolCallError(error),
+    };
+}

--- a/packages/ai/test/stream/convert.test.ts
+++ b/packages/ai/test/stream/convert.test.ts
@@ -341,7 +341,7 @@ describe('ensureToolCallResults', () => {
             {
                 type: 'tool-divide',
                 toolCallId: 'call_1',
-                state: 'error',
+                state: 'output-error',
                 input: { a: 10, b: 0 },
                 errorText: 'Division by zero',
             } as any,
@@ -361,7 +361,7 @@ describe('ensureToolCallResults', () => {
         expect(result[0]).toEqual({
             type: 'tool-divide',
             toolCallId: 'call_1',
-            state: 'error',
+            state: 'output-error',
             input: { a: 10, b: 0 },
             errorText: 'Division by zero',
         });

--- a/packages/ai/test/tools/result.test.ts
+++ b/packages/ai/test/tools/result.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createToolErrorResult, formatToolCallError } from '../../src/tools/result';
+
+describe('tool result helpers', () => {
+    test('formats Error instances as user-facing messages', () => {
+        expect(formatToolCallError(new Error('Sandbox not found'))).toBe('Sandbox not found');
+    });
+
+    test('formats string errors without wrapping them as normal output', () => {
+        expect(formatToolCallError('Zod parse failed')).toBe('Zod parse failed');
+    });
+
+    test('formats undefined errors without returning undefined', () => {
+        expect(formatToolCallError(undefined)).toBe('undefined');
+    });
+
+    test('creates first-class output-error tool results', () => {
+        expect(createToolErrorResult('read_file', 'call_123', new Error('File is binary'))).toEqual({
+            state: 'output-error',
+            tool: 'read_file',
+            toolCallId: 'call_123',
+            errorText: 'File is binary',
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- report browser-side tool execution failures as AI SDK `output-error` tool results instead of normal output strings
- add a small shared helper for formatting tool-call errors and producing typed error results
- keep the chat execution state from getting stuck when `addToolResult` fails by clearing `isExecutingToolCall` in `finally`
- update the stream regression test to use the AI SDK v5 `output-error` state

## Why
Issue #2766 asks for tool results to carry an error string so the UI can render tool failures separately from successful results. The UI already passes `errorText` into `ToolOutput`, but `handleToolCall` was catching failures and sending `"error handling tool call ..."` as a normal `output`. That makes parse failures, unavailable tools, sandbox errors, and thrown client-tool failures look like successful tool output in the transcript.

This change preserves the existing success path while making failures first-class UI errors, so the chat can show the red error block and the next agent turn can distinguish a failed tool execution from a successful result string.

Closes #2766

## Verification
- `npm exec --package bun@1.3.1 -- bun test packages/ai/test/tools/result.test.ts`
- `npm exec --package bun@1.3.1 -- bun test packages/ai/test/stream/convert.test.ts`
- `npm exec --package bun@1.3.1 -- bun --filter @onlook/web-client typecheck`
- `git diff --check`

Note: `bun --filter @onlook/ai typecheck` still fails on existing repo alias/test typing issues unrelated to this change (for example unresolved `@/trpc/client` imports from web-client files referenced by the AI package and pre-existing test typing errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool call error handling to ensure UI state properly resets even when tool execution fails.
  * Enhanced error reporting for tool execution results with more consistent and standardized error handling.

* **Tests**
  * Added test coverage for tool result error handling and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/onlook-dev/onlook/pull/3113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->