### PR TITLE
fix: 在使用docker部署的时候运行bun run setup:env报错！！！

### DIFF
--- a/packages/scripts/src/backend.ts
+++ b/packages/scripts/src/backend.ts
@@ -3,7 +3,8 @@ import { spawn } from 'node:child_process';
 import type { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import path from 'node:path';
-import ora, { type Ora } from 'ora';import { z } from 'zod';
+import ora, { type Ora } from 'ora';
+import { z } from 'zod';
 import { writeEnvFile } from './helpers';
 
 /**
@@ -349,6 +350,28 @@ export interface BackendStartOptions {
     onOutput?: (chunk: string) => void;
 }
 
+const REDACTED = '[redacted]';
+
+const SENSITIVE_LABEL_PATTERN =
+    /\b((?:jwt|anon|service[_ ]role|publishable|secret|access|s3)[a-z_ ]*(?:key|secret|token|password)[a-z_ ]*)(\s*[:=]\s*)(\S+)/gi;
+
+const SENSITIVE_TOKEN_PATTERNS: RegExp[] = [
+    /\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}/g,
+    /\bsb_[a-z]+_[A-Za-z0-9_-]{8,}/g,
+];
+
+const redactSensitiveOutput = (text: string): string => {
+    const withoutLabelledValues = text.replace(
+        SENSITIVE_LABEL_PATTERN,
+        (_match, label: string, separator: string) => `${label}${separator}${REDACTED}`,
+    );
+
+    return SENSITIVE_TOKEN_PATTERNS.reduce(
+        (redacted, pattern) => redacted.replace(pattern, REDACTED),
+        withoutLabelledValues,
+    );
+};
+
 const lastNonEmptyLine = (chunk: string): string | undefined =>
     chunk
         .split(/[\r\n]+/)
@@ -425,7 +448,7 @@ const startBackendAndExtractKeys = async (): Promise<BackendKeys> => {
             inactivityTimeoutMs: BACKEND_START_INACTIVITY_TIMEOUT_MS,
             onOutput: (chunk) => {
                 outputTail = (outputTail + chunk).slice(-OUTPUT_TAIL_LIMIT);
-                const progress = lastNonEmptyLine(chunk);
+                const progress = lastNonEmptyLine(redactSensitiveOutput(chunk));
                 if (progress) {
                     spinner.text = `Waiting for Supabase to initialize... ${progress.slice(0, PROGRESS_LINE_LIMIT)}`;
                 }
@@ -433,8 +456,9 @@ const startBackendAndExtractKeys = async (): Promise<BackendKeys> => {
         });
     } catch (error) {
         spinner.fail((error as Error).message);
-        if (outputTail.trim()) {
-            console.error(chalk.gray(outputTail.trim()));
+        const redactedTail = redactSensitiveOutput(outputTail).trim();
+        if (redactedTail) {
+            console.error(chalk.gray(redactedTail));
         }
         throw error;
     }

--- a/packages/scripts/src/backend.ts
+++ b/packages/scripts/src/backend.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
 import { spawn } from 'node:child_process';
+import type { EventEmitter } from 'node:events';
 import fs from 'node:fs';
 import path from 'node:path';
-import ora, { type Ora } from 'ora';
-import { z } from 'zod';
+import ora, { type Ora } from 'ora';import { z } from 'zod';
 import { writeEnvFile } from './helpers';
 
 /**
@@ -332,38 +332,114 @@ const createProcessHandlers = (
     return { onData, onClose, onError };
 };
 
+const BACKEND_START_INACTIVITY_TIMEOUT_MS = 300_000;
+const OUTPUT_TAIL_LIMIT = 2_000;
+const PROGRESS_LINE_LIMIT = 100;
+
+export interface MonitoredProcess {
+    stdout: EventEmitter | null;
+    stderr: EventEmitter | null;
+    on(event: 'close', listener: (code: number | null) => void): unknown;
+    on(event: 'error', listener: (err: Error) => void): unknown;
+    kill(): unknown;
+}
+
+export interface BackendStartOptions {
+    inactivityTimeoutMs: number;
+    onOutput?: (chunk: string) => void;
+}
+
+const lastNonEmptyLine = (chunk: string): string | undefined =>
+    chunk
+        .split(/[\r\n]+/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .pop();
+
+export const waitForBackendStart = (
+    proc: MonitoredProcess,
+    { inactivityTimeoutMs, onOutput }: BackendStartOptions,
+): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+        let settled = false;
+        let timeout: NodeJS.Timeout | undefined;
+
+        const settle = (finish: () => void) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            finish();
+        };
+
+        const armTimeout = () => {
+            timeout = setTimeout(() => {
+                settle(() => {
+                    proc.kill();
+                    reject(
+                        new Error(
+                            `Supabase produced no output for ${Math.round(inactivityTimeoutMs / 1000)}s while starting.`,
+                        ),
+                    );
+                });
+            }, inactivityTimeoutMs);
+        };
+
+        const onData = (chunk: Buffer | string) => {
+            if (settled) return;
+            clearTimeout(timeout);
+            armTimeout();
+            onOutput?.(chunk.toString());
+        };
+
+        proc.stdout?.on('data', onData);
+        proc.stderr?.on('data', onData);
+
+        proc.on('close', (code) =>
+            settle(() => {
+                if (code === 0) {
+                    resolve();
+                } else {
+                    reject(new Error(`Supabase start failed with exit code ${code ?? 'unknown'}.`));
+                }
+            }),
+        );
+
+        proc.on('error', (err) => settle(() => reject(err)));
+
+        armTimeout();
+    });
+
 const startBackendAndExtractKeys = async (): Promise<BackendKeys> => {
     console.log(chalk.yellow('🚀 Starting Supabase backend...'));
     const spinner = ora('Waiting for Supabase to initialize...').start();
 
-    const startProc = spawn('bun run', ['backend:start'], { cwd: rootDir, shell: true });
-
-    await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-            startProc.kill();
-            spinner.fail('Timed out waiting for Supabase keys.');
-            reject(new Error('Supabase start timeout'));
-        }, 120_000);
-
-        startProc.on('close', (code) => {
-            clearTimeout(timeout);
-            if (code === 0) {
-                resolve();
-            } else {
-                spinner.fail('Failed to start Supabase backend.');
-                reject(new Error('Supabase start failed'));
-            }
-        });
-
-        startProc.on('error', (err) => {
-            clearTimeout(timeout);
-            spinner.fail(`Backend error: ${err.message}`);
-            reject(err);
-        });
+    const startProc = spawn('bun', ['run', 'backend:start'], {
+        cwd: rootDir,
+        stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    spinner.succeed('Supabase backend started.');
+    let outputTail = '';
 
+    try {
+        await waitForBackendStart(startProc, {
+            inactivityTimeoutMs: BACKEND_START_INACTIVITY_TIMEOUT_MS,
+            onOutput: (chunk) => {
+                outputTail = (outputTail + chunk).slice(-OUTPUT_TAIL_LIMIT);
+                const progress = lastNonEmptyLine(chunk);
+                if (progress) {
+                    spinner.text = `Waiting for Supabase to initialize... ${progress.slice(0, PROGRESS_LINE_LIMIT)}`;
+                }
+            },
+        });
+    } catch (error) {
+        spinner.fail((error as Error).message);
+        if (outputTail.trim()) {
+            console.error(chalk.gray(outputTail.trim()));
+        }
+        throw error;
+    }
+
+    spinner.succeed('Supabase backend started.');
     // Now get all keys from status
     const keysSpinner = ora('Extracting Supabase keys...').start();
     const backendDir = path.join(rootDir, 'apps', 'backend');

--- a/packages/scripts/src/backend.ts
+++ b/packages/scripts/src/backend.ts
@@ -336,6 +336,7 @@ const createProcessHandlers = (
 const BACKEND_START_INACTIVITY_TIMEOUT_MS = 300_000;
 const OUTPUT_TAIL_LIMIT = 2_000;
 const PROGRESS_LINE_LIMIT = 100;
+const PROGRESS_CARRY_LIMIT = 4_000;
 
 export interface MonitoredProcess {
     stdout: EventEmitter | null;
@@ -378,6 +379,29 @@ const lastNonEmptyLine = (chunk: string): string | undefined =>
         .map((line) => line.trim())
         .filter((line) => line.length > 0)
         .pop();
+
+/**
+ * Builds a reporter that keeps incomplete lines in a carry buffer so redaction
+ * always runs on whole lines
+ * @returns Function returning the redacted progress line for a chunk, if any
+ */
+export const createProgressReporter = (): ((chunk: string) => string | undefined) => {
+    let carry = '';
+
+    return (chunk: string): string | undefined => {
+        const combined = carry + chunk;
+        const lastBreak = Math.max(combined.lastIndexOf('\n'), combined.lastIndexOf('\r'));
+
+        if (lastBreak === -1) {
+            carry = combined.slice(0, PROGRESS_CARRY_LIMIT);
+            return undefined;
+        }
+
+        carry = combined.slice(lastBreak + 1, lastBreak + 1 + PROGRESS_CARRY_LIMIT);
+        const progress = lastNonEmptyLine(redactSensitiveOutput(combined.slice(0, lastBreak)));
+        return progress?.slice(0, PROGRESS_LINE_LIMIT);
+    };
+};
 
 export const waitForBackendStart = (
     proc: MonitoredProcess,
@@ -442,15 +466,16 @@ const startBackendAndExtractKeys = async (): Promise<BackendKeys> => {
     });
 
     let outputTail = '';
+    const reportProgress = createProgressReporter();
 
     try {
         await waitForBackendStart(startProc, {
             inactivityTimeoutMs: BACKEND_START_INACTIVITY_TIMEOUT_MS,
             onOutput: (chunk) => {
                 outputTail = (outputTail + chunk).slice(-OUTPUT_TAIL_LIMIT);
-                const progress = lastNonEmptyLine(redactSensitiveOutput(chunk));
+                const progress = reportProgress(chunk);
                 if (progress) {
-                    spinner.text = `Waiting for Supabase to initialize... ${progress.slice(0, PROGRESS_LINE_LIMIT)}`;
+                    spinner.text = `Waiting for Supabase to initialize... ${progress}`;
                 }
             },
         });

--- a/packages/scripts/src/backend.ts
+++ b/packages/scripts/src/backend.ts
@@ -346,9 +346,11 @@ export interface MonitoredProcess {
     kill(): unknown;
 }
 
+export type OutputStream = 'stdout' | 'stderr';
+
 export interface BackendStartOptions {
     inactivityTimeoutMs: number;
-    onOutput?: (chunk: string) => void;
+    onOutput?: (chunk: string, stream: OutputStream) => void;
 }
 
 const REDACTED = '[redacted]';
@@ -403,6 +405,18 @@ export const createProgressReporter = (): ((chunk: string) => string | undefined
     };
 };
 
+export const createStreamProgressReporter = (): ((
+    chunk: string,
+    stream: OutputStream,
+) => string | undefined) => {
+    const reporters: Record<OutputStream, (chunk: string) => string | undefined> = {
+        stdout: createProgressReporter(),
+        stderr: createProgressReporter(),
+    };
+
+    return (chunk: string, stream: OutputStream): string | undefined => reporters[stream](chunk);
+};
+
 export const waitForBackendStart = (
     proc: MonitoredProcess,
     { inactivityTimeoutMs, onOutput }: BackendStartOptions,
@@ -431,15 +445,15 @@ export const waitForBackendStart = (
             }, inactivityTimeoutMs);
         };
 
-        const onData = (chunk: Buffer | string) => {
+        const onData = (stream: OutputStream) => (chunk: Buffer | string) => {
             if (settled) return;
             clearTimeout(timeout);
             armTimeout();
-            onOutput?.(chunk.toString());
+            onOutput?.(chunk.toString(), stream);
         };
 
-        proc.stdout?.on('data', onData);
-        proc.stderr?.on('data', onData);
+        proc.stdout?.on('data', onData('stdout'));
+        proc.stderr?.on('data', onData('stderr'));
 
         proc.on('close', (code) =>
             settle(() => {
@@ -466,14 +480,14 @@ const startBackendAndExtractKeys = async (): Promise<BackendKeys> => {
     });
 
     let outputTail = '';
-    const reportProgress = createProgressReporter();
+    const reportProgress = createStreamProgressReporter();
 
     try {
         await waitForBackendStart(startProc, {
             inactivityTimeoutMs: BACKEND_START_INACTIVITY_TIMEOUT_MS,
-            onOutput: (chunk) => {
+            onOutput: (chunk, stream) => {
                 outputTail = (outputTail + chunk).slice(-OUTPUT_TAIL_LIMIT);
-                const progress = reportProgress(chunk);
+                const progress = reportProgress(chunk, stream);
                 if (progress) {
                     spinner.text = `Waiting for Supabase to initialize... ${progress}`;
                 }

--- a/packages/scripts/test/comprehensive.test.ts
+++ b/packages/scripts/test/comprehensive.test.ts
@@ -8,6 +8,7 @@ import {
     generateBackendEnvContent,
     CLIENT_BACKEND_KEYS,
     createProgressReporter,
+    createStreamProgressReporter,
 } from '../src/backend';
 import { parseEnvContent, buildEnvFileContent, writeEnvFile } from '../src/helpers';
 
@@ -425,6 +426,18 @@ Supabase local development setup completed.
             expect(reportProgress('Starting containers...\n')).toBe('Starting containers...');
             expect(reportProgress('Seeding data')).toBeUndefined();
             expect(reportProgress('...done\r')).toBe('Seeding data...done');
+        });
+
+        it('should keep stdout and stderr carry buffers separate', () => {
+            const reportProgress = createStreamProgressReporter();
+
+            expect(reportProgress('SERVICE_ROLE_KEY=', 'stdout')).toBeUndefined();
+            expect(reportProgress('warning: docker is slow\n', 'stderr')).toBe(
+                'warning: docker is slow',
+            );
+            expect(reportProgress('super-secret-value\n', 'stdout')).toBe(
+                'SERVICE_ROLE_KEY=[redacted]',
+            );
         });
     });
 

--- a/packages/scripts/test/comprehensive.test.ts
+++ b/packages/scripts/test/comprehensive.test.ts
@@ -3,7 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 // Import actual functions to test
-import { getDbEnvContent, generateBackendEnvContent, CLIENT_BACKEND_KEYS } from '../src/backend';
+import {
+    getDbEnvContent,
+    generateBackendEnvContent,
+    CLIENT_BACKEND_KEYS,
+    createProgressReporter,
+} from '../src/backend';
 import { parseEnvContent, buildEnvFileContent, writeEnvFile } from '../src/helpers';
 
 describe('comprehensive functionality tests', () => {
@@ -394,6 +399,32 @@ Supabase local development setup completed.
             expect(isValidJWT('ey')).toBe(false); // Too short
             expect(isValidJWT('')).toBe(false);
             expect(isValidJWT('eyJ contains spaces')).toBe(false);
+        });
+    });
+
+    describe('Startup progress redaction', () => {
+        it('should redact a labeled secret split across chunks', () => {
+            const reportProgress = createProgressReporter();
+
+            expect(reportProgress('SERVICE_ROLE_KEY=')).toBeUndefined();
+            expect(reportProgress('super-secret-value\n')).toBe('SERVICE_ROLE_KEY=[redacted]');
+        });
+
+        it('should redact a JWT split across chunks', () => {
+            const reportProgress = createProgressReporter();
+
+            expect(reportProgress('starting...\neyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJz')).toBe(
+                'starting...',
+            );
+            expect(reportProgress('dWIiOiIxMjM0NTY3ODkwIn0.signature\n')).toBe('[redacted]');
+        });
+
+        it('should report plain progress lines unchanged', () => {
+            const reportProgress = createProgressReporter();
+
+            expect(reportProgress('Starting containers...\n')).toBe('Starting containers...');
+            expect(reportProgress('Seeding data')).toBeUndefined();
+            expect(reportProgress('...done\r')).toBe('Seeding data...done');
         });
     });
 


### PR DESCRIPTION
Fixes #3047

## Root cause

setup:env deadlocks because `supabase start` output pipe is never drained

## Changes

- In packages/scripts/src/backend.ts the backend start child process was spawned with default piped stdio but no reader, so once `supabase start` wrote more than the OS pipe buffer (first run pulls Docker images, far more than 64KB) the child blocked forever and the fixed 120s timer fired. Added an exported `waitForBackendStart` helper that continuously drains stdout/stderr, surfaces progress in the spinner, uses an inactivity-based timeout (300s of silence) instead of a hard 120s cap, and reports the child's exit code plus captured output tail on failure. Also spawn `bun run backend:start` as command+args without `shell: true`, removing the Node DEP0190 warning seen in the report. Added test/backend-start.test.ts covering drain-on-stdout/stderr, no timeout while progress continues, inactivity timeout with process kill, non-zero exit, and spawn error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend startup reliability by detecting failures, process errors, and inactivity timeouts.
  * Replaced generic startup errors with clearer messages, including exit codes and inactivity details.
  * Prevented startup processes from hanging indefinitely.
  * Improved redaction of sensitive credentials and tokens, including split output chunks.
  * Ensured progress from separate output streams is handled independently and consistently.

* **User Experience**
  * Added live startup progress updates based on recent backend output.
  * Displays relevant, sanitized diagnostic output when backend startup fails.
  * Prevents incomplete or sensitive information from appearing in startup messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->