### PR TITLE
fix: cross-platform path handling in setup:env api-keys writer

### DIFF
--- a/packages/scripts/src/api-keys.ts
+++ b/packages/scripts/src/api-keys.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import fs from 'node:fs';
+import path from 'node:path';
 import prompts from 'prompts';
 
 interface ApiKeyConfig {
@@ -157,7 +158,9 @@ const extractKeyName = (variableLine: string): string | undefined => {
  * @param filePath - Full path to the file
  */
 const ensureDirectoryExists = (filePath: string): void => {
-    const dir = filePath.substring(0, filePath.lastIndexOf('/'));
+    // Use cross-platform path handling — on Windows, paths use '\' so
+    // lastIndexOf('/') returned -1 and mkdirSync('') threw ENOENT (#3119)
+    const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
     }

--- a/packages/scripts/test/comprehensive.test.ts
+++ b/packages/scripts/test/comprehensive.test.ts
@@ -658,7 +658,7 @@ SUPABASE_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres`;
             const content = 'TEST_KEY=test_value';
 
             // Simulate ensureDirectoryExists logic
-            const dir = nestedPath.substring(0, nestedPath.lastIndexOf('/'));
+            const dir = path.dirname(nestedPath);
             if (!fs.existsSync(dir)) {
                 fs.mkdirSync(dir, { recursive: true });
             }

--- a/packages/scripts/test/integration.test.ts
+++ b/packages/scripts/test/integration.test.ts
@@ -190,7 +190,7 @@ SUPABASE_DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres`;
         const content = 'NESTED_KEY=nested_value\n';
 
         // Simulate creating directory structure
-        const dir = nestedEnvPath.substring(0, nestedEnvPath.lastIndexOf('/'));
+        const dir = path.dirname(nestedEnvPath);
         if (!fs.existsSync(dir)) {
             fs.mkdirSync(dir, { recursive: true });
         }


### PR DESCRIPTION
## Description

`setup:env` crashes on Windows with `ENOENT: no such file or directory, mkdir ''` when writing API keys.

Root cause: `ensureDirectoryExists` in `packages/scripts/src/api-keys.ts` derives the parent directory with `filePath.substring(0, filePath.lastIndexOf('/'))`. Paths built by `path.join` use `\` on Windows, so `lastIndexOf('/')` returns -1, the directory comes out as `''`, and `mkdirSync('')` throws.

`helpers.ts` in the same package already handles this with `path.dirname` ("cross-platform path handling") — this applies the same fix to `api-keys.ts` and aligns the two tests that had copied the old pattern.

## Related Issues

Fixes #3119

## Type of Change

- [x] Bug fix

## Testing

- `bun test` in `packages/scripts`: 43 pass / 0 fail
- Reproduced the original crash on Windows 11 (fresh clone, `bun run setup:env`), confirmed gone after the fix

## Additional Notes

Hit this while self-hosting on Windows. Same root cause as the cross-platform fix already in `helpers.ts` — it just missed this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file and directory paths across different operating systems.
  * Updated environment-file path processing to correctly identify parent directories.

* **Tests**
  * Enhanced path-related test coverage for nested environment files and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->