### PR TITLE
fix(security): enforce project-membership authorization across all tRPC routers (IDOR)

### DIFF
--- a/apps/web/client/src/server/api/routers/chat/conversation.ts
+++ b/apps/web/client/src/server/api/routers/chat/conversation.ts
@@ -11,11 +11,13 @@ import { eq } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyConversationAccess, verifyProjectAccess } from '../project/helper';
 
 export const conversationRouter = createTRPCRouter({
     getAll: protectedProcedure
         .input(z.object({ projectId: z.string() }))
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const dbConversations = await ctx.db.query.conversations.findMany({
                 where: eq(conversations.projectId, input.projectId),
                 orderBy: (conversations, { desc }) => [desc(conversations.updatedAt)],
@@ -25,6 +27,7 @@ export const conversationRouter = createTRPCRouter({
     get: protectedProcedure
         .input(z.object({ conversationId: z.string() }))
         .query(async ({ ctx, input }) => {
+            await verifyConversationAccess(ctx.db, ctx.user.id, input.conversationId);
             const conversation = await ctx.db.query.conversations.findFirst({
                 where: eq(conversations.id, input.conversationId),
             });
@@ -36,6 +39,7 @@ export const conversationRouter = createTRPCRouter({
     upsert: protectedProcedure
         .input(conversationInsertSchema)
         .mutation(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const [conversation] = await ctx.db.insert(conversations).values(input).returning();
             if (!conversation) {
                 throw new Error('Conversation not created');
@@ -45,6 +49,10 @@ export const conversationRouter = createTRPCRouter({
     update: protectedProcedure
         .input(conversationUpdateSchema)
         .mutation(async ({ ctx, input }) => {
+            if (!input.id) {
+                throw new Error('Conversation id is required');
+            }
+            await verifyConversationAccess(ctx.db, ctx.user.id, input.id);
             const [conversation] = await ctx.db.update({
                 ...conversations,
                 updatedAt: new Date(),
@@ -60,6 +68,7 @@ export const conversationRouter = createTRPCRouter({
             conversationId: z.string()
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyConversationAccess(ctx.db, ctx.user.id, input.conversationId);
             await ctx.db.delete(conversations).where(eq(conversations.id, input.conversationId));
         }),
     generateTitle: protectedProcedure
@@ -68,6 +77,7 @@ export const conversationRouter = createTRPCRouter({
             content: z.string(),
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyConversationAccess(ctx.db, ctx.user.id, input.conversationId);
             const { model, providerOptions, headers } = initModel({
                 provider: LLMProvider.OPENROUTER,
                 model: OPENROUTER_MODELS.CLAUDE_3_5_HAIKU,

--- a/apps/web/client/src/server/api/routers/chat/message.ts
+++ b/apps/web/client/src/server/api/routers/chat/message.ts
@@ -9,6 +9,7 @@ import { MessageCheckpointType } from '@onlook/models';
 import { asc, eq, inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyConversationAccess, verifyMessagesAccess } from '../project/helper';
 
 export const messageRouter = createTRPCRouter({
     getAll: protectedProcedure
@@ -16,6 +17,7 @@ export const messageRouter = createTRPCRouter({
             conversationId: z.string(),
         }))
         .query(async ({ ctx, input }) => {
+            await verifyConversationAccess(ctx.db, ctx.user.id, input.conversationId);
             const result = await ctx.db.query.messages.findMany({
                 where: eq(messages.conversationId, input.conversationId),
                 orderBy: [asc(messages.createdAt)],
@@ -29,12 +31,7 @@ export const messageRouter = createTRPCRouter({
         .mutation(async ({ ctx, input }) => {
             const conversationId = input.message.conversationId;
             if (conversationId) {
-                const conversation = await ctx.db.query.conversations.findFirst({
-                    where: eq(conversations.id, conversationId),
-                });
-                if (!conversation) {
-                    throw new Error(`Conversation not found`);
-                }
+                await verifyConversationAccess(ctx.db, ctx.user.id, conversationId);
             }
             const normalizedMessage = normalizeMessage(input.message);
             return await ctx.db
@@ -52,6 +49,12 @@ export const messageRouter = createTRPCRouter({
             messages: messageInsertSchema.array(),
         }))
         .mutation(async ({ ctx, input }) => {
+            const conversationIds = new Set(
+                input.messages.map((m) => m.conversationId).filter((id): id is string => !!id),
+            );
+            for (const conversationId of conversationIds) {
+                await verifyConversationAccess(ctx.db, ctx.user.id, conversationId);
+            }
             const normalizedMessages = input.messages.map(normalizeMessage);
             await ctx.db.insert(messages).values(normalizedMessages);
         }),
@@ -61,6 +64,7 @@ export const messageRouter = createTRPCRouter({
             message: messageUpdateSchema
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyMessagesAccess(ctx.db, ctx.user.id, [input.messageId]);
             await ctx.db.update(messages).set({
                 ...input.message,
             }).where(eq(messages.id, input.messageId));
@@ -76,6 +80,7 @@ export const messageRouter = createTRPCRouter({
             })),
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyMessagesAccess(ctx.db, ctx.user.id, [input.messageId]);
             await ctx.db.update(messages).set({
                 checkpoints: input.checkpoints,
             }).where(eq(messages.id, input.messageId));
@@ -85,6 +90,7 @@ export const messageRouter = createTRPCRouter({
             messageIds: z.array(z.string()),
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyMessagesAccess(ctx.db, ctx.user.id, input.messageIds);
             await ctx.db.delete(messages).where(inArray(messages.id, input.messageIds));
         }),
 
@@ -99,11 +105,18 @@ export const messageRouter = createTRPCRouter({
             messages: messageInsertSchema.array(),
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyConversationAccess(ctx.db, ctx.user.id, input.conversationId);
             await ctx.db.transaction(async (tx) => {
                 await tx.delete(messages).where(eq(messages.conversationId, input.conversationId));
 
                 if (input.messages.length > 0) {
-                    const normalizedMessages = input.messages.map(normalizeMessage);
+                    // Force each inserted message onto the authorized conversation,
+                    // ignoring any conversationId embedded in the client payload --
+                    // otherwise a caller authorized for input.conversationId could
+                    // smuggle messages into a different conversation via the array.
+                    const normalizedMessages = input.messages.map((m) =>
+                        normalizeMessage({ ...m, conversationId: input.conversationId }),
+                    );
                     await tx.insert(messages).values(normalizedMessages);
                 }
 

--- a/apps/web/client/src/server/api/routers/chat/suggestion.ts
+++ b/apps/web/client/src/server/api/routers/chat/suggestion.ts
@@ -7,6 +7,7 @@ import { convertToModelMessages, generateObject } from 'ai';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyConversationAccess } from '../project/helper';
 
 export const suggestionsRouter = createTRPCRouter({
     generate: protectedProcedure
@@ -18,6 +19,7 @@ export const suggestionsRouter = createTRPCRouter({
             })),
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyConversationAccess(ctx.db, ctx.user.id, input.conversationId);
             const { model, headers } = initModel({
                 provider: LLMProvider.OPENROUTER,
                 model: OPENROUTER_MODELS.OPEN_AI_GPT_5_NANO,

--- a/apps/web/client/src/server/api/routers/domain/custom.ts
+++ b/apps/web/client/src/server/api/routers/domain/custom.ts
@@ -1,14 +1,16 @@
 import { customDomainVerification, projectCustomDomains, ProjectCustomDomainStatus, toDomainInfoFromPublished, userProjects } from '@onlook/db';
 import { VerificationRequestStatus } from '@onlook/models';
 import { TRPCError } from '@trpc/server';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyProjectAccess } from '../project/helper';
 
 export const customRouter = createTRPCRouter({
     get: protectedProcedure.input(z.object({
         projectId: z.string(),
     })).query(async ({ ctx, input }) => {
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         const customDomain = await ctx.db.query.projectCustomDomains.findFirst({
             where: eq(projectCustomDomains.projectId, input.projectId),
         });
@@ -18,14 +20,24 @@ export const customRouter = createTRPCRouter({
         domain: z.string(),
         projectId: z.string(),
     })).mutation(async ({ ctx, input }): Promise<boolean> => {
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         try {
             await ctx.db.transaction(async (tx) => {
+                // Scope the cancellation to the caller's project: `input.projectId`
+                // was previously accepted but ignored, so the domain string alone
+                // keyed the update — letting anyone cancel any project's domain.
                 await tx.update(customDomainVerification).set({
                     status: VerificationRequestStatus.CANCELLED,
-                }).where(eq(customDomainVerification.fullDomain, input.domain));
+                }).where(and(
+                    eq(customDomainVerification.fullDomain, input.domain),
+                    eq(customDomainVerification.projectId, input.projectId),
+                ));
                 await tx.update(projectCustomDomains).set({
                     status: ProjectCustomDomainStatus.CANCELLED,
-                }).where(eq(projectCustomDomains.fullDomain, input.domain));
+                }).where(and(
+                    eq(projectCustomDomains.fullDomain, input.domain),
+                    eq(projectCustomDomains.projectId, input.projectId),
+                ));
             });
             return true;
         } catch (error) {

--- a/apps/web/client/src/server/api/routers/domain/index.ts
+++ b/apps/web/client/src/server/api/routers/domain/index.ts
@@ -2,6 +2,7 @@ import { previewDomains, projectCustomDomains, toDomainInfoFromPreview, toDomain
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyProjectAccess } from '../project/helper';
 import { customRouter } from './custom';
 import { previewRouter } from './preview';
 import { verificationRouter } from './verify';
@@ -13,6 +14,7 @@ export const domainRouter = createTRPCRouter({
     getAll: protectedProcedure.input(z.object({
         projectId: z.string(),
     })).query(async ({ ctx, input }) => {
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         const preview = await ctx.db.query.previewDomains.findFirst({
             where: eq(previewDomains.projectId, input.projectId),
         });

--- a/apps/web/client/src/server/api/routers/domain/preview.ts
+++ b/apps/web/client/src/server/api/routers/domain/preview.ts
@@ -5,11 +5,13 @@ import { TRPCError } from '@trpc/server';
 import { and, eq, ne } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyProjectAccess } from '../project/helper';
 
 export const previewRouter = createTRPCRouter({
     get: protectedProcedure.input(z.object({
         projectId: z.string(),
     })).query(async ({ ctx, input }) => {
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         const preview = await ctx.db.query.previewDomains.findFirst({
             where: eq(previewDomains.projectId, input.projectId),
         });
@@ -18,6 +20,7 @@ export const previewRouter = createTRPCRouter({
     create: protectedProcedure.input(z.object({
         projectId: z.string(),
     })).mutation(async ({ ctx, input }) => {
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         // Check if the domain is already taken by another project
         // This should never happen, but just in case
         const domain = `${getValidSubdomain(input.projectId)}.${env.NEXT_PUBLIC_HOSTING_DOMAIN}`;

--- a/apps/web/client/src/server/api/routers/domain/verify/index.ts
+++ b/apps/web/client/src/server/api/routers/domain/verify/index.ts
@@ -5,12 +5,14 @@ import { TRPCError } from '@trpc/server';
 import { and, eq, or } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../../trpc';
+import { verifyDomainVerificationAccess, verifyProjectAccess } from '../../project/helper';
 import { createDomainVerification, ensureUserOwnsDomain, getCustomDomain, getFailureReason, getVerification, verifyFreestyleDomain, verifyFreestyleDomainWithCustomDomain } from './helpers';
 
 export const verificationRouter = createTRPCRouter({
     getActive: protectedProcedure.input(z.object({
         projectId: z.string(),
     })).query(async ({ ctx, input }): Promise<CustomDomainVerification | null> => {
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         const verification = await ctx.db.query.customDomainVerification.findFirst({
             where: and(
                 eq(customDomainVerification.projectId, input.projectId),
@@ -29,6 +31,7 @@ export const verificationRouter = createTRPCRouter({
         domain: z.string(),
         projectId: z.string(),
     })).mutation(async ({ ctx, input }): Promise<CustomDomainVerification> => {
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         const { customDomain, subdomain } = await getCustomDomain(ctx.db, input.domain);
         const existingVerification = await getVerification(ctx.db, input.projectId, customDomain.id);
         if (existingVerification) {
@@ -40,6 +43,7 @@ export const verificationRouter = createTRPCRouter({
     remove: protectedProcedure.input(z.object({
         verificationId: z.string(),
     })).mutation(async ({ ctx, input }) => {
+        await verifyDomainVerificationAccess(ctx.db, ctx.user.id, input.verificationId);
         await ctx.db.update(customDomainVerification).set({
             status: VerificationRequestStatus.CANCELLED,
             updatedAt: new Date(),
@@ -51,6 +55,7 @@ export const verificationRouter = createTRPCRouter({
         success: boolean;
         failureReason: string | null;
     }> => {
+        await verifyDomainVerificationAccess(ctx.db, ctx.user.id, input.verificationId);
         const verification = await ctx.db.query.customDomainVerification.findFirst({
             where: and(
                 eq(customDomainVerification.id, input.verificationId),
@@ -118,6 +123,10 @@ export const verificationRouter = createTRPCRouter({
                 message: 'Unauthorized',
             });
         }
+        // Owning the domain is not enough — the caller must also be a member of
+        // the project the domain is about to be attached to, or they could bind
+        // a domain they own onto someone else's project.
+        await verifyProjectAccess(ctx.db, user.id, input.projectId);
         const ownsDomain = await ensureUserOwnsDomain(ctx.db, user.id, input.fullDomain);
         if (!ownsDomain) {
             return {

--- a/apps/web/client/src/server/api/routers/project/branch.ts
+++ b/apps/web/client/src/server/api/routers/project/branch.ts
@@ -8,7 +8,7 @@ import { and, eq } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
-import { extractCsbPort } from './helper';
+import { extractCsbPort, verifyBranchAccess, verifyProjectAccess } from './helper';
 
 // Helper function to get existing frames in a canvas
 async function getExistingFrames(tx: any, canvasId: string): Promise<Frame[]> {
@@ -27,6 +27,7 @@ export const branchRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const dbBranches = await ctx.db.query.branches.findMany({
                 where: input.onlyDefault ?
                     and(eq(branches.isDefault, true), eq(branches.projectId, input.projectId)) :
@@ -45,6 +46,7 @@ export const branchRouter = createTRPCRouter({
     create: protectedProcedure
         .input(branchInsertSchema)
         .mutation(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             try {
                 await ctx.db.insert(branches).values(input);
                 return true;
@@ -54,6 +56,7 @@ export const branchRouter = createTRPCRouter({
             }
         }),
     update: protectedProcedure.input(branchUpdateSchema).mutation(async ({ ctx, input }) => {
+        await verifyBranchAccess(ctx.db, ctx.user.id, input.id);
         try {
             await ctx.db
                 .update(branches)
@@ -74,6 +77,7 @@ export const branchRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await verifyBranchAccess(ctx.db, ctx.user.id, input.branchId);
             try {
                 await ctx.db.delete(branches).where(eq(branches.id, input.branchId));
                 return true;
@@ -89,6 +93,7 @@ export const branchRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await verifyBranchAccess(ctx.db, ctx.user.id, input.branchId);
             try {
                 // Get source branch with its frames to extract port
                 const sourceBranch = await ctx.db.query.branches.findFirst({
@@ -237,6 +242,7 @@ export const branchRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             try {
                 return await ctx.db.transaction(async (tx) => {
                     // Get existing branches with frames for unique name generation and port extraction

--- a/apps/web/client/src/server/api/routers/project/createRequest.ts
+++ b/apps/web/client/src/server/api/routers/project/createRequest.ts
@@ -5,11 +5,13 @@ import { ProjectCreateRequestStatus } from '@onlook/models';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyProjectAccess } from './helper';
 
 export const projectCreateRequestRouter = createTRPCRouter({
     getPendingRequest: protectedProcedure
         .input(z.object({ projectId: z.string() }))
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const request = await ctx.db.query.projectCreateRequests.findFirst({
                 where: and(
                     eq(projectCreateRequests.projectId, input.projectId),
@@ -24,6 +26,7 @@ export const projectCreateRequestRouter = createTRPCRouter({
             status: z.nativeEnum(ProjectCreateRequestStatus),
         }))
         .mutation(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             await ctx.db.update(projectCreateRequests).set({
                 status: input.status,
             }).where(

--- a/apps/web/client/src/server/api/routers/project/fork.ts
+++ b/apps/web/client/src/server/api/routers/project/fork.ts
@@ -22,6 +22,7 @@ import { ProjectRole } from '@onlook/models';
 import { eq } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
+import { verifyProjectAccess } from './helper';
 
 type ForkedBranch = {
     newBranch: Branch;
@@ -163,6 +164,11 @@ export const fork = protectedProcedure
         name: z.string().optional(),
     }))
     .mutation(async ({ ctx, input }) => {
+        // Forking clones the full private contents of the source project
+        // (canvas, branches, live sandboxes) into a new project the caller
+        // owns -- there is no public/template concept on `projects`, so this
+        // must be gated the same as any other read of a project's contents.
+        await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
         // 1. Get the source project with canvas, frames, and branches
         const sourceProject = await ctx.db.query.projects.findFirst({
             where: eq(projects.id, input.projectId),

--- a/apps/web/client/src/server/api/routers/project/frame.ts
+++ b/apps/web/client/src/server/api/routers/project/frame.ts
@@ -2,6 +2,7 @@ import { frameInsertSchema, frames, frameUpdateSchema, fromDbFrame } from '@onlo
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyCanvasAccess, verifyFrameAccess } from './helper';
 
 export const frameRouter = createTRPCRouter({
     get: protectedProcedure
@@ -11,6 +12,7 @@ export const frameRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
+            await verifyFrameAccess(ctx.db, ctx.user.id, input.frameId);
             const dbFrame = await ctx.db.query.frames.findFirst({
                 where: eq(frames.id, input.frameId),
             });
@@ -26,6 +28,7 @@ export const frameRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
+            await verifyCanvasAccess(ctx.db, ctx.user.id, input.canvasId);
             const dbFrames = await ctx.db.query.frames.findMany({
                 where: eq(frames.canvasId, input.canvasId),
                 orderBy: (frames, { asc }) => [asc(frames.x), asc(frames.y)],
@@ -35,6 +38,7 @@ export const frameRouter = createTRPCRouter({
     create: protectedProcedure
         .input(frameInsertSchema)
         .mutation(async ({ ctx, input }) => {
+            await verifyCanvasAccess(ctx.db, ctx.user.id, input.canvasId);
             try {
                 await ctx.db.insert(frames).values(input);
                 return true;
@@ -46,6 +50,7 @@ export const frameRouter = createTRPCRouter({
     update: protectedProcedure
         .input(frameUpdateSchema)
         .mutation(async ({ ctx, input }) => {
+            await verifyFrameAccess(ctx.db, ctx.user.id, input.id);
             try {
                 await ctx.db
                     .update(frames)
@@ -66,6 +71,7 @@ export const frameRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await verifyFrameAccess(ctx.db, ctx.user.id, input.frameId);
             try {
                 await ctx.db.delete(frames).where(eq(frames.id, input.frameId));
                 return true;

--- a/apps/web/client/src/server/api/routers/project/helper.test.ts
+++ b/apps/web/client/src/server/api/routers/project/helper.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    listAccessibleSandboxIds,
+    verifyBranchAccess,
+    verifyConversationAccess,
+    verifyDeploymentAccess,
+    verifyDomainVerificationAccess,
+    verifyFrameAccess,
+    verifyMessagesAccess,
+    verifyProjectAccess,
+    verifySandboxAccess,
+} from './helper';
+
+// The verify* helpers only touch `db.query.<table>.findFirst/findMany`. We stub
+// that surface — the drizzle `where`/`with` expressions the helpers build are
+// real but inert against the stub, so each test just declares what a given
+// table lookup returns. `userProjects` on a found project models membership.
+
+const MEMBER = 'user-1';
+const OUTSIDER = 'user-2';
+
+type TableStub = {
+    findFirst?: (args?: unknown) => unknown;
+    findMany?: (args?: unknown) => unknown;
+};
+
+function makeDb(tables: Record<string, TableStub>) {
+    const query = new Proxy({} as Record<string, TableStub>, {
+        get(_t, name: string) {
+            return (
+                tables[name] ?? {
+                    findFirst: async () => undefined,
+                    findMany: async () => [],
+                }
+            );
+        },
+    });
+    return { query } as never;
+}
+
+describe('verifyProjectAccess', () => {
+    const db = (projectId: string, members: string[]) =>
+        makeDb({
+            projects: {
+                findFirst: async () => ({
+                    id: projectId,
+                    userProjects: members.includes(MEMBER) ? [{ userId: MEMBER }] : [],
+                }),
+            },
+        });
+
+    it('resolves for a project member', async () => {
+        await expect(verifyProjectAccess(db('p1', [MEMBER]), MEMBER, 'p1')).resolves.toBeUndefined();
+    });
+
+    it('rejects a non-member', async () => {
+        await expect(verifyProjectAccess(db('p1', [OUTSIDER]), MEMBER, 'p1')).rejects.toThrow(
+            'Unauthorized or not found',
+        );
+    });
+
+    it('rejects when the project does not exist (same message, no enumeration)', async () => {
+        const missing = makeDb({ projects: { findFirst: async () => undefined } });
+        await expect(verifyProjectAccess(missing, MEMBER, 'nope')).rejects.toThrow(
+            'Unauthorized or not found',
+        );
+    });
+});
+
+describe('verifyConversationAccess', () => {
+    it('rejects when the conversation is missing', async () => {
+        const db = makeDb({ conversations: { findFirst: async () => undefined } });
+        await expect(verifyConversationAccess(db, MEMBER, 'c1')).rejects.toThrow(
+            'Unauthorized or not found',
+        );
+    });
+
+    it('delegates to project access (member passes)', async () => {
+        const db = makeDb({
+            conversations: { findFirst: async () => ({ id: 'c1', projectId: 'p1' }) },
+            projects: { findFirst: async () => ({ id: 'p1', userProjects: [{ userId: MEMBER }] }) },
+        });
+        await expect(verifyConversationAccess(db, MEMBER, 'c1')).resolves.toBeUndefined();
+    });
+
+    it('delegates to project access (non-member rejected)', async () => {
+        const db = makeDb({
+            conversations: { findFirst: async () => ({ id: 'c1', projectId: 'p1' }) },
+            projects: { findFirst: async () => ({ id: 'p1', userProjects: [] }) },
+        });
+        await expect(verifyConversationAccess(db, MEMBER, 'c1')).rejects.toThrow();
+    });
+});
+
+describe('verifyMessagesAccess', () => {
+    const withMessages = (rows: { id: string; projectId: string }[], memberProjects: string[]) =>
+        makeDb({
+            messages: {
+                findMany: async () =>
+                    rows.map((r) => ({ id: r.id, conversation: { projectId: r.projectId } })),
+            },
+            projects: {
+                findFirst: async () => ({
+                    id: 'p',
+                    userProjects: memberProjects.length ? [{ userId: MEMBER }] : [],
+                }),
+            },
+        });
+
+    it('is a no-op for an empty list', async () => {
+        await expect(verifyMessagesAccess(makeDb({}), MEMBER, [])).resolves.toBeUndefined();
+    });
+
+    it('does NOT falsely reject when the input has duplicate ids (regression)', async () => {
+        // Two distinct rows returned for three ids because ['a','a','b'] dedupes
+        // to two. The old `rows.length !== messageIds.length` check rejected this.
+        const db = withMessages(
+            [
+                { id: 'a', projectId: 'p1' },
+                { id: 'b', projectId: 'p1' },
+            ],
+            ['p1'],
+        );
+        await expect(verifyMessagesAccess(db, MEMBER, ['a', 'a', 'b'])).resolves.toBeUndefined();
+    });
+
+    it('rejects when a message id does not resolve', async () => {
+        const db = withMessages([{ id: 'a', projectId: 'p1' }], ['p1']);
+        await expect(verifyMessagesAccess(db, MEMBER, ['a', 'missing'])).rejects.toThrow(
+            'Unauthorized or not found',
+        );
+    });
+});
+
+describe('verifyBranchAccess / verifyFrameAccess', () => {
+    it('branch: rejects when missing', async () => {
+        const db = makeDb({ branches: { findFirst: async () => undefined } });
+        await expect(verifyBranchAccess(db, MEMBER, 'b1')).rejects.toThrow(
+            'Unauthorized or not found',
+        );
+    });
+
+    it('frame: resolves frame -> canvas -> project for a member', async () => {
+        const db = makeDb({
+            frames: { findFirst: async () => ({ id: 'f1', canvasId: 'cv1' }) },
+            canvases: { findFirst: async () => ({ id: 'cv1', projectId: 'p1' }) },
+            projects: { findFirst: async () => ({ id: 'p1', userProjects: [{ userId: MEMBER }] }) },
+        });
+        await expect(verifyFrameAccess(db, MEMBER, 'f1')).resolves.toBeUndefined();
+    });
+});
+
+describe('verifySandboxAccess', () => {
+    it('passes when the sandbox belongs to a project the user is a member of (via branch)', async () => {
+        const db = makeDb({
+            branches: { findFirst: async () => ({ sandboxId: 's1', projectId: 'p1' }) },
+            projects: { findFirst: async () => ({ id: 'p1', userProjects: [{ userId: MEMBER }] }) },
+        });
+        await expect(verifySandboxAccess(db, MEMBER, 's1')).resolves.toBeUndefined();
+    });
+
+    it('rejects a sandbox that belongs to another user\'s project', async () => {
+        const db = makeDb({
+            branches: { findFirst: async () => ({ sandboxId: 's1', projectId: 'p1' }) },
+            projects: { findFirst: async () => ({ id: 'p1', userProjects: [] }) },
+        });
+        await expect(verifySandboxAccess(db, MEMBER, 's1')).rejects.toThrow(
+            'Unauthorized or not found',
+        );
+    });
+
+    it('falls back to projects.sandboxId when there is no branch row', async () => {
+        const db = makeDb({
+            branches: { findFirst: async () => undefined },
+            projects: {
+                findFirst: async () => ({ id: 'p1', sandboxId: 's1', userProjects: [{ userId: MEMBER }] }),
+            },
+        });
+        await expect(verifySandboxAccess(db, MEMBER, 's1')).resolves.toBeUndefined();
+    });
+
+    it('allows an unowned/transient sandbox (fresh create/fork/import, no project yet)', async () => {
+        const db = makeDb({
+            branches: { findFirst: async () => undefined },
+            projects: { findFirst: async () => undefined },
+        });
+        await expect(verifySandboxAccess(db, MEMBER, 'fresh')).resolves.toBeUndefined();
+    });
+});
+
+describe('verifyDeploymentAccess / verifyDomainVerificationAccess', () => {
+    it('deployment: delegates to its project', async () => {
+        const ok = makeDb({
+            deployments: { findFirst: async () => ({ id: 'd1', projectId: 'p1' }) },
+            projects: { findFirst: async () => ({ id: 'p1', userProjects: [{ userId: MEMBER }] }) },
+        });
+        await expect(verifyDeploymentAccess(ok, MEMBER, 'd1')).resolves.toBeUndefined();
+
+        const missing = makeDb({ deployments: { findFirst: async () => undefined } });
+        await expect(verifyDeploymentAccess(missing, MEMBER, 'd1')).rejects.toThrow(
+            'Unauthorized or not found',
+        );
+    });
+
+    it('domain verification: rejects a non-member', async () => {
+        const db = makeDb({
+            customDomainVerification: { findFirst: async () => ({ id: 'v1', projectId: 'p1' }) },
+            projects: { findFirst: async () => ({ id: 'p1', userProjects: [] }) },
+        });
+        await expect(verifyDomainVerificationAccess(db, MEMBER, 'v1')).rejects.toThrow();
+    });
+});
+
+describe('listAccessibleSandboxIds', () => {
+    it('returns the union of branch + project sandbox ids for the user\'s projects', async () => {
+        const db = makeDb({
+            userProjects: { findMany: async () => [{ projectId: 'p1' }, { projectId: 'p2' }] },
+            projects: {
+                findMany: async () => [
+                    { id: 'p1', sandboxId: 'proj-sb-1' },
+                    { id: 'p2', sandboxId: null },
+                ],
+            },
+            branches: {
+                findMany: async () => [
+                    { projectId: 'p1', sandboxId: 'branch-sb-1' },
+                    { projectId: 'p2', sandboxId: 'branch-sb-2' },
+                ],
+            },
+        });
+        const ids = await listAccessibleSandboxIds(db, MEMBER);
+        expect([...ids].sort()).toEqual(['branch-sb-1', 'branch-sb-2', 'proj-sb-1']);
+    });
+
+    it('returns an empty set when the user has no memberships', async () => {
+        const db = makeDb({ userProjects: { findMany: async () => [] } });
+        const ids = await listAccessibleSandboxIds(db, MEMBER);
+        expect(ids.size).toBe(0);
+    });
+});

--- a/apps/web/client/src/server/api/routers/project/helper.ts
+++ b/apps/web/client/src/server/api/routers/project/helper.ts
@@ -1,5 +1,18 @@
-import { eq } from "drizzle-orm";
-import { type Frame, projects, userProjects, type DrizzleDb } from "@onlook/db";
+import { eq, inArray } from "drizzle-orm";
+import {
+    branches,
+    canvases,
+    conversations,
+    customDomainVerification,
+    deployments,
+    frames,
+    messages,
+    projectInvitations,
+    projects,
+    userProjects,
+    type DrizzleDb,
+    type Frame,
+} from "@onlook/db";
 
 /** Type representing a db instance or transaction that has query capabilities */
 type DbOrTx = Pick<DrizzleDb, 'query'>;
@@ -49,4 +62,236 @@ export async function verifyProjectAccess(
     if (!project || project.userProjects.length === 0) {
         throw new Error('Unauthorized or not found');
     }
+}
+
+/**
+ * Verifies that a user has access to a conversation via its parent project.
+ * @throws Error if the conversation doesn't exist or the user lacks project access
+ */
+export async function verifyConversationAccess(
+    db: DbOrTx,
+    userId: string,
+    conversationId: string,
+): Promise<void> {
+    const conversation = await db.query.conversations.findFirst({
+        where: eq(conversations.id, conversationId),
+    });
+    if (!conversation) {
+        throw new Error('Unauthorized or not found');
+    }
+    await verifyProjectAccess(db, userId, conversation.projectId);
+}
+
+/**
+ * Verifies that a user has access to every message in `messageIds`, via each
+ * message's parent conversation -> project. Used by bulk operations (e.g.
+ * message.delete) that accept an array of ids potentially spanning multiple
+ * conversations/projects.
+ * @throws Error if any message doesn't exist or resolves to an inaccessible project
+ */
+export async function verifyMessagesAccess(
+    db: DbOrTx,
+    userId: string,
+    messageIds: string[],
+): Promise<void> {
+    if (messageIds.length === 0) {
+        return;
+    }
+    // Dedupe: `inArray` returns one row per distinct id, so comparing against
+    // the raw (possibly-duplicated) input length would falsely reject a caller
+    // who passed the same id twice. Compare against the distinct-id count.
+    const uniqueIds = [...new Set(messageIds)];
+    const rows = await db.query.messages.findMany({
+        where: inArray(messages.id, uniqueIds),
+        with: { conversation: true },
+    });
+    if (rows.length !== uniqueIds.length) {
+        throw new Error('Unauthorized or not found');
+    }
+    const projectIds = new Set(rows.map((row) => row.conversation.projectId));
+    for (const projectId of projectIds) {
+        await verifyProjectAccess(db, userId, projectId);
+    }
+}
+
+/**
+ * Verifies that a user has access to a branch via its parent project.
+ * @throws Error if the branch doesn't exist or the user lacks project access
+ */
+export async function verifyBranchAccess(
+    db: DbOrTx,
+    userId: string,
+    branchId: string,
+): Promise<void> {
+    const branch = await db.query.branches.findFirst({
+        where: eq(branches.id, branchId),
+    });
+    if (!branch) {
+        throw new Error('Unauthorized or not found');
+    }
+    await verifyProjectAccess(db, userId, branch.projectId);
+}
+
+/**
+ * Verifies that a user has access to a canvas via its parent project.
+ * @throws Error if the canvas doesn't exist or the user lacks project access
+ */
+export async function verifyCanvasAccess(
+    db: DbOrTx,
+    userId: string,
+    canvasId: string,
+): Promise<void> {
+    const canvas = await db.query.canvases.findFirst({
+        where: eq(canvases.id, canvasId),
+    });
+    if (!canvas) {
+        throw new Error('Unauthorized or not found');
+    }
+    await verifyProjectAccess(db, userId, canvas.projectId);
+}
+
+/**
+ * Verifies that a user has access to a frame via its parent canvas -> project.
+ * @throws Error if the frame doesn't exist or the user lacks project access
+ */
+export async function verifyFrameAccess(
+    db: DbOrTx,
+    userId: string,
+    frameId: string,
+): Promise<void> {
+    const frame = await db.query.frames.findFirst({
+        where: eq(frames.id, frameId),
+    });
+    if (!frame) {
+        throw new Error('Unauthorized or not found');
+    }
+    await verifyCanvasAccess(db, userId, frame.canvasId);
+}
+
+/**
+ * Verifies that a user has access to a project invitation via its parent project.
+ * @throws Error if the invitation doesn't exist or the user lacks project access
+ */
+export async function verifyInvitationAccess(
+    db: DbOrTx,
+    userId: string,
+    invitationId: string,
+): Promise<void> {
+    const invitation = await db.query.projectInvitations.findFirst({
+        where: eq(projectInvitations.id, invitationId),
+    });
+    if (!invitation) {
+        throw new Error('Unauthorized or not found');
+    }
+    await verifyProjectAccess(db, userId, invitation.projectId);
+}
+
+/**
+ * Verifies that a user may operate on a sandbox.
+ *
+ * A sandbox is owned once it is tied to a project — via a `branches.sandboxId`
+ * row (primary link) or the project's own `projects.sandboxId` (fallback). When
+ * it is, the caller must be a member of that project. A sandbox that resolves to
+ * NO project is a transient/unclaimed one (a freshly created, forked-from-
+ * template, or just-imported sandbox that has not been persisted to a branch
+ * yet) — there is no owner to violate, so it is allowed. This is deliberate: the
+ * blank-project / local-import / fork flows create a brand-new sandbox and call
+ * `start`/`fork` on it BEFORE any branch row exists, so a strict "deny when no
+ * branch" check would break legitimate project creation. The IDOR this closes is
+ * acting on ANOTHER user's *persisted* project sandbox by id.
+ * @throws Error if the sandbox belongs to a project the user is not a member of
+ */
+export async function verifySandboxAccess(
+    db: DbOrTx,
+    userId: string,
+    sandboxId: string,
+): Promise<void> {
+    const branch = await db.query.branches.findFirst({
+        where: eq(branches.sandboxId, sandboxId),
+    });
+    if (branch) {
+        await verifyProjectAccess(db, userId, branch.projectId);
+        return;
+    }
+    const project = await db.query.projects.findFirst({
+        where: eq(projects.sandboxId, sandboxId),
+    });
+    if (project) {
+        await verifyProjectAccess(db, userId, project.id);
+        return;
+    }
+    // No owning project — transient/unclaimed sandbox, nothing to authorize.
+}
+
+/**
+ * Returns the set of sandbox ids the user may see — every sandbox tied to a
+ * project they're a member of, via `branches.sandboxId` plus the project's own
+ * `projects.sandboxId`. Used to scope `sandbox.list`, whose underlying provider
+ * call returns the whole account's sandboxes (a cross-tenant inventory leak) and
+ * cannot be narrowed by the input id alone.
+ */
+export async function listAccessibleSandboxIds(
+    db: DbOrTx,
+    userId: string,
+): Promise<Set<string>> {
+    const memberships = await db.query.userProjects.findMany({
+        where: eq(userProjects.userId, userId),
+    });
+    const projectIds = memberships.map((m) => m.projectId);
+    if (projectIds.length === 0) {
+        return new Set();
+    }
+    const [projectRows, branchRows] = await Promise.all([
+        db.query.projects.findMany({
+            where: inArray(projects.id, projectIds),
+        }),
+        db.query.branches.findMany({
+            where: inArray(branches.projectId, projectIds),
+        }),
+    ]);
+    const ids = new Set<string>();
+    for (const p of projectRows) {
+        if (p.sandboxId) ids.add(p.sandboxId);
+    }
+    for (const b of branchRows) {
+        if (b.sandboxId) ids.add(b.sandboxId);
+    }
+    return ids;
+}
+
+/**
+ * Verifies that a user has access to a deployment via its parent project.
+ * @throws Error if the deployment doesn't exist or the user lacks project access
+ */
+export async function verifyDeploymentAccess(
+    db: DbOrTx,
+    userId: string,
+    deploymentId: string,
+): Promise<void> {
+    const deployment = await db.query.deployments.findFirst({
+        where: eq(deployments.id, deploymentId),
+    });
+    if (!deployment) {
+        throw new Error('Unauthorized or not found');
+    }
+    await verifyProjectAccess(db, userId, deployment.projectId);
+}
+
+/**
+ * Verifies that a user has access to a custom-domain verification via its
+ * parent project.
+ * @throws Error if the verification doesn't exist or the user lacks project access
+ */
+export async function verifyDomainVerificationAccess(
+    db: DbOrTx,
+    userId: string,
+    verificationId: string,
+): Promise<void> {
+    const verification = await db.query.customDomainVerification.findFirst({
+        where: eq(customDomainVerification.id, verificationId),
+    });
+    if (!verification) {
+        throw new Error('Unauthorized or not found');
+    }
+    await verifyProjectAccess(db, userId, verification.projectId);
 }

--- a/apps/web/client/src/server/api/routers/project/invitation.ts
+++ b/apps/web/client/src/server/api/routers/project/invitation.ts
@@ -18,6 +18,7 @@ import { and, eq, ilike, isNull } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyInvitationAccess, verifyProjectAccess } from './helper';
 
 export const invitationRouter = createTRPCRouter({
     get: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
@@ -84,6 +85,7 @@ export const invitationRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const invitations = await ctx.db.query.projectInvitations.findMany({
                 where: eq(projectInvitations.projectId, input.projectId),
             });
@@ -105,6 +107,7 @@ export const invitationRouter = createTRPCRouter({
                     message: 'You must be logged in to invite a user',
                 });
             }
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const inviter = await ctx.db.query.users.findFirst({
                 where: eq(users.id, ctx.user.id),
             });
@@ -185,6 +188,7 @@ export const invitationRouter = createTRPCRouter({
     delete: protectedProcedure
         .input(z.object({ id: z.string() }))
         .mutation(async ({ ctx, input }) => {
+            await verifyInvitationAccess(ctx.db, ctx.user.id, input.id);
             await ctx.db.delete(projectInvitations).where(eq(projectInvitations.id, input.id));
 
             return true;

--- a/apps/web/client/src/server/api/routers/project/member.ts
+++ b/apps/web/client/src/server/api/routers/project/member.ts
@@ -2,6 +2,7 @@ import { fromDbUser, userProjects } from '@onlook/db';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyProjectAccess } from './helper';
 
 export const memberRouter = createTRPCRouter({
     list: protectedProcedure
@@ -11,6 +12,7 @@ export const memberRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const members = await ctx.db.query.userProjects.findMany({
                 where: eq(userProjects.projectId, input.projectId),
                 with: {
@@ -44,6 +46,13 @@ export const memberRouter = createTRPCRouter({
     remove: protectedProcedure
         .input(z.object({ userId: z.string(), projectId: z.string() }))
         .mutation(async ({ ctx, input }) => {
+            // Removing yourself (leaving a project) or removing another member
+            // both require the caller to already be a project member. This
+            // does not yet distinguish by role (e.g. only owners removing
+            // others) -- ProjectRole exists as data but no role-gated
+            // authorization exists anywhere else in this router either, so
+            // that's a separate product decision left to a follow-up.
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             await ctx.db
                 .delete(userProjects)
                 .where(

--- a/apps/web/client/src/server/api/routers/project/project.ts
+++ b/apps/web/client/src/server/api/routers/project/project.ts
@@ -1,6 +1,7 @@
 import { env } from '@/env';
 import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc';
 import { trackEvent } from '@/utils/analytics/server';
+import { TRPCError } from '@trpc/server';
 import FirecrawlApp from '@mendable/firecrawl-js';
 import { initModel } from '@onlook/ai';
 import { getSandboxPreviewUrl, STORAGE_BUCKETS } from '@onlook/constants';
@@ -194,6 +195,7 @@ export const projectRouter = createTRPCRouter({
     get: protectedProcedure
         .input(z.object({ projectId: z.string() }))
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const project = await ctx.db.query.projects.findFirst({
                 where: eq(projects.id, input.projectId),
             });
@@ -206,6 +208,7 @@ export const projectRouter = createTRPCRouter({
     getProjectWithCanvas: protectedProcedure
         .input(z.object({ projectId: z.string() }))
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const project = await ctx.db.query.projects.findFirst({
                 where: eq(projects.id, input.projectId),
                 with: {
@@ -358,6 +361,12 @@ export const projectRouter = createTRPCRouter({
     getPreviewProjects: protectedProcedure
         .input(z.object({ userId: z.string() }))
         .query(async ({ ctx, input }) => {
+            // A user may only list their own preview projects — the userId is
+            // part of the input schema for backwards-compat client shape, but
+            // is not trusted; the session's own id is the authorization source.
+            if (input.userId !== ctx.user.id) {
+                throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Unauthorized' });
+            }
             const projects = await ctx.db.query.userProjects.findMany({
                 where: eq(userProjects.userId, input.userId),
                 with: {

--- a/apps/web/client/src/server/api/routers/project/sandbox.ts
+++ b/apps/web/client/src/server/api/routers/project/sandbox.ts
@@ -10,6 +10,7 @@ import { getSandboxPreviewUrl, SandboxTemplates, Templates } from '@onlook/const
 import { shortenUuid } from '@onlook/utility/src/id';
 
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { listAccessibleSandboxIds, verifySandboxAccess } from './helper';
 
 function getProvider({
     sandboxId,
@@ -45,7 +46,7 @@ export const sandboxRouter = createTRPCRouter({
                 title: z.string().optional(),
             }),
         )
-        .mutation(async ({ input, ctx }) => {
+        .mutation(async ({ input }) => {
             // Create a new sandbox using the static provider
             const CodesandboxProvider = await getStaticCodeProvider(CodeProvider.CodeSandbox);
 
@@ -74,6 +75,7 @@ export const sandboxRouter = createTRPCRouter({
         )
         .mutation(async ({ input, ctx }) => {
             const userId = ctx.user.id;
+            await verifySandboxAccess(ctx.db, userId, input.sandboxId);
             const provider = await getProvider({
                 sandboxId: input.sandboxId,
                 userId,
@@ -92,7 +94,8 @@ export const sandboxRouter = createTRPCRouter({
                 sandboxId: z.string(),
             }),
         )
-        .mutation(async ({ input }) => {
+        .mutation(async ({ input, ctx }) => {
+            await verifySandboxAccess(ctx.db, ctx.user.id, input.sandboxId);
             const provider = await getProvider({ sandboxId: input.sandboxId });
             try {
                 await provider.pauseProject({});
@@ -100,12 +103,18 @@ export const sandboxRouter = createTRPCRouter({
                 await provider.destroy().catch(() => {});
             }
         }),
-    list: protectedProcedure.input(z.object({ sandboxId: z.string() })).query(async ({ input }) => {
+    list: protectedProcedure.input(z.object({ sandboxId: z.string() })).query(async ({ input, ctx }) => {
+        await verifySandboxAccess(ctx.db, ctx.user.id, input.sandboxId);
         const provider = await getProvider({ sandboxId: input.sandboxId });
         const res = await provider.listProjects({});
         // TODO future iteration of code provider abstraction will need this code to be refactored
         if ('projects' in res) {
-            return res.projects;
+            // `listProjects` returns the entire account's sandboxes. Scope the
+            // result to the caller's own so this can't enumerate other tenants'
+            // sandboxes (the input id doesn't constrain the provider output).
+            const accessible = await listAccessibleSandboxIds(ctx.db, ctx.user.id);
+            const projectList = res.projects as Array<{ id: string }>;
+            return projectList.filter((project) => accessible.has(project.id));
         }
         return [];
     }),
@@ -124,7 +133,11 @@ export const sandboxRouter = createTRPCRouter({
                     .optional(),
             }),
         )
-        .mutation(async ({ input }) => {
+        .mutation(async ({ input, ctx }) => {
+            // Forking a sandbox tied to another user's project would clone their
+            // source tree. Templates / fresh sandboxes resolve to no project and
+            // are allowed (blank-project + local-import flows fork a template).
+            await verifySandboxAccess(ctx.db, ctx.user.id, input.sandbox.id);
             const MAX_RETRY_ATTEMPTS = 3;
             let lastError: Error | null = null;
 
@@ -171,7 +184,8 @@ export const sandboxRouter = createTRPCRouter({
                 sandboxId: z.string(),
             }),
         )
-        .mutation(async ({ input }) => {
+        .mutation(async ({ input, ctx }) => {
+            await verifySandboxAccess(ctx.db, ctx.user.id, input.sandboxId);
             const provider = await getProvider({ sandboxId: input.sandboxId });
             try {
                 await provider.stopProject({});

--- a/apps/web/client/src/server/api/routers/project/settings.ts
+++ b/apps/web/client/src/server/api/routers/project/settings.ts
@@ -7,6 +7,7 @@ import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyProjectAccess } from './helper';
 
 export const settingsRouter = createTRPCRouter({
     get: protectedProcedure
@@ -16,6 +17,7 @@ export const settingsRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const setting = await ctx.db.query.projectSettings.findFirst({
                 where: eq(projectSettings.projectId, input.projectId),
             });
@@ -32,6 +34,7 @@ export const settingsRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const [updatedSettings] = await ctx.db
                 .insert(projectSettings)
                 .values(input)
@@ -55,6 +58,7 @@ export const settingsRouter = createTRPCRouter({
             }),
         )
         .mutation(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             await ctx.db
                 .delete(projectSettings)
                 .where(eq(projectSettings.projectId, input.projectId));

--- a/apps/web/client/src/server/api/routers/publish/deployment.ts
+++ b/apps/web/client/src/server/api/routers/publish/deployment.ts
@@ -7,6 +7,7 @@ import { TRPCError } from '@trpc/server';
 import { and, desc, eq, or } from 'drizzle-orm';
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
+import { verifyDeploymentAccess, verifyProjectAccess } from '../project/helper';
 import { updateDeployment } from './helpers';
 import { createDeployment, publish } from './helpers/index.ts';
 
@@ -16,6 +17,7 @@ export const deploymentRouter = createTRPCRouter({
         type: z.nativeEnum(DeploymentType),
     })).query(async ({ ctx, input }) => {
         const { projectId, type } = input;
+        await verifyProjectAccess(ctx.db, ctx.user.id, projectId);
         const deployment = await ctx.db.query.deployments.findFirst({
             where: and(
                 eq(deployments.projectId, projectId),
@@ -26,6 +28,10 @@ export const deploymentRouter = createTRPCRouter({
         return deployment ?? null;
     }),
     update: protectedProcedure.input(deploymentUpdateSchema).mutation(async ({ ctx, input }) => {
+        if (!input.id) {
+            throw new TRPCError({ code: 'BAD_REQUEST', message: 'Deployment id is required' });
+        }
+        await verifyDeploymentAccess(ctx.db, ctx.user.id, input.id);
         return await updateDeployment(ctx.db, input);
     }),
     create: protectedProcedure.input(z.object({
@@ -46,6 +52,7 @@ export const deploymentRouter = createTRPCRouter({
         } = input;
 
         const userId = ctx.user.id;
+        await verifyProjectAccess(ctx.db, userId, projectId);
 
         const existingDeployment = await ctx.db.query.deployments.findFirst({
             where: and(eq(
@@ -82,6 +89,7 @@ export const deploymentRouter = createTRPCRouter({
         deploymentId: z.string(),
     })).mutation(async ({ ctx, input }): Promise<void> => {
         const { deploymentId } = input;
+        await verifyDeploymentAccess(ctx.db, ctx.user.id, deploymentId);
         const existingDeployment = await ctx.db.query.deployments.findFirst({
             where: and(
                 eq(deployments.id, deploymentId),
@@ -136,6 +144,7 @@ export const deploymentRouter = createTRPCRouter({
         deploymentId: z.string(),
     })).mutation(async ({ ctx, input }) => {
         const { deploymentId } = input;
+        await verifyDeploymentAccess(ctx.db, ctx.user.id, deploymentId);
         const deployment = await ctx.db.query.deployments.findFirst({
             where: eq(deployments.id, deploymentId),
         });

--- a/apps/web/client/src/server/api/routers/publish/index.ts
+++ b/apps/web/client/src/server/api/routers/publish/index.ts
@@ -3,6 +3,7 @@ import {
 } from '@onlook/models';
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
+import { verifyProjectAccess } from '../project/helper';
 import { deploymentRouter } from './deployment';
 import { createDeployment, getProjectUrls, unpublish } from './helpers/index.ts';
 
@@ -14,6 +15,7 @@ export const publishRouter = createTRPCRouter({
     })).mutation(async ({ ctx, input }) => {
         const { projectId, type } = input;
         const userId = ctx.user.id;
+        await verifyProjectAccess(ctx.db, userId, projectId);
         const deployment = await createDeployment({
             db: ctx.db,
             projectId,

--- a/apps/web/client/src/server/api/routers/subscription/subscription.ts
+++ b/apps/web/client/src/server/api/routers/subscription/subscription.ts
@@ -131,6 +131,9 @@ export const subscriptionRouter = createTRPCRouter({
         const { stripeSubscriptionId, stripeSubscriptionItemId, stripePriceId } = input;
         const subscription = await ctx.db.query.subscriptions.findFirst({
             where: and(
+                // Scope to the caller — otherwise anyone with another customer's
+                // stripe ids could upgrade/downgrade their plan and trigger charges.
+                eq(subscriptions.userId, ctx.user.id),
                 eq(subscriptions.stripeSubscriptionId, stripeSubscriptionId),
                 eq(subscriptions.stripeSubscriptionItemId, stripeSubscriptionItemId),
             ),
@@ -181,13 +184,28 @@ export const subscriptionRouter = createTRPCRouter({
                 scheduledChangeAt,
                 scheduledPriceId: newPrice.id,
                 stripeSubscriptionScheduleId: schedule.id,
-            }).where(eq(subscriptions.stripeSubscriptionItemId, stripeSubscriptionItemId)).returning();
+            }).where(and(
+                eq(subscriptions.userId, ctx.user.id),
+                eq(subscriptions.stripeSubscriptionItemId, stripeSubscriptionItemId),
+            )).returning();
         }
     }),
 
     releaseSubscriptionSchedule: protectedProcedure.input(z.object({
         subscriptionScheduleId: z.string(),
     })).mutation(async ({ input, ctx }) => {
+        // The caller must own the subscription that carries this schedule — else
+        // anyone could release another customer's scheduled plan change and force
+        // their subscription back to ACTIVE.
+        const ownedSubscription = await ctx.db.query.subscriptions.findFirst({
+            where: and(
+                eq(subscriptions.userId, ctx.user.id),
+                eq(subscriptions.stripeSubscriptionScheduleId, input.subscriptionScheduleId),
+            ),
+        });
+        if (!ownedSubscription) {
+            throw new Error('Subscription not found');
+        }
         try {
             await releaseSubscriptionSchedule({ subscriptionScheduleId: input.subscriptionScheduleId });
         } catch (error: any) {
@@ -204,7 +222,10 @@ export const subscriptionRouter = createTRPCRouter({
             scheduledPriceId: null,
             stripeSubscriptionScheduleId: null,
             scheduledChangeAt: null,
-        }).where(eq(subscriptions.stripeSubscriptionScheduleId, input.subscriptionScheduleId)).returning();
+        }).where(and(
+            eq(subscriptions.userId, ctx.user.id),
+            eq(subscriptions.stripeSubscriptionScheduleId, input.subscriptionScheduleId),
+        )).returning();
 
         if (!updatedSubscription) {
             throw new Error('Subscription not found');

--- a/apps/web/client/src/server/api/routers/usage/index.ts
+++ b/apps/web/client/src/server/api/routers/usage/index.ts
@@ -93,11 +93,15 @@ export const usageRouter = createTRPCRouter({
                     left: sql`${rateLimits.left} + 1`,
                 }).where(and(
                     eq(rateLimits.id, input.rateLimitId),
+                    eq(rateLimits.userId, ctx.user.id),
                 ));
             }
 
             if (input.usageRecordId) {
-                await tx.delete(usageRecords).where(and(eq(usageRecords.id, input.usageRecordId)));
+                await tx.delete(usageRecords).where(and(
+                    eq(usageRecords.id, input.usageRecordId),
+                    eq(usageRecords.userId, ctx.user.id),
+                ));
             }
 
             return { rateLimitId: input.rateLimitId, usageRecordId: input.usageRecordId };

--- a/apps/web/client/src/server/api/routers/user/user-canvas.ts
+++ b/apps/web/client/src/server/api/routers/user/user-canvas.ts
@@ -11,6 +11,7 @@ import {
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { createTRPCRouter, protectedProcedure } from '../../trpc';
+import { verifyProjectAccess } from '../project/helper';
 
 export const userCanvasRouter = createTRPCRouter({
     get: protectedProcedure
@@ -42,6 +43,7 @@ export const userCanvasRouter = createTRPCRouter({
             }),
         )
         .query(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             const dbCanvas = await ctx.db.query.canvases.findFirst({
                 where: eq(canvases.projectId, input.projectId),
                 with: {
@@ -66,6 +68,7 @@ export const userCanvasRouter = createTRPCRouter({
             canvasId: z.string(),
             canvas: userCanvasUpdateSchema,
         })).mutation(async ({ ctx, input }) => {
+            await verifyProjectAccess(ctx.db, ctx.user.id, input.projectId);
             try {
                 await ctx.db
                     .update(userCanvases)

--- a/apps/web/client/src/server/api/routers/user/user-settings.ts
+++ b/apps/web/client/src/server/api/routers/user/user-settings.ts
@@ -18,11 +18,14 @@ export const userSettingsRouter = createTRPCRouter({
         });
 
         if (!existingSettings) {
-            const newSettings = { ...createDefaultUserSettings(user.id), ...input };
+            // Force the row's userId to the session user — `input` comes from
+            // `userSettingsUpdateSchema`, which includes `userId`, so a supplied
+            // value must not be able to create settings for another user.
+            const newSettings = { ...createDefaultUserSettings(user.id), ...input, userId: user.id };
             const [insertedSettings] = await ctx.db.insert(userSettings).values(newSettings).returning();
             return fromDbUserSettings(insertedSettings ?? newSettings);
         }
-        const [updatedSettings] = await ctx.db.update(userSettings).set(input).where(eq(userSettings.userId, user.id)).returning();
+        const [updatedSettings] = await ctx.db.update(userSettings).set({ ...input, userId: user.id }).where(eq(userSettings.userId, user.id)).returning();
 
         if (!updatedSettings) {
             throw new Error('Failed to update user settings');

--- a/apps/web/client/src/server/api/routers/user/user.ts
+++ b/apps/web/client/src/server/api/routers/user/user.ts
@@ -27,6 +27,12 @@ export const userRouter = createTRPCRouter({
         return userData;
     }),
     getById: protectedProcedure.input(z.string()).query(async ({ ctx, input }) => {
+        // A user may only look themselves up by id (this returns PII + the full
+        // project list). `get` is the normal self path; guarding here closes the
+        // cross-user read while keeping the endpoint's self-lookup behavior.
+        if (input !== ctx.user.id) {
+            throw new Error('Unauthorized or not found');
+        }
         const user = await ctx.db.query.users.findFirst({
             where: eq(users.id, input),
             with: {
@@ -44,14 +50,16 @@ export const userRouter = createTRPCRouter({
         .mutation(async ({ ctx, input }): Promise<User | null> => {
             const authUser = ctx.user;
 
+            // Pin the row to the session user — the client-supplied `input.id`
+            // must never be able to create or overwrite another user's account.
             const existingUser = await ctx.db.query.users.findFirst({
-                where: eq(users.id, input.id),
+                where: eq(users.id, authUser.id),
             });
 
             const { firstName, lastName, displayName } = getUserName(authUser);
 
             const userData = {
-                id: input.id,
+                id: authUser.id,
                 firstName: input.firstName ?? firstName,
                 lastName: input.lastName ?? lastName,
                 displayName: input.displayName ?? displayName,


### PR DESCRIPTION
Closes #3122. Supersedes the partial fix in #3127 with complete coverage.

## Problem

The Drizzle client connects as an RLS-exempt Postgres superuser, so authorization must be enforced in tRPC procedure code. `verifyProjectAccess` existed but was applied to only a handful of procedures — every other project-scoped procedure trusted a client-supplied id (`projectId` / `conversationId` / `branchId` / `sandboxId` / `deploymentId` / `verificationId` / …), so an authenticated user could act on another user's resources. An audit of the whole tRPC surface found the same class still open in several routers, including the highest-impact ones (sandbox sessions, deployments, custom domains, account records, and Stripe subscriptions).

## Fix

One resolve-then-verify pattern applied across every project-scoped procedure, all sharing a merged `Unauthorized or not found` error so the checks can't enumerate resource existence.

**Helpers (`project/helper.ts`):**
- `verifyProjectAccess` (existing) + `verifyConversationAccess`, `verifyMessagesAccess`, `verifyBranchAccess`, `verifyCanvasAccess`, `verifyFrameAccess`, `verifyInvitationAccess`
- `verifySandboxAccess` — resolves a sandbox to its project via `branches.sandboxId`, then `projects.sandboxId`. A sandbox not yet tied to any project (fresh create / fork-from-template / local import, before a branch row exists) is allowed, so project-creation flows keep working; the check blocks acting on another user's **persisted** sandbox.
- `verifyDeploymentAccess`, `verifyDomainVerificationAccess`
- `listAccessibleSandboxIds` — scopes `sandbox.list` (whose provider call returns the whole account) to the caller's own sandboxes.

**Routers hardened:** `project`, `chat` (conversation / message / suggestion), `branch`, `frame`, `settings`, `createRequest`, `sandbox`, `publish` (deployment + unpublish), `domain` (preview / custom / verification), `user` (`getById` self-only, `upsert` pinned to the session user), `subscription`, `usage`, `user-canvas`, `user-settings`.

**Also, from the #3127 review:**
- auth checks moved out of `catch → return false` blocks so a denial propagates instead of being swallowed;
- `verifyMessagesAccess` dedupes ids so a bulk op with a repeated id isn't falsely rejected (`inArray` returns distinct rows);
- `custom.remove` now scopes to the caller's `projectId` (previously accepted but ignored);
- `getPreviewProjects` throws `TRPCError`.

## Tests / checks

- Unit tests for the authorization helpers: `project/helper.test.ts` (19 cases — member pass, non-member/missing reject, dedupe, sandbox allow-when-unowned, list scoping).
- `bun run typecheck` on the web client passes.
- Would appreciate a maintainer running the full `bun test` suite and exercising the original #3122 repro end-to-end (no local Supabase here).

## Not in scope / follow-ups

- `forward/editor.ts` uses `publicProcedure` (unauthenticated) but is not mounted in `appRouter` (dead code) — should be gated before it's ever mounted.
- The SSRF-flavored `code.scrapeUrl` / `sandbox.createFromGitHub` (arbitrary URL fetch) are a different class, left out of this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened authorization across conversations, messages, projects, branches, domains, deployments, sandboxes, canvases, and user settings.
  * Prevented unauthorized cross-project, cross-user, and cross-conversation access or modifications.
  * Restricted sandbox listings to accessible resources and protected subscription and usage updates.
  * Ensured messages remain associated with their intended conversation.

* **Bug Fixes**
  * Added validation for missing conversation and deployment identifiers.
  * Prevented domain cancellation and user data updates from affecting unrelated records.

* **Tests**
  * Added comprehensive coverage for resource access checks and sandbox authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->