### PR TITLE
fix(scripts): use path.dirname in setup:env so it works on Windows

### DIFF
--- a/packages/scripts/src/api-keys.ts
+++ b/packages/scripts/src/api-keys.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import fs from 'node:fs';
+import path from 'node:path';
 import prompts from 'prompts';
 
 interface ApiKeyConfig {
@@ -157,7 +158,7 @@ const extractKeyName = (variableLine: string): string | undefined => {
  * @param filePath - Full path to the file
  */
 const ensureDirectoryExists = (filePath: string): void => {
-    const dir = filePath.substring(0, filePath.lastIndexOf('/'));
+    const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
     }

--- a/packages/scripts/test/comprehensive.test.ts
+++ b/packages/scripts/test/comprehensive.test.ts
@@ -658,7 +658,7 @@ SUPABASE_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres`;
             const content = 'TEST_KEY=test_value';
 
             // Simulate ensureDirectoryExists logic
-            const dir = nestedPath.substring(0, nestedPath.lastIndexOf('/'));
+            const dir = path.dirname(nestedPath);
             if (!fs.existsSync(dir)) {
                 fs.mkdirSync(dir, { recursive: true });
             }


### PR DESCRIPTION
## Description

`bun run setup:env` crashes on Windows at the API Key Configuration step, so the CSB/OpenRouter keys are never written to the `.env` files:

```
✓ Set CSB_API_KEY key
✓ Set OPENROUTER_API_KEY key
Failed to write API keys: Error: ENOENT: no such file or directory, mkdir ''
    at ensureDirectoryExists (packages/scripts/dist/index.js:9290:8)
```

**Root cause.** In `packages/scripts/src/api-keys.ts`, `ensureDirectoryExists()` derived the parent directory with a hardcoded forward-slash search:

```ts
const dir = filePath.substring(0, filePath.lastIndexOf('/'));
```

The env paths are built with `path.join(...)` (`src/index.ts`), so on Windows they use backslash separators (`...\web\client\.env`). `lastIndexOf('/')` then returns `-1`, `substring(0, -1)` returns `''`, and `fs.mkdirSync('')` throws `ENOENT: mkdir ''`. It only reproduces on Windows — POSIX paths use `/`, so the bug never triggers on Linux/macOS.

**Fix.** Use Node's cross-platform `path.dirname()`. This is already the pattern used for the same purpose in `packages/scripts/src/helpers.ts`, so the two write paths now agree.

I also updated the one test in `comprehensive.test.ts` that *reimplemented* the old slice-based logic (`nestedPath.substring(0, nestedPath.lastIndexOf('/'))`) instead of exercising the real function — which is why the suite passed on CI (Linux) while the bug shipped. It now uses `path.dirname()` too.

## Related Issues

Fixes #3119

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other (please describe):

## Testing

- `bun test` in `packages/scripts` — 43 pass, 0 fail.
- `bun run typecheck` and `bun run lint` in `packages/scripts` — no new errors or warnings introduced (pre-existing `TS6059` rootDir notices and prettier warnings are unchanged from `main` and unrelated to this change).
- CI (Linux) can't exercise the Windows path, so I verified the behaviour directly with Node's `path.win32`:

  | path | old `substring` | `path.dirname` |
  | --- | --- | --- |
  | `A:\Users\dev\onlook\apps\web\client\.env` | `""` → `ENOENT` | `A:\Users\dev\onlook\apps\web\client` |
  | `/home/dev/onlook/apps/web/client/.env` | `/home/dev/onlook/apps/web/client` | `/home/dev/onlook/apps/web/client` |

  Windows now resolves the parent dir correctly; POSIX output is identical, so there's no regression.

## Additional Notes

Minimal diff — 3 lines across two files. I don't have a Windows machine to run the full `setup:env` flow end-to-end; the `path.win32` check above isolates the exact line that threw.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory handling so nested paths are processed more reliably across different path formats.
  * Updated the related test coverage to match the new path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->