### PR TITLE
fix: typo in web README

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -7,4 +7,4 @@ Structure
   app
 - Shared - All the shared packages for the web project
 - Preload - The script that gets injected into Template app. This allows
-  communnicating directly with the app DOM through iframe
+  communicating directly with the app DOM through iframe


### PR DESCRIPTION
## Summary
There's a double-n typo in `apps/web/README.md`: "communnicating" should be "communicating". Small but looks unprofessional in a contributor-facing doc.

## How to reproduce
Open `apps/web/README.md` and look at the description of the Preload section on line 10.

## Test plan
Verify the word reads "communicating" in the updated file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the README's Preload section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->