### PR TITLE
Add TrustedRouter as a model provider

### DIFF
--- a/apps/web/client/src/env.ts
+++ b/apps/web/client/src/env.ts
@@ -34,6 +34,7 @@ export const env = createEnv({
 
         // Model providers
         OPENROUTER_API_KEY: z.string(),
+        TRUSTEDROUTER_API_KEY: z.string().optional(),
         ANTHROPIC_API_KEY: z.string().optional(),
         GOOGLE_AI_STUDIO_API_KEY: z.string().optional(),
         OPENAI_API_KEY: z.string().optional(),
@@ -130,6 +131,7 @@ export const env = createEnv({
         GOOGLE_AI_STUDIO_API_KEY: process.env.GOOGLE_AI_STUDIO_API_KEY,
         OPENAI_API_KEY: process.env.OPENAI_API_KEY,
         OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+        TRUSTEDROUTER_API_KEY: process.env.TRUSTEDROUTER_API_KEY,
 
         // n8n
         N8N_WEBHOOK_URL: process.env.N8N_WEBHOOK_URL,

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -34,6 +34,7 @@
     },
     "dependencies": {
         "@mendable/firecrawl-js": "^1.29.1",
+        "@ai-sdk/openai-compatible": "^1.0.0",
         "@openrouter/ai-sdk-provider": "^1.2.0",
         "ai": "5.0.60",
         "exa-js": "^1.8.26",

--- a/packages/ai/src/chat/providers.ts
+++ b/packages/ai/src/chat/providers.ts
@@ -2,9 +2,11 @@ import {
     LLMProvider,
     MODEL_MAX_TOKENS,
     OPENROUTER_MODELS,
+    TRUSTEDROUTER_MODELS,
     type InitialModelPayload,
     type ModelConfig
 } from '@onlook/models';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { assertNever } from '@onlook/utility';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import type { LanguageModel } from 'ai';
@@ -33,6 +35,9 @@ export function initModel({
                 ? { ...providerOptions, anthropic: { cacheControl: { type: 'ephemeral' } } }
                 : providerOptions;
             break;
+        case LLMProvider.TRUSTEDROUTER:
+            model = getTrustedRouterProvider(requestedModel);
+            break;
         default:
             assertNever(requestedProvider);
     }
@@ -43,6 +48,18 @@ export function initModel({
         headers,
         maxOutputTokens,
     };
+}
+
+function getTrustedRouterProvider(model: TRUSTEDROUTER_MODELS): LanguageModel {
+    if (!process.env.TRUSTEDROUTER_API_KEY) {
+        throw new Error('TRUSTEDROUTER_API_KEY must be set');
+    }
+    const trustedrouter = createOpenAICompatible({
+        name: 'trustedrouter',
+        apiKey: process.env.TRUSTEDROUTER_API_KEY,
+        baseURL: 'https://api.trustedrouter.com/v1',
+    });
+    return trustedrouter(model);
 }
 
 function getOpenRouterProvider(model: OPENROUTER_MODELS): LanguageModel {

--- a/packages/models/src/llm/index.ts
+++ b/packages/models/src/llm/index.ts
@@ -2,6 +2,7 @@ import type { LanguageModel } from 'ai';
 
 export enum LLMProvider {
     OPENROUTER = 'openrouter',
+    TRUSTEDROUTER = 'trustedrouter',
 }
 
 export enum OPENROUTER_MODELS {
@@ -13,8 +14,19 @@ export enum OPENROUTER_MODELS {
     OPEN_AI_GPT_5_NANO = 'openai/gpt-5-nano',
 }
 
+// TrustedRouter model ids are namespaced; a bare id is rejected. Ids under
+// `trustedrouter/` are routing policies rather than single models: each picks an
+// upstream per request and fails over.
+export enum TRUSTEDROUTER_MODELS {
+    AUTO = 'trustedrouter/auto',
+    ZDR = 'trustedrouter/zdr',
+    CLAUDE_4_6_SONNET = 'anthropic/claude-sonnet-4-6',
+    OPEN_AI_GPT_5_4_MINI = 'openai/gpt-5.4-mini',
+}
+
 interface ModelMapping {
     [LLMProvider.OPENROUTER]: OPENROUTER_MODELS;
+    [LLMProvider.TRUSTEDROUTER]: TRUSTEDROUTER_MODELS;
 }
 
 export type InitialModelPayload = {
@@ -37,4 +49,8 @@ export const MODEL_MAX_TOKENS = {
     [OPENROUTER_MODELS.OPEN_AI_GPT_5_NANO]: 400000,
     [OPENROUTER_MODELS.OPEN_AI_GPT_5_MINI]: 400000,
     [OPENROUTER_MODELS.OPEN_AI_GPT_5]: 400000,
+    [TRUSTEDROUTER_MODELS.AUTO]: 200000,
+    [TRUSTEDROUTER_MODELS.ZDR]: 200000,
+    [TRUSTEDROUTER_MODELS.CLAUDE_4_6_SONNET]: 1000000,
+    [TRUSTEDROUTER_MODELS.OPEN_AI_GPT_5_4_MINI]: 400000,
 } as const;


### PR DESCRIPTION
Adds TrustedRouter as a second model provider. It's an OpenAI-compatible router — one key reaches models from OpenAI, Anthropic, Google, DeepSeek and others, with per-request routing and failover.

`LLMProvider` had a single member, so this extends the existing shape rather than inventing one: a `TRUSTEDROUTER_MODELS` enum, a `ModelMapping` entry, `MODEL_MAX_TOKENS` values, and a `switch` case in `initModel`. The `assertNever` default meant the compiler required the new case, which is a nice guarantee.

**New dependency: `@ai-sdk/openai-compatible`.** TrustedRouter has no bespoke AI SDK package, and `packages/ai` had no generic OpenAI-compatible provider — only `@openrouter/ai-sdk-provider`. This is the standard AI SDK v5 package for exactly this case. Say the word if you'd rather I route it through something already present.

`TRUSTEDROUTER_API_KEY` is `.optional()` in `env.ts`, unlike the required `OPENROUTER_API_KEY`, so existing deployments keep booting without setting it.

Model ids are namespaced — `anthropic/claude-sonnet-4-6` works, a bare id is rejected. The ids under `trustedrouter/` are routing policies rather than single models: `auto` picks per request with failover, `zdr` restricts routing to providers that retain no data.

Verified: `bun install` resolves the new dependency, and `tsc --noEmit` reports **0 errors in `packages/ai` and `packages/models`** — the two packages this touches. Running tsc from a package directory also surfaces pre-existing path-alias errors from `apps/web/client`; those are unrelated to this change and present before it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TrustedRouter as an available AI provider.
  * Added support for TrustedRouter routing policies and supported models.
  * Added model-specific maximum token limits for TrustedRouter options.
  * Added optional TrustedRouter API key configuration for connecting to the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->