### PR TITLE
fix: storage bucket migrations fail on current Supabase (SQLSTATE 42501)

### DIFF
--- a/apps/backend/supabase/migrations/0008_preview-img-storage.sql
+++ b/apps/backend/supabase/migrations/0008_preview-img-storage.sql
@@ -1,10 +1,10 @@
-delete from storage.objects where bucket_id = 'preview_images';
-delete from storage.buckets where id = 'preview_images';
-
+-- Direct deletes from storage tables are rejected by newer Supabase storage
+-- versions (SQLSTATE 42501); upsert instead — identical result on a fresh DB.
 insert into storage.buckets
   (id, name, public)
 values
-  ('preview_images', 'preview_images', true);
+  ('preview_images', 'preview_images', true)
+on conflict (id) do update set public = excluded.public;
 
 -- Allow any users to select from preview_images files
 drop policy if exists "preview_images_select_policy" on storage.objects;

--- a/apps/backend/supabase/migrations/0012_file-transfer-bucket.sql
+++ b/apps/backend/supabase/migrations/0012_file-transfer-bucket.sql
@@ -1,10 +1,10 @@
-delete from storage.objects where bucket_id = 'file_transfer';
-delete from storage.buckets where id = 'file_transfer';
-
+-- Direct deletes from storage tables are rejected by newer Supabase storage
+-- versions (SQLSTATE 42501); upsert instead — identical result on a fresh DB.
 insert into storage.buckets
   (id, name, public)
 values
-  ('file_transfer', 'file_transfer', false);
+  ('file_transfer', 'file_transfer', false)
+on conflict (id) do update set public = excluded.public;
 
 -- Allow authenticated users to select only their own files from file_transfer
 drop policy if exists "file_transfer_select_policy" on storage.objects;


### PR DESCRIPTION
## Description

Fresh self-hosts fail during `supabase start` at migration `0008_preview-img-storage.sql`:

```
ERROR: Direct deletion from storage tables is not allowed. Use the Storage API instead. (SQLSTATE 42501)
```

`0008` and `0012_file-transfer-bucket.sql` start with direct deletes against `storage.objects` / `storage.buckets`, which recent Supabase versions reject — so the backend never comes up on a fresh clone with a current CLI (hit with 2.75.0; the pinned ^2.45.5 still passes).

On a fresh database the deletes are no-ops, so this replaces each delete+insert pair with an upsert (`insert ... on conflict (id) do update`) — identical end state, no direct writes the storage privilege model forbids.

## Related Issues

Fixes #3133

## Type of Change

- [x] Bug fix

## Testing

- `supabase start` on a fresh database completes all migrations; both buckets exist with correct visibility (`preview_images` public, `file_transfer` private)
- Ran the full local flow afterward (db push, seed, app boot) — no regressions

## Additional Notes

One behavior difference worth a conscious review: the old code also wiped existing objects in these buckets when re-applied; the upsert preserves them. On fresh databases (the only place these migrations run in practice) there is no difference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing preview images during database updates while ensuring their storage remains publicly accessible.
  * Preserved the file-transfer storage bucket during updates while maintaining private access controls.
  * Reduced the risk of data loss when applying storage configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->